### PR TITLE
Change EditingStack from StateObject to regular variable

### DIFF
--- a/Sources/BrightroomUIPhotosCrop/PhotosCropRotating/PhotosCropRotating.swift
+++ b/Sources/BrightroomUIPhotosCrop/PhotosCropRotating/PhotosCropRotating.swift
@@ -67,7 +67,7 @@ public struct PhotosCropRotating: View {
   public init(
     editingStack: @escaping () -> EditingStack
   ) {
-    self._editingStack = editingStack()
+    self.editingStack = editingStack()
   }
 
   private var isLoading: Bool {

--- a/Sources/BrightroomUIPhotosCrop/PhotosCropRotating/PhotosCropRotating.swift
+++ b/Sources/BrightroomUIPhotosCrop/PhotosCropRotating/PhotosCropRotating.swift
@@ -51,7 +51,7 @@ public struct PhotosCropRotating: View {
     }
   }
 
-  @StateObject var editingStack: EditingStack
+  var editingStack: EditingStack
 
   @State private var rotation: EditingCrop.Rotation?
   @State private var adjustmentAngle: EditingCrop.AdjustmentAngle?
@@ -67,7 +67,7 @@ public struct PhotosCropRotating: View {
   public init(
     editingStack: @escaping () -> EditingStack
   ) {
-    self._editingStack = .init(wrappedValue: editingStack())
+    self._editingStack = editingStack()
   }
 
   private var isLoading: Bool {


### PR DESCRIPTION
This is because the latest version of Brightroom (3.1.x) removes the `@ObservableObject` from EditingStack, which means that adding `@StateObject` won't work anymore.