### PR TITLE
Fix ImageRenderer - recorver error from creating copy image

### DIFF
--- a/Sources/BrightroomEngine/Engine/ImageRenderer.swift
+++ b/Sources/BrightroomEngine/Engine/ImageRenderer.swift
@@ -189,13 +189,18 @@ public final class ImageRenderer {
      */
     EngineLog.debug(
       .renderer,
-      "Fixing colorspace \(sourceCGImage.colorSpace?.name as NSString? ?? "") -> \(options.workingColorSpace.name as NSString? ?? "")"
+      "Fixing colorspace \(sourceCGImage.colorSpace as Any) -> \(options.workingColorSpace)"
     )
 
-    let fixedColorspace: CGImage = try sourceCGImage.copy(colorSpace: options.workingColorSpace)
-      .unwrap(orThrow: "Failed to copy with fixing colorspace.")
+    let fixedColorspace: CGImage
+    do {
+      fixedColorspace = try sourceCGImage.copy(colorSpace: options.workingColorSpace)
+        .unwrap(orThrow: "Failed to copy with fixing colorspace. \(sourceCGImage.colorSpace as Any), \(options.workingColorSpace)")
+    } catch {
+      EngineLog.error(.renderer, "Failed to create fixed colorspace image, \(error)")
+      fixedColorspace = sourceCGImage
+    }
 
-    assert(fixedColorspace.colorSpace == options.workingColorSpace)
     /*
      ===
      ===


### PR DESCRIPTION
this image was failed to create image with fixed color space.

`kCGColorSpaceIndexed` maybe root cause.

```
<CGImage 0x12af38be0> (IP)
	<<CGColorSpace 0x600002bc0840> (kCGColorSpaceIndexed; base <CGColorSpace 0x600002bea520> (kCGColorSpaceICCBased; kCGColorSpaceModelRGB; sRGB IEC61966-2.1))>
		width = 750, height = 750, bpc = 8, bpp = 8, row bytes = 750 
		kCGImageAlphaNone | 0 (default byte order)  | kCGImagePixelFormatPacked 
		is mask? No, has masking color? No, has soft mask? No, has matte? No, should interpolate? Yes
```