### PR TITLE
Fix loading texture from PHImageManager

### DIFF
--- a/Sources/BrightroomEngine/Engine/CoreGraphics+.swift
+++ b/Sources/BrightroomEngine/Engine/CoreGraphics+.swift
@@ -32,8 +32,6 @@ extension CGContext {
 
   static func makeContext(for image: CGImage, size: CGSize? = nil) throws -> CGContext {
 
-    let context: CGContext
-
     var bitmapInfo = image.bitmapInfo
 
     /**
@@ -51,7 +49,13 @@ extension CGContext {
     bitmapInfo.remove(.alphaInfoMask)
     bitmapInfo.formUnion(.init(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue))
 
-    context = try CGContext.init(
+    /**
+     The image from PHImageManager uses `.byteOrder32Little`.
+     This is not compatible with MTLTexture.
+     */
+    bitmapInfo.remove(.byteOrder32Little)
+
+    let context = try CGContext.init(
       data: nil,
       width: size.map { Int($0.width) } ?? image.width,
       height: size.map { Int($0.height) } ?? image.height,

--- a/Sources/Demo/Contents/DemoCropMenuViewController.swift
+++ b/Sources/Demo/Contents/DemoCropMenuViewController.swift
@@ -170,6 +170,16 @@ final class DemoCropMenuViewController: StackScrollNodeViewController {
         }
 
       }),
+
+      Components.makeSelectionCell(title: "Pick from library with PHImageManager", onTap: { [unowned self] in
+
+        self.__pickPhotoWithPHAsset { asset in
+
+          let stack = EditingStack(imageProvider: .init(asset: asset))
+          _presentCropViewConroller(stack)
+        }
+
+      }),
     ])
   }
 


### PR DESCRIPTION
The image pre-rendered by PHImangeManager contains `byteOrder32Little` in bitmapInfo.
It does not compatible with MTLTexture.

While creating bitmap, it removes that byteorder.

## Checks

- It can show DisplayP3 image

![IMG_5630](https://user-images.githubusercontent.com/1888355/113400378-aa0d0400-93dc-11eb-9906-be2d90ca1d20.PNG)
