### PR TITLE
Update SPM swift settings safe

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,7 @@ let package = Package(
       name: "BrightroomUI",
       dependencies: ["BrightroomEngine", "Verge", "TransitionPatch"],
       exclude: ["Info.plist"],
-      swiftSettings: [.unsafeFlags(["-DSWIFT_PACKAGE_MANAGER"])]
-    )
+      swiftSettings: [.define("SWIFT_PACKAGE_MANAGER"))
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
       name: "BrightroomUI",
       dependencies: ["BrightroomEngine", "Verge", "TransitionPatch"],
       exclude: ["Info.plist"],
-      swiftSettings: [.define("SWIFT_PACKAGE_MANAGER"))
+      swiftSettings: [.define("SWIFT_PACKAGE_MANAGER")]
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,9 @@ let package = Package(
       name: "BrightroomUI",
       dependencies: ["BrightroomEngine", "Verge", "TransitionPatch"],
       exclude: ["Info.plist"],
-      swiftSettings: [.define("SWIFT_PACKAGE_MANAGER")]
+      swiftSettings: [
+        .define("SWIFT_PACKAGE_MANAGER")
+      ]
   ],
   swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -24,9 +24,8 @@ let package = Package(
       name: "BrightroomUI",
       dependencies: ["BrightroomEngine", "Verge", "TransitionPatch"],
       exclude: ["Info.plist"],
-      swiftSettings: [
-        .define("SWIFT_PACKAGE_MANAGER")
-      ]
+      swiftSettings: [.define("SWIFT_PACKAGE_MANAGER")]
+    )
   ],
   swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
Fix compile error: The package product 'BrightroomEngine' cannot be used as a dependency of this target because it uses unsafe build flags