### PR TITLE
[codex] Replace stepped slider with UIKit control

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/SteppedSlider/BrightroomSteppedSlider.swift
+++ b/Sources/BrightroomUI/Shared/Components/SteppedSlider/BrightroomSteppedSlider.swift
@@ -20,122 +20,117 @@
 // THE SOFTWARE.
 
 import SwiftUI
+import UIKit
 
-struct BrightroomSteppedSlider<TopMarker: View, Tick: View, ActiveTick: View>: View {
+struct BrightroomSteppedSlider<TopMarker: View, Tick: View>: UIViewRepresentable {
 
+  @Environment(\.isEnabled) private var isEnabled
   @Binding var value: Double
 
   let range: ClosedRange<Double>
   let stepCount: Int
   let style: BrightroomSteppedSliderStyle
+  let resetValue: Double?
   let transform: (Double) -> Double
   let hapticIdentity: (Double) -> AnyHashable?
   let onHaptic: () -> Void
   let topMarker: (BrightroomSteppedSliderTickContext) -> TopMarker
   let tick: (BrightroomSteppedSliderTickContext) -> Tick
-  let activeTick: (BrightroomSteppedSliderTickContext) -> ActiveTick
-
-  @State private var scrollIndex: Int?
-  @State private var lastHapticIdentity: AnyHashable?
-  @State private var lastEmittedValue: Double?
-  @State private var coordinateSpaceName = "BrightroomSteppedSlider.\(UUID().uuidString)"
 
   init(
     value: Binding<Double>,
     range: ClosedRange<Double>,
     stepCount: Int,
     style: BrightroomSteppedSliderStyle,
+    resetValue: Double? = nil,
     transform: @escaping (Double) -> Double,
     hapticIdentity: @escaping (Double) -> AnyHashable?,
     onHaptic: @escaping () -> Void,
     @ViewBuilder topMarker: @escaping (BrightroomSteppedSliderTickContext) -> TopMarker,
-    @ViewBuilder tick: @escaping (BrightroomSteppedSliderTickContext) -> Tick,
-    @ViewBuilder activeTick: @escaping (BrightroomSteppedSliderTickContext) -> ActiveTick
+    @ViewBuilder tick: @escaping (BrightroomSteppedSliderTickContext) -> Tick
   ) {
     self._value = value
     self.range = range
     self.stepCount = stepCount
     self.style = style
+    self.resetValue = resetValue
     self.transform = transform
     self.hapticIdentity = hapticIdentity
     self.onHaptic = onHaptic
     self.topMarker = topMarker
     self.tick = tick
-    self.activeTick = activeTick
-    self._scrollIndex = State(initialValue: Self.index(
-      for: value.wrappedValue,
+  }
+
+  func makeUIView(context: Context) -> BrightroomSteppedSliderControl<TopMarker, Tick> {
+    let uiView = BrightroomSteppedSliderControl(
+      configuration: configuration,
+      value: value
+    )
+
+    uiView.onValueChanged = { newValue in
+      Task { @MainActor in
+        self.value = newValue
+      }
+    }
+
+    uiView.isEnabled = isEnabled
+    return uiView
+  }
+
+  func updateUIView(_ uiView: BrightroomSteppedSliderControl<TopMarker, Tick>, context: Context) {
+    uiView.onValueChanged = { newValue in
+      Task { @MainActor in
+        self.value = newValue
+      }
+    }
+
+    uiView.isEnabled = isEnabled
+    uiView.update(
+      configuration: configuration,
+      value: value
+    )
+  }
+
+  private var configuration: BrightroomSteppedSliderConfiguration<TopMarker, Tick> {
+    .init(
       range: range,
-      stepCount: stepCount
-    ))
+      stepCount: stepCount,
+      style: style,
+      resetValue: resetValue,
+      transform: transform,
+      hapticIdentity: hapticIdentity,
+      onHaptic: onHaptic,
+      topMarker: topMarker,
+      tick: tick
+    )
+  }
+}
+
+struct BrightroomSteppedSliderConfiguration<TopMarker: View, Tick: View> {
+
+  let range: ClosedRange<Double>
+  let stepCount: Int
+  let style: BrightroomSteppedSliderStyle
+  let resetValue: Double?
+  let transform: (Double) -> Double
+  let hapticIdentity: (Double) -> AnyHashable?
+  let onHaptic: () -> Void
+  let topMarker: (BrightroomSteppedSliderTickContext) -> TopMarker
+  let tick: (BrightroomSteppedSliderTickContext) -> Tick
+
+  var normalizedStepCount: Int {
+    max(0, stepCount)
   }
 
-  var body: some View {
-    GeometryReader { proxy in
-      ZStack {
-        ScrollView(.horizontal, showsIndicators: false) {
-          LazyHStack(spacing: style.tickSpacing) {
-            ForEach(0...stepCount, id: \.self) { index in
-              let context = tickContext(for: index)
-
-              BrightroomSteppedSliderTickItem(
-                context: context,
-                style: style,
-                viewportWidth: proxy.size.width,
-                coordinateSpaceName: coordinateSpaceName,
-                topMarker: topMarker,
-                tick: tick,
-                activeTick: activeTick
-              )
-              .id(index)
-              .frame(width: style.tickWidth)
-            }
-          }
-          .scrollTargetLayout()
-        }
-        .contentMargins(.horizontal, contentMargin(for: proxy.size.width))
-        .scrollPosition(id: $scrollIndex, anchor: .center)
-        .scrollTargetBehavior(.brightroomSteppedSliderSnap(step: Double(style.tickPitch)))
-        .mask(BrightroomSteppedSliderMask())
-        .coordinateSpace(name: coordinateSpaceName)
-      }
-    }
-    .onChange(of: value) { _, newValue in
-      if let lastEmittedValue, Self.isEquivalent(newValue, to: lastEmittedValue) {
-        self.lastEmittedValue = nil
-        return
-      }
-
-      let index = index(for: newValue)
-      guard index != scrollIndex else {
-        return
-      }
-
-      withAnimation(.smooth) {
-        scrollIndex = index
-      }
-    }
-    .onChange(of: scrollIndex) { _, newIndex in
-      guard let newIndex else {
-        return
-      }
-
-      let newValue = value(for: newIndex)
-      triggerHapticIfNeeded(for: newValue)
-      lastEmittedValue = newValue
-
-      guard !Self.isEquivalent(value, to: newValue) else {
-        return
-      }
-
-      value = newValue
-    }
+  var contentWidth: CGFloat {
+    style.tickWidth + CGFloat(normalizedStepCount) * style.tickPitch
   }
 
-  private func contentMargin(for width: CGFloat) -> CGFloat {
-    max(0, width / 2 - style.tickWidth / 2)
+  var contentHeight: CGFloat {
+    style.activeTickHeight + 9
   }
 
-  private func tickContext(for index: Int) -> BrightroomSteppedSliderTickContext {
+  func tickContext(for index: Int) -> BrightroomSteppedSliderTickContext {
     .init(
       index: index,
       value: rawValue(for: index),
@@ -143,25 +138,426 @@ struct BrightroomSteppedSlider<TopMarker: View, Tick: View, ActiveTick: View>: V
     )
   }
 
-  private func rawValue(for index: Int) -> Double {
-    guard stepCount > 0 else {
+  func rawValue(for index: Int) -> Double {
+    guard normalizedStepCount > 0 else {
       return range.lowerBound
     }
 
-    let ratio = Double(index) / Double(stepCount)
-    return range.lowerBound + (range.upperBound - range.lowerBound) * ratio
+    let ratio = Double(index) / Double(normalizedStepCount)
+    return rawValue(forProgress: ratio)
   }
 
-  private func value(for index: Int) -> Double {
-    transform(rawValue(for: index).clamped(to: range))
+  func rawValue(forProgress progress: Double) -> Double {
+    range.lowerBound + (range.upperBound - range.lowerBound) * progress.clamped(to: 0...1)
   }
 
-  private func index(for value: Double) -> Int {
-    Self.index(for: value, range: range, stepCount: stepCount)
+  func value(forProgress progress: Double) -> Double {
+    transform(rawValue(forProgress: progress).clamped(to: range))
+  }
+
+  func indexProgress(for value: Double) -> Double {
+    guard range.lowerBound != range.upperBound else {
+      return 0
+    }
+
+    return ((value - range.lowerBound) / (range.upperBound - range.lowerBound))
+      .clamped(to: 0...1)
+  }
+
+  func floatingIndex(for value: Double) -> CGFloat {
+    CGFloat(indexProgress(for: value)) * CGFloat(normalizedStepCount)
+  }
+}
+
+private final class BrightroomSteppedSliderRenderProxy: ObservableObject {
+  @Published var viewportWidth: CGFloat = 0
+  @Published var contentOffsetX: CGFloat = 0
+}
+
+private struct BrightroomSteppedSliderLayoutGeometry: Equatable {
+  let boundsWidth: CGFloat
+  let contentWidth: CGFloat
+  let horizontalContentInset: CGFloat
+}
+
+final class BrightroomSteppedSliderControl<TopMarker: View, Tick: View>: UIControl, UIScrollViewDelegate {
+
+  var onValueChanged: (Double) -> Void = { _ in }
+
+  private var configuration: BrightroomSteppedSliderConfiguration<TopMarker, Tick>
+  private let proxy = BrightroomSteppedSliderRenderProxy()
+  private let scrollView = UIScrollView()
+  private let contentView = UIView()
+  private let hostingController: UIHostingController<BrightroomSteppedSliderTrackView<TopMarker, Tick>>
+  private let maskGradientLayer: CAGradientLayer = {
+    let gradientLayer = CAGradientLayer()
+    gradientLayer.colors = [
+      UIColor.clear.cgColor,
+      UIColor.black.cgColor,
+      UIColor.black.cgColor,
+      UIColor.clear.cgColor,
+    ]
+    gradientLayer.locations = [0, 0.4, 0.6, 1]
+    gradientLayer.startPoint = CGPoint(x: 0, y: 0)
+    gradientLayer.endPoint = CGPoint(x: 1, y: 0)
+    return gradientLayer
+  }()
+
+  private var value: Double
+  private var lastHapticIdentity: AnyHashable?
+  private var isAnimatingUserSnap = false
+  private var isAnimatingProgrammaticScroll = false
+  private var lastLayoutGeometry: BrightroomSteppedSliderLayoutGeometry?
+  private var hasLaidOut = false
+
+  init(
+    configuration: BrightroomSteppedSliderConfiguration<TopMarker, Tick>,
+    value: Double
+  ) {
+    self.configuration = configuration
+    self.value = value.clamped(to: configuration.range)
+    self.hostingController = UIHostingController(
+      rootView: BrightroomSteppedSliderTrackView(
+        configuration: configuration,
+        proxy: proxy
+      )
+    )
+
+    super.init(frame: .zero)
+
+    layer.mask = maskGradientLayer
+    backgroundColor = .clear
+
+    scrollView.backgroundColor = .clear
+    scrollView.decelerationRate = .fast
+    scrollView.delegate = self
+    scrollView.contentInsetAdjustmentBehavior = .never
+    scrollView.showsHorizontalScrollIndicator = false
+    scrollView.showsVerticalScrollIndicator = false
+    scrollView.alwaysBounceHorizontal = true
+    scrollView.delaysContentTouches = false
+
+    addSubview(scrollView)
+    scrollView.addSubview(contentView)
+
+    hostingController.view.backgroundColor = .clear
+    hostingController.view.isUserInteractionEnabled = false
+    contentView.addSubview(hostingController.view)
+
+    let doubleTapGestureRecognizer = UITapGestureRecognizer(
+      target: self,
+      action: #selector(handleDoubleTap)
+    )
+    doubleTapGestureRecognizer.numberOfTapsRequired = 2
+    doubleTapGestureRecognizer.cancelsTouchesInView = false
+    addGestureRecognizer(doubleTapGestureRecognizer)
+
+    isAccessibilityElement = true
+    accessibilityTraits.insert(.adjustable)
+    updateAccessibilityValue()
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override var isEnabled: Bool {
+    didSet {
+      scrollView.isScrollEnabled = isEnabled
+      accessibilityTraits = isEnabled ? [.adjustable] : [.notEnabled]
+    }
+  }
+
+  override var intrinsicContentSize: CGSize {
+    CGSize(
+      width: UIView.noIntrinsicMetric,
+      height: UIView.noIntrinsicMetric
+    )
+  }
+
+  override func contentHuggingPriority(for axis: NSLayoutConstraint.Axis) -> UILayoutPriority {
+    switch axis {
+    case .horizontal:
+      return .defaultLow
+    case .vertical:
+      return .defaultHigh
+    @unknown default:
+      return .defaultLow
+    }
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+
+    hasLaidOut = true
+    maskGradientLayer.frame = bounds
+    scrollView.frame = bounds
+
+    let contentSize = CGSize(
+      width: configuration.contentWidth,
+      height: max(bounds.height, configuration.contentHeight)
+    )
+    let contentInset = UIEdgeInsets(
+      top: 0,
+      left: horizontalContentInset,
+      bottom: 0,
+      right: horizontalContentInset
+    )
+    let layoutGeometry = BrightroomSteppedSliderLayoutGeometry(
+      boundsWidth: bounds.width,
+      contentWidth: contentSize.width,
+      horizontalContentInset: contentInset.left
+    )
+    let canPreserveProgrammaticScrollAnimation = isAnimatingProgrammaticScroll && lastLayoutGeometry == layoutGeometry
+
+    contentView.frame = CGRect(origin: .zero, size: contentSize)
+    hostingController.view.frame = contentView.bounds
+    scrollView.contentSize = contentSize
+    scrollView.contentInset = contentInset
+
+    if isUserScrolling {
+      updateRenderProxy()
+    } else if canPreserveProgrammaticScrollAnimation {
+      updateRenderProxy()
+    } else {
+      setContentOffsetForValue(value, animated: false)
+    }
+
+    lastLayoutGeometry = layoutGeometry
+  }
+
+  override func accessibilityIncrement() {
+    guard isEnabled else {
+      return
+    }
+
+    applyAccessibilityStep(1)
+  }
+
+  override func accessibilityDecrement() {
+    guard isEnabled else {
+      return
+    }
+
+    applyAccessibilityStep(-1)
+  }
+
+  func update(
+    configuration: BrightroomSteppedSliderConfiguration<TopMarker, Tick>,
+    value: Double
+  ) {
+    self.configuration = configuration
+    hostingController.rootView = BrightroomSteppedSliderTrackView(
+      configuration: configuration,
+      proxy: proxy
+    )
+
+    setNeedsLayout()
+    setValue(
+      value.clamped(to: configuration.range),
+      animated: hasLaidOut
+    )
+  }
+
+  func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    updateRenderProxy()
+
+    guard isUserScrolling else {
+      return
+    }
+
+    commitValueFromCurrentOffset()
+  }
+
+  func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    isAnimatingUserSnap = false
+    isAnimatingProgrammaticScroll = false
+  }
+
+  func scrollViewWillEndDragging(
+    _ scrollView: UIScrollView,
+    withVelocity velocity: CGPoint,
+    targetContentOffset: UnsafeMutablePointer<CGPoint>
+  ) {
+    targetContentOffset.pointee = targetContentOffsetForNearestTick(
+      from: targetContentOffset.pointee
+    )
+  }
+
+  func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+    guard decelerate == false else {
+      return
+    }
+
+    snapToNearestTick(animated: true)
+  }
+
+  func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+    snapToNearestTick(animated: false)
+    commitValueFromCurrentOffset()
+  }
+
+  func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+    updateRenderProxy()
+    isAnimatingProgrammaticScroll = false
+
+    if isAnimatingUserSnap {
+      isAnimatingUserSnap = false
+      commitValueFromCurrentOffset()
+    }
+  }
+
+  private var horizontalContentInset: CGFloat {
+    max(0, bounds.width / 2 - configuration.style.tickWidth / 2)
+  }
+
+  private var isUserScrolling: Bool {
+    scrollView.isDragging || scrollView.isTracking || scrollView.isDecelerating
+  }
+
+  private func setValue(_ newValue: Double, animated: Bool) {
+    let clampedValue = newValue.clamped(to: configuration.range)
+    let valueChanged = !Self.isEquivalent(value, to: clampedValue)
+    value = clampedValue
+    updateAccessibilityValue()
+
+    guard valueChanged || !hasLaidOut else {
+      return
+    }
+
+    guard isUserScrolling == false else {
+      return
+    }
+
+    setContentOffsetForValue(
+      clampedValue,
+      animated: animated && hasLaidOut
+    )
+  }
+
+  private func setContentOffsetForValue(_ value: Double, animated: Bool) {
+    let offset = contentOffsetForFloatingIndex(configuration.floatingIndex(for: value))
+    let shouldAnimate = animated && distance(from: scrollView.contentOffset, to: offset) > 0.000_001
+    isAnimatingProgrammaticScroll = shouldAnimate
+    scrollView.setContentOffset(offset, animated: shouldAnimate)
+
+    if shouldAnimate == false {
+      updateRenderProxy()
+    }
+  }
+
+  private func contentOffsetForFloatingIndex(_ floatingIndex: CGFloat) -> CGPoint {
+    let tickCenterX = configuration.style.tickWidth / 2 + floatingIndex * configuration.style.tickPitch
+    return CGPoint(
+      x: tickCenterX - bounds.width / 2,
+      y: -scrollView.adjustedContentInset.top
+    )
+  }
+
+  private func floatingIndex(forContentOffset contentOffset: CGPoint) -> CGFloat {
+    guard configuration.style.tickPitch > 0 else {
+      return 0
+    }
+
+    let visibleCenterX = contentOffset.x + bounds.width / 2
+    let floatingIndex = (visibleCenterX - configuration.style.tickWidth / 2) / configuration.style.tickPitch
+    return floatingIndex.clamped(to: 0...CGFloat(configuration.normalizedStepCount))
+  }
+
+  private func targetContentOffsetForNearestTick(from proposedContentOffset: CGPoint) -> CGPoint {
+    let nearestIndex = floatingIndex(forContentOffset: proposedContentOffset).rounded()
+    return contentOffsetForFloatingIndex(nearestIndex)
+  }
+
+  private func snapToNearestTick(animated: Bool) {
+    let targetContentOffset = targetContentOffsetForNearestTick(from: scrollView.contentOffset)
+    guard distance(from: scrollView.contentOffset, to: targetContentOffset) > 0.000_001 else {
+      updateRenderProxy()
+      return
+    }
+
+    isAnimatingUserSnap = animated
+    scrollView.setContentOffset(targetContentOffset, animated: animated)
+
+    if animated == false {
+      isAnimatingUserSnap = false
+      updateRenderProxy()
+    }
+  }
+
+  private func commitValueFromCurrentOffset() {
+    guard configuration.normalizedStepCount > 0 else {
+      return
+    }
+
+    let progress = Double(floatingIndex(forContentOffset: scrollView.contentOffset)) / Double(configuration.normalizedStepCount)
+    let newValue = configuration.value(forProgress: progress)
+    guard !Self.isEquivalent(value, to: newValue) else {
+      return
+    }
+
+    value = newValue
+    updateAccessibilityValue()
+    triggerHapticIfNeeded(for: newValue)
+    onValueChanged(newValue)
+    sendActions(for: .valueChanged)
+  }
+
+  private func applyAccessibilityStep(_ delta: Int) {
+    guard configuration.normalizedStepCount > 0 else {
+      return
+    }
+
+    let currentIndex = Int(configuration.floatingIndex(for: value).rounded())
+    let nextIndex = (currentIndex + delta).clamped(to: 0...configuration.normalizedStepCount)
+    let progress = Double(nextIndex) / Double(configuration.normalizedStepCount)
+    let newValue = configuration.value(forProgress: progress)
+
+    guard !Self.isEquivalent(value, to: newValue) else {
+      return
+    }
+
+    value = newValue
+    updateAccessibilityValue()
+    setContentOffsetForValue(newValue, animated: true)
+    triggerHapticIfNeeded(for: newValue)
+    onValueChanged(newValue)
+    sendActions(for: .valueChanged)
+  }
+
+  @objc private func handleDoubleTap() {
+    guard isEnabled else {
+      return
+    }
+
+    guard let resetValue = configuration.resetValue?.clamped(to: configuration.range) else {
+      return
+    }
+
+    guard !Self.isEquivalent(value, to: resetValue) else {
+      return
+    }
+
+    value = resetValue
+    updateAccessibilityValue()
+    setContentOffsetForValue(resetValue, animated: true)
+    triggerHapticIfNeeded(for: resetValue)
+    onValueChanged(resetValue)
+    sendActions(for: .valueChanged)
+  }
+
+  private func updateRenderProxy() {
+    proxy.viewportWidth = bounds.width
+    proxy.contentOffsetX = scrollView.contentOffset.x
+  }
+
+  private func updateAccessibilityValue() {
+    accessibilityValue = String(format: "%.2f", value)
   }
 
   private func triggerHapticIfNeeded(for value: Double) {
-    guard let identity = hapticIdentity(value) else {
+    guard let identity = configuration.hapticIdentity(value) else {
       lastHapticIdentity = nil
       return
     }
@@ -171,25 +567,117 @@ struct BrightroomSteppedSlider<TopMarker: View, Tick: View, ActiveTick: View>: V
     }
 
     lastHapticIdentity = identity
-    onHaptic()
+    configuration.onHaptic()
+  }
+
+  private func distance(from lhs: CGPoint, to rhs: CGPoint) -> CGFloat {
+    hypot(lhs.x - rhs.x, lhs.y - rhs.y)
   }
 
   nonisolated private static func isEquivalent(_ lhs: Double, to rhs: Double) -> Bool {
     abs(lhs - rhs) < 0.000_001
   }
+}
 
-  nonisolated private static func index(
-    for value: Double,
-    range: ClosedRange<Double>,
-    stepCount: Int
-  ) -> Int {
-    guard stepCount > 0, range.lowerBound != range.upperBound else {
+private struct BrightroomSteppedSliderTrackView<TopMarker: View, Tick: View>: View {
+
+  let configuration: BrightroomSteppedSliderConfiguration<TopMarker, Tick>
+  @ObservedObject var proxy: BrightroomSteppedSliderRenderProxy
+
+  var body: some View {
+    HStack(spacing: configuration.style.tickSpacing) {
+      ForEach(0...configuration.normalizedStepCount, id: \.self) { index in
+        let context = configuration.tickContext(for: index)
+
+        BrightroomSteppedSliderTickItem(
+          context: context,
+          style: configuration.style,
+          activeProgress: activeProgress(for: index),
+          topMarker: configuration.topMarker,
+          tick: configuration.tick
+        )
+        .frame(width: configuration.style.tickWidth)
+      }
+    }
+    .frame(
+      width: configuration.contentWidth,
+      height: configuration.contentHeight,
+      alignment: .leading
+    )
+  }
+
+  private func activeProgress(for index: Int) -> CGFloat {
+    guard proxy.viewportWidth > 0, configuration.style.tickPitch > 0 else {
       return 0
     }
 
-    let ratio = ((value - range.lowerBound) / (range.upperBound - range.lowerBound))
-      .clamped(to: 0...1)
-    return Int((ratio * Double(stepCount)).rounded())
+    let tickCenterX = configuration.style.tickWidth / 2 + CGFloat(index) * configuration.style.tickPitch
+    let visibleCenterX = proxy.contentOffsetX + proxy.viewportWidth / 2
+    let distance = abs(tickCenterX - visibleCenterX)
+    return max(0, 1 - distance / configuration.style.tickPitch)
+  }
+}
+
+private struct BrightroomSteppedSliderTickItem<TopMarker: View, Tick: View>: View {
+
+  let context: BrightroomSteppedSliderTickContext
+  let style: BrightroomSteppedSliderStyle
+  let activeProgress: CGFloat
+  let topMarker: (BrightroomSteppedSliderTickContext) -> TopMarker
+  let tick: (BrightroomSteppedSliderTickContext) -> Tick
+
+  var body: some View {
+    VStack(spacing: 3) {
+      topMarker(context)
+
+      tick(context)
+        .frame(width: style.tickWidth, height: style.tickHeight)
+        .scaleEffect(
+          x: Self.scaleWidth(
+            activeProgress: activeProgress,
+            style: style
+          ),
+          y: Self.scaleHeight(
+            activeProgress: activeProgress,
+            style: style
+          ),
+          anchor: .center
+        )
+    }
+    .frame(height: style.contentHeight)
+  }
+
+  nonisolated private static func scaleWidth(
+    activeProgress: CGFloat,
+    style: BrightroomSteppedSliderStyle
+  ) -> CGFloat {
+    scale(
+      activeProgress: activeProgress,
+      inactiveLength: style.tickWidth,
+      activeLength: style.activeTickWidth
+    )
+  }
+
+  nonisolated private static func scaleHeight(
+    activeProgress: CGFloat,
+    style: BrightroomSteppedSliderStyle
+  ) -> CGFloat {
+    scale(
+      activeProgress: activeProgress,
+      inactiveLength: style.tickHeight,
+      activeLength: style.activeTickHeight
+    )
+  }
+
+  nonisolated private static func scale(
+    activeProgress: CGFloat,
+    inactiveLength: CGFloat,
+    activeLength: CGFloat
+  ) -> CGFloat {
+    guard inactiveLength > 0 else { return 1 }
+
+    let lengthRatio = activeLength / inactiveLength
+    return 1 + (lengthRatio - 1) * activeProgress
   }
 }
 
@@ -197,11 +685,32 @@ struct BrightroomSteppedSliderStyle {
   var tickWidth: CGFloat
   var tickSpacing: CGFloat
   var tickHeight: CGFloat
+  var activeTickWidth: CGFloat
   var activeTickHeight: CGFloat
   var majorTickInterval: Int
 
   var tickPitch: CGFloat {
     tickWidth + tickSpacing
+  }
+
+  fileprivate var contentHeight: CGFloat {
+    activeTickHeight + 9
+  }
+
+  init(
+    tickWidth: CGFloat,
+    tickSpacing: CGFloat,
+    tickHeight: CGFloat,
+    activeTickWidth: CGFloat?,
+    activeTickHeight: CGFloat?,
+    majorTickInterval: Int
+  ) {
+    self.tickWidth = tickWidth
+    self.tickSpacing = tickSpacing
+    self.tickHeight = tickHeight
+    self.activeTickWidth = activeTickWidth ?? tickWidth
+    self.activeTickHeight = activeTickHeight ?? tickHeight
+    self.majorTickInterval = majorTickInterval
   }
 }
 
@@ -211,123 +720,21 @@ struct BrightroomSteppedSliderTickContext {
   let isMajor: Bool
 }
 
-private struct BrightroomSteppedSliderTickItem<TopMarker: View, Tick: View, ActiveTick: View>: View {
-
-  let context: BrightroomSteppedSliderTickContext
-  let style: BrightroomSteppedSliderStyle
-  let viewportWidth: CGFloat
-  let coordinateSpaceName: String
-  let topMarker: (BrightroomSteppedSliderTickContext) -> TopMarker
-  let tick: (BrightroomSteppedSliderTickContext) -> Tick
-  let activeTick: (BrightroomSteppedSliderTickContext) -> ActiveTick
-
-  var body: some View {
-    VStack(spacing: 3) {
-      topMarker(context)
-
-      ZStack {
-        tick(context)
-
-        activeTick(context)
-          .visualEffect { content, proxy in
-            content
-              .opacity(Double(Self.activeProgress(
-                in: proxy,
-                viewportWidth: viewportWidth,
-                coordinateSpaceName: coordinateSpaceName,
-                tickPitch: style.tickPitch
-              )))
-              .scaleEffect(
-                x: 1,
-                y: Self.scale(
-                  activeProgress: Self.activeProgress(
-                    in: proxy,
-                    viewportWidth: viewportWidth,
-                    coordinateSpaceName: coordinateSpaceName,
-                    tickPitch: style.tickPitch
-                  ),
-                  style: style
-                ),
-                anchor: .center
-              )
-          }
-      }
-      .frame(width: style.tickWidth, height: style.tickHeight)
-    }
-    .frame(height: style.activeTickHeight + 9)
-  }
-
-  nonisolated private static func activeProgress(
-    in proxy: GeometryProxy,
-    viewportWidth: CGFloat,
-    coordinateSpaceName: String,
-    tickPitch: CGFloat
-  ) -> CGFloat {
-    let centerX = proxy.frame(in: .named(coordinateSpaceName)).midX
-    let distance = abs(centerX - viewportWidth / 2)
-    return max(0, 1 - distance / tickPitch)
-  }
-
-  nonisolated private static func scale(
-    activeProgress: CGFloat,
-    style: BrightroomSteppedSliderStyle
-  ) -> CGFloat {
-    let heightRatio = style.activeTickHeight / style.tickHeight
-    return 1 + (heightRatio - 1) * activeProgress
-  }
-}
-
-private struct BrightroomSteppedSliderMask: View {
-  var body: some View {
-    HStack(spacing: 0) {
-      LinearGradient(
-        colors: [.black.opacity(0), .black],
-        startPoint: .leading,
-        endPoint: .trailing
-      )
-      .frame(width: 24)
-
-      Color.black
-
-      LinearGradient(
-        colors: [.black, .black.opacity(0)],
-        startPoint: .leading,
-        endPoint: .trailing
-      )
-      .frame(width: 24)
-    }
-  }
-}
-
-private struct BrightroomSteppedSliderSnapBehavior: ScrollTargetBehavior {
-
-  let step: Double
-
-  func updateTarget(_ target: inout ScrollTarget, context: TargetContext) {
-    guard step > 0 else {
-      return
-    }
-
-    let lower = floor(target.rect.origin.x / step) * step
-    let upper = lower + step
-
-    if abs(target.rect.origin.x - lower) <= abs(target.rect.origin.x - upper) {
-      target.rect.origin.x = lower
-    } else {
-      target.rect.origin.x = upper
-    }
-  }
-}
-
-private extension ScrollTargetBehavior where Self == BrightroomSteppedSliderSnapBehavior {
-  static func brightroomSteppedSliderSnap(step: Double) -> BrightroomSteppedSliderSnapBehavior {
-    .init(step: step)
-  }
-}
-
 private extension Double {
   func clamped(to range: ClosedRange<Double>) -> Double {
-    min(max(self, range.lowerBound), range.upperBound)
+    Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+  }
+}
+
+private extension CGFloat {
+  func clamped(to range: ClosedRange<CGFloat>) -> CGFloat {
+    Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
+  }
+}
+
+private extension Int {
+  func clamped(to range: ClosedRange<Int>) -> Int {
+    Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
   }
 }
 
@@ -339,8 +746,8 @@ private extension Double {
 private struct BrightroomSteppedSliderPreview: View {
 
   @State private var exposureValue: Double = 0
-  @State private var rotationValue: Double = -12
-  @State private var strengthValue: Double = 0.38
+  @State private var rotationValue: Double = 0
+  @State private var strengthValue: Double = 0
 
   var body: some View {
     VStack(spacing: 28) {
@@ -408,6 +815,7 @@ private struct BrightroomSteppedSliderPreview: View {
         range: range,
         stepCount: stepCount,
         style: style,
+        resetValue: markerValue,
         transform: { $0 },
         hapticIdentity: { _ in nil },
         onHaptic: {},
@@ -419,10 +827,6 @@ private struct BrightroomSteppedSliderPreview: View {
         tick: { context in
           Capsule()
             .foregroundStyle(context.isMajor ? Color.primary : Color.secondary)
-        },
-        activeTick: { _ in
-          Capsule()
-            .foregroundStyle(accent)
         }
       )
       .frame(height: 50)
@@ -435,16 +839,18 @@ private extension BrightroomSteppedSliderStyle {
   static let previewDense = BrightroomSteppedSliderStyle(
     tickWidth: 2,
     tickSpacing: 4,
-    tickHeight: 10,
-    activeTickHeight: 18,
+    tickHeight: 16,
+    activeTickWidth: 3,
+    activeTickHeight: 24,
     majorTickInterval: 10
   )
 
   static let previewRotation = BrightroomSteppedSliderStyle(
     tickWidth: 1,
     tickSpacing: 4,
-    tickHeight: 10,
-    activeTickHeight: 18,
+    tickHeight: 16,
+    activeTickWidth: 3,
+    activeTickHeight: 24,
     majorTickInterval: 5
   )
 }

--- a/Sources/BrightroomUI/Shared/Components/SteppedSlider/BrightroomSteppedSlider.swift
+++ b/Sources/BrightroomUI/Shared/Components/SteppedSlider/BrightroomSteppedSlider.swift
@@ -127,7 +127,7 @@ struct BrightroomSteppedSliderConfiguration<TopMarker: View, Tick: View> {
   }
 
   var contentHeight: CGFloat {
-    style.activeTickHeight + 9
+    style.contentHeight
   }
 
   func tickContext(for index: Int) -> BrightroomSteppedSliderTickContext {

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -392,8 +392,13 @@ private struct PhotosCropRotationSlider: View {
       range: -45...45,
       stepCount: 90,
       style: .photosCropRotationSlider,
+      resetValue: 0,
       transform: { source in
-        source.rounded(.toNearestOrEven)
+        if (-PhotosCropRotationSliderMetrics.neutralDeadZoneDegrees...PhotosCropRotationSliderMetrics.neutralDeadZoneDegrees).contains(source) {
+          return 0
+        }
+
+        return source.rounded(.toNearestOrEven)
       },
       hapticIdentity: { value in
         let degree = Int(value.rounded(.toNearestOrEven))
@@ -411,10 +416,6 @@ private struct PhotosCropRotationSlider: View {
       tick: { context in
         RoundedRectangle(cornerRadius: 8)
           .foregroundStyle(context.isMajor ? Color.primary : Color.secondary)
-      },
-      activeTick: { _ in
-        RoundedRectangle(cornerRadius: 8)
-          .foregroundStyle(.tint)
       }
     )
     .tint(.white)
@@ -425,6 +426,7 @@ private struct PhotosCropRotationSlider: View {
     .opacity(isEnabled ? 1 : 0.5)
     .disabled(!isEnabled)
     .accessibilityLabel("Rotation")
+    .environment(\.colorScheme, .dark)
   }
 
   private var valueBinding: Binding<Double> {
@@ -441,11 +443,16 @@ private struct PhotosCropRotationSlider: View {
   }
 }
 
+private enum PhotosCropRotationSliderMetrics {
+  static let neutralDeadZoneDegrees: Double = 2.5
+}
+
 private extension BrightroomSteppedSliderStyle {
   static let photosCropRotationSlider = BrightroomSteppedSliderStyle(
-    tickWidth: 1,
+    tickWidth: 2,
     tickSpacing: 4,
     tickHeight: 10,
+    activeTickWidth: 3,
     activeTickHeight: 18,
     majorTickInterval: 5
   )

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -419,7 +419,6 @@ private struct PhotosCropRotationSlider: View {
       }
     )
     .tint(.white)
-    .accentColor(.white)
     .frame(height: 50)
     .padding(.horizontal, 24)
     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/BrightroomUI/builtin/PixelEditor/PixelEditorLocalizedStrings.swift
+++ b/Sources/BrightroomUI/builtin/PixelEditor/PixelEditorLocalizedStrings.swift
@@ -52,8 +52,6 @@ public struct PixelEditorLocalizedStrings: Sendable {
   public var editFade = "Fade"
   public var editClarity = "Clarity"
   public var editSharpen = "Sharpen"
-  public var brushSizeSmall = "◦"
-  public var brushSizeLarge = "◯"
   public var clear = "Clear"
 
   public init() {}

--- a/Sources/BrightroomUI/builtin/PixelEditor/SwiftUIPixelEditorView.swift
+++ b/Sources/BrightroomUI/builtin/PixelEditor/SwiftUIPixelEditorView.swift
@@ -128,6 +128,12 @@ private enum PixelEditorLayout {
   static let controlHorizontalMargin: CGFloat = 44
 }
 
+private enum PixelEditorControlAnimation {
+  static let panelChange = Animation.spring(response: 0.28, dampingFraction: 0.92)
+  static let blurRadius: CGFloat = 5
+  static let slideDistance: CGFloat = 12
+}
+
 private enum PixelEditorColor {
   static let background = Color(uiColor: .systemBackground)
   static let primary = Color(uiColor: .label)
@@ -248,6 +254,17 @@ private extension View {
 #else
     self
 #endif
+  }
+
+  func pixelEditorControlPresentation(
+    isVisible: Bool,
+    hiddenOffsetY: CGFloat = PixelEditorControlAnimation.slideDistance
+  ) -> some View {
+    self
+      .opacity(isVisible ? 1 : 0)
+      .blur(radius: isVisible ? 0 : PixelEditorControlAnimation.blurRadius)
+      .offset(y: isVisible ? 0 : hiddenOffsetY)
+      .animation(PixelEditorControlAnimation.panelChange, value: isVisible)
   }
 }
 
@@ -387,68 +404,153 @@ private struct PixelEditorControlPanel: View {
   @Binding var route: PixelEditorControlRoute
   @Binding var displayedRootPanel: PixelEditorRootPanel
 
+  @State private var presentedDetailRoute: PixelEditorControlRoute?
+  @State private var isDetailControlVisible = false
+  @State private var detailEntryRevision: EditingStack.Revision?
+  @State private var detailSessionID = 0
+
   var body: some View {
-    ZStack {
-      switch route {
-      case .root:
-        PixelEditorRootControl(
-          viewModel: viewModel,
-          displayedPanel: $displayedRootPanel,
-          onSelectRoute: showRoute
-        )
-        .transition(.move(edge: .bottom).combined(with: .opacity))
+    ZStack(alignment: .bottom) {
+      PixelEditorRootControl(
+        viewModel: viewModel,
+        displayedPanel: $displayedRootPanel,
+        onSelectRoute: showRoute
+      )
+      .pixelEditorControlPresentation(isVisible: !isDetailControlVisible)
+      .allowsHitTesting(route == .root)
+      .accessibilityHidden(route != .root)
 
-      case .crop:
-        PixelEditorCropControl(
-          viewModel: viewModel,
-          onCancel: {
-            viewModel.endCrop(save: false)
-            showRoute(.root)
-          },
-          onDone: {
-            viewModel.endCrop(save: true)
-            showRoute(.root)
-          }
-        )
-        .transition(.move(edge: .bottom).combined(with: .opacity))
-
-      case .masking:
-        PixelEditorMaskControl(
-          viewModel: viewModel,
-          onCancel: {
-            viewModel.endMasking(save: false)
-            showRoute(.root)
-          },
-          onDone: {
-            viewModel.endMasking(save: true)
-            showRoute(.root)
-          }
-        )
-        .transition(.move(edge: .bottom).combined(with: .opacity))
-
-      case let .filter(kind):
-        PixelEditorFilterControl(
-          viewModel: viewModel,
-          kind: kind,
-          onCancel: {
-            viewModel.editingStack.revertEdit()
-            showRoute(.root)
-          },
-          onDone: {
-            viewModel.editingStack.takeSnapshot()
-            showRoute(.root)
-          }
-        )
-        .transition(.move(edge: .bottom).combined(with: .opacity))
+      if let presentedDetailRoute {
+        detailControl(for: presentedDetailRoute)
+          .id(detailSessionID)
+          .pixelEditorControlPresentation(isVisible: isDetailControlVisible)
+          .allowsHitTesting(route != .root)
+          .accessibilityHidden(route == .root)
       }
     }
-    .animation(.spring(response: 0.32, dampingFraction: 1), value: route)
+    .onAppear {
+      configureMode(for: route)
+      updatePresentedControl(for: route, animated: false)
+    }
+    .onChange(of: route) { _, newRoute in
+      configureMode(for: newRoute)
+      updatePresentedControl(for: newRoute, animated: true)
+    }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
   }
 
+  @ViewBuilder
+  private func detailControl(for route: PixelEditorControlRoute) -> some View {
+    switch route {
+    case .root:
+      EmptyView()
+
+    case .crop:
+      PixelEditorCropControl(
+        viewModel: viewModel,
+        onCancel: {
+          viewModel.endCrop(save: false)
+          finishDetailEditing()
+          showRoute(.root)
+        },
+        onDone: {
+          viewModel.endCrop(save: true)
+          finishDetailEditing()
+          showRoute(.root)
+        }
+      )
+
+    case .masking:
+      PixelEditorMaskControl(
+        viewModel: viewModel,
+        onCancel: {
+          restoreDetailEntryRevision()
+          showRoute(.root)
+        },
+        onDone: {
+          viewModel.endMasking(save: true)
+          finishDetailEditing()
+          showRoute(.root)
+        }
+      )
+
+    case let .filter(kind):
+      PixelEditorFilterControl(
+        viewModel: viewModel,
+        kind: kind,
+        onCancel: {
+          restoreDetailEntryRevision()
+          showRoute(.root)
+        },
+        onDone: {
+          viewModel.editingStack.takeSnapshot()
+          finishDetailEditing()
+          showRoute(.root)
+        }
+      )
+    }
+  }
+
   private func showRoute(_ route: PixelEditorControlRoute) {
-    withAnimation(.spring(response: 0.32, dampingFraction: 1)) {
-      self.route = route
+    self.route = route
+  }
+
+  private func configureMode(for route: PixelEditorControlRoute) {
+    switch route {
+    case .root:
+      viewModel.setMode(.preview)
+
+    case .crop:
+      viewModel.setMode(.crop)
+
+    case .masking:
+      viewModel.setMode(.masking)
+
+    case let .filter(kind):
+      viewModel.setMode(.editing)
+      viewModel.setTitle(kind.title(localizedStrings: viewModel.localizedStrings))
+    }
+  }
+
+  private func updatePresentedControl(for route: PixelEditorControlRoute, animated: Bool) {
+    switch route {
+    case .root:
+      setDetailControlVisible(false, animated: animated)
+
+    case .crop, .masking, .filter(_):
+      if route != presentedDetailRoute || !isDetailControlVisible {
+        detailEntryRevision = viewModel.editingStack.currentRevision
+        detailSessionID += 1
+      }
+      presentedDetailRoute = route
+      setDetailControlVisible(true, animated: animated)
+    }
+  }
+
+  private func restoreDetailEntryRevision() {
+    if let detailEntryRevision {
+      viewModel.editingStack.revert(to: detailEntryRevision)
+    } else {
+      viewModel.editingStack.revertEdit()
+    }
+    finishDetailEditing()
+  }
+
+  private func finishDetailEditing() {
+    detailEntryRevision = nil
+  }
+
+  private func setDetailControlVisible(_ isVisible: Bool, animated: Bool) {
+    if animated {
+      withAnimation(PixelEditorControlAnimation.panelChange) {
+        isDetailControlVisible = isVisible
+      }
+    } else {
+      var transaction = Transaction()
+      transaction.disablesAnimations = true
+      withTransaction(transaction) {
+        isDetailControlVisible = isVisible
+      }
     }
   }
 }
@@ -461,17 +563,19 @@ private struct PixelEditorRootControl: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      Group {
-        switch displayedPanel {
-        case .filter:
-          PixelEditorPresetList(viewModel: viewModel)
+      ZStack {
+        PixelEditorPresetList(viewModel: viewModel)
+          .pixelEditorControlPresentation(isVisible: displayedPanel == .filter, hiddenOffsetY: 6)
+          .allowsHitTesting(displayedPanel == .filter)
+          .accessibilityHidden(displayedPanel != .filter)
 
-        case .edit:
-          PixelEditorEditMenuView(
-            viewModel: viewModel,
-            onSelectRoute: onSelectRoute
-          )
-        }
+        PixelEditorEditMenuView(
+          viewModel: viewModel,
+          onSelectRoute: onSelectRoute
+        )
+        .pixelEditorControlPresentation(isVisible: displayedPanel == .edit, hiddenOffsetY: 6)
+        .allowsHitTesting(displayedPanel == .edit)
+        .accessibilityHidden(displayedPanel != .edit)
       }
       .frame(height: 118)
 
@@ -678,9 +782,6 @@ private struct PixelEditorCropControl: View {
         onDone: onDone
       )
     }
-    .onAppear {
-      viewModel.setMode(.crop)
-    }
   }
 }
 
@@ -693,6 +794,28 @@ private struct PixelEditorMaskControl: View {
   var body: some View {
     VStack(spacing: 0) {
       VStack(spacing: 16) {
+
+        Circle()
+          .fill(PixelEditorColor.primary)
+          .stroke(PixelEditorColor.primary, lineWidth: 1)
+          .background(Circle().fill(PixelEditorColor.background))
+          .frame(width: brushSize, height: brushSize)
+          .frame(width: 50, height: 50)
+
+        HStack(spacing: 10) {
+
+          PixelEditorBrushSizeSlider(
+            value: brushSize,
+            onChange: { size in
+              viewModel.setBrushSize(size)
+            }
+          )
+          .frame(maxWidth: .infinity)
+          .frame(height: 44)
+
+        }
+        .padding(.horizontal, 36)
+
         Button(viewModel.localizedStrings.clear) {
           viewModel.editingStack.set(blurringMaskPaths: [])
           viewModel.editingStack.takeSnapshot()
@@ -700,34 +823,6 @@ private struct PixelEditorMaskControl: View {
         .font(.system(size: 17, weight: .bold))
         .foregroundStyle(PixelEditorColor.primary)
 
-        HStack(spacing: 10) {
-          Text(viewModel.localizedStrings.brushSizeSmall)
-            .font(.system(size: 18, weight: .medium))
-            .foregroundStyle(PixelEditorColor.primary)
-
-          PixelEditorStepSlider(
-            value: brushSliderValue,
-            range: -0.5...0.5,
-            mode: .plusAndMinus,
-            onChange: { value in
-              let position = CGFloat(value + 0.5)
-              let size = (5 + position * (50 - 5)).rounded()
-              viewModel.setBrushSize(size)
-            }
-          )
-          .frame(height: 44)
-
-          Text(viewModel.localizedStrings.brushSizeLarge)
-            .font(.system(size: 18, weight: .medium))
-            .foregroundStyle(PixelEditorColor.primary)
-        }
-        .padding(.horizontal, 36)
-
-        Circle()
-          .stroke(PixelEditorColor.primary, lineWidth: 1)
-          .background(Circle().fill(PixelEditorColor.background))
-          .frame(width: brushSize, height: brushSize)
-          .frame(width: 50, height: 50)
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -738,9 +833,6 @@ private struct PixelEditorMaskControl: View {
         onDone: onDone
       )
     }
-    .onAppear {
-      viewModel.setMode(.masking)
-    }
   }
 
   private var brushSize: CGFloat {
@@ -750,9 +842,56 @@ private struct PixelEditorMaskControl: View {
     }
   }
 
-  private var brushSliderValue: Double {
-    Double((brushSize - 5) / (50 - 5)) - 0.5
+}
+
+private struct PixelEditorBrushSizeSlider: View {
+
+  let value: CGFloat
+  let onChange: (CGFloat) -> Void
+
+  var body: some View {
+    BrightroomSteppedSlider(
+      value: valueBinding,
+      range: PixelEditorBrushSizeMetrics.sizeRange,
+      stepCount: PixelEditorBrushSizeMetrics.stepCount,
+      style: .pixelEditorStepSlider,
+      transform: { value in
+        value.rounded()
+      },
+      hapticIdentity: { _ in nil },
+      onHaptic: {},
+      topMarker: { _ in
+        Color.clear
+          .frame(width: 6, height: 6)
+      },
+      tick: { context in
+        Capsule()
+          .foregroundStyle(context.isMajor ? Color.primary : Color.secondary)
+      }
+    )
+    .tint(PixelEditorColor.primary)
   }
+
+  private var valueBinding: Binding<Double> {
+    Binding(
+      get: {
+        Double(value)
+          .clamped(to: PixelEditorBrushSizeMetrics.sizeRange)
+      },
+      set: { newValue in
+        let newSize = CGFloat(newValue.rounded())
+        guard newSize != value else { return }
+        onChange(newSize)
+      }
+    )
+  }
+}
+
+private enum PixelEditorBrushSizeMetrics {
+  static let minimumSize: Double = 5
+  static let maximumSize: Double = 50
+  static let sizeRange = minimumSize...maximumSize
+  static let stepCount = Int(maximumSize - minimumSize)
 }
 
 private struct PixelEditorFilterControl: View {
@@ -763,16 +902,25 @@ private struct PixelEditorFilterControl: View {
   let onDone: () -> Void
 
   var body: some View {
+    let displayValue = kind.displayValue(in: viewModel.editingStack.loadedState?.currentEdit.filters)
+
     VStack(spacing: 0) {
-      PixelEditorStepSlider(
-        value: kind.value(in: viewModel.editingStack.loadedState?.currentEdit.filters),
-        range: kind.range,
-        mode: kind.sliderMode,
-        onChange: {
-          kind.setValue($0, editingStack: viewModel.editingStack)
-        }
-      )
-      .frame(height: 44)
+      VStack(spacing: 8) {
+        Text(displayText(for: displayValue))
+          .font(.system(size: 13, weight: .semibold, design: .monospaced))
+          .foregroundStyle(PixelEditorColor.primary)
+          .frame(minWidth: 42)
+
+        PixelEditorStepSlider(
+          value: displayValue,
+          range: PixelEditorAdjustmentSliderMetrics.displayRange,
+          mode: kind.sliderMode,
+          onChange: {
+            kind.setDisplayValue($0, editingStack: viewModel.editingStack)
+          }
+        )
+        .frame(height: 44)
+      }
       .padding(.horizontal, PixelEditorLayout.controlHorizontalMargin)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -783,9 +931,14 @@ private struct PixelEditorFilterControl: View {
         onDone: onDone
       )
     }
-    .onAppear {
-      viewModel.setMode(.editing)
-      viewModel.setTitle(kind.title(localizedStrings: viewModel.localizedStrings))
+  }
+
+  private func displayText(for value: Double) -> String {
+    let roundedValue = Int(value.rounded())
+    if roundedValue > 0 {
+      return "+\(roundedValue)"
+    } else {
+      return "\(roundedValue)"
     }
   }
 }
@@ -805,22 +958,20 @@ private struct PixelEditorStepSlider: View {
 
   var body: some View {
     let currentPosition = sliderPosition(forEditingValue: value)
-    let showsOriginMarker = abs(currentPosition - mode.originPosition) > 0.000_001
+    let currentStep = step(forPosition: currentPosition)
+    let showsOriginMarker = currentStep != 0
 
     BrightroomSteppedSlider(
       value: positionBinding,
       range: mode.positionRange,
       stepCount: mode.tickCount,
       style: .pixelEditorStepSlider,
+      resetValue: mode.originPosition,
       transform: { position in
         sliderPosition(forEditingValue: editingValue(forPosition: position))
       },
-      hapticIdentity: { position in
-        step(forPosition: position) == 0 ? AnyHashable(0) : nil
-      },
-      onHaptic: {
-        UISelectionFeedbackGenerator().selectionChanged()
-      },
+      hapticIdentity: { _ in nil },
+      onHaptic: {},
       topMarker: { context in
         Circle()
           .frame(width: 6, height: 6)
@@ -830,13 +981,12 @@ private struct PixelEditorStepSlider: View {
       tick: { context in
         Capsule()
           .foregroundStyle(context.isMajor ? Color.primary : Color.secondary)
-      },
-      activeTick: { _ in
-        Capsule()
-          .foregroundStyle(.red)
       }
     )
     .tint(PixelEditorColor.primary)
+    .sensoryFeedback(.selection, trigger: currentStep) { _, newStep in
+      newStep == 0
+    }
     .id(mode)
   }
 
@@ -854,34 +1004,21 @@ private struct PixelEditorStepSlider: View {
   }
 
   private func sliderPosition(forEditingValue value: Double) -> Double {
-    guard value != 0 else { return 0 }
-
-    if value > 0 {
-      guard range.upperBound != 0 else { return 0 }
-      let ratio = (value / range.upperBound).clamped(to: 0...1)
-      return PixelEditorStepSliderMetrics.deadZone + ratio * (mode.positionRange.upperBound - PixelEditorStepSliderMetrics.deadZone)
-    } else {
-      guard range.lowerBound != 0 else { return 0 }
-      let ratio = (value / range.lowerBound).clamped(to: 0...1)
-      return -PixelEditorStepSliderMetrics.deadZone + ratio * (mode.positionRange.lowerBound + PixelEditorStepSliderMetrics.deadZone)
-    }
+    sliderPosition(forStep: step(for: value))
   }
 
   private func editingValue(forPosition position: Double) -> Double {
-    if (-PixelEditorStepSliderMetrics.deadZone...PixelEditorStepSliderMetrics.deadZone).contains(position) {
+    let step = step(forSliderPosition: position)
+    guard step != 0 else {
       return 0
     }
 
-    if position > 0 {
-      let ratio = ((position - PixelEditorStepSliderMetrics.deadZone) / (mode.positionRange.upperBound - PixelEditorStepSliderMetrics.deadZone))
-        .clamped(to: 0...1)
-      let step = (ratio * Double(mode.maxStep)).rounded()
-      return range.upperBound * step / Double(mode.maxStep)
+    if step > 0 {
+      guard mode.maxStep > 0 else { return 0 }
+      return range.upperBound * Double(step) / Double(mode.maxStep)
     } else {
-      let ratio = ((position + PixelEditorStepSliderMetrics.deadZone) / (mode.positionRange.lowerBound + PixelEditorStepSliderMetrics.deadZone))
-        .clamped(to: 0...1)
-      let step = (ratio * Double(abs(mode.minStep))).rounded()
-      return range.lowerBound * step / Double(abs(mode.minStep))
+      guard mode.minStep < 0 else { return 0 }
+      return range.lowerBound * Double(abs(step)) / Double(abs(mode.minStep))
     }
   }
 
@@ -902,12 +1039,67 @@ private struct PixelEditorStepSlider: View {
   }
 
   private func step(forPosition position: Double) -> Int {
-    step(for: editingValue(forPosition: position))
+    step(forSliderPosition: position)
+  }
+
+  private func step(forSliderPosition position: Double) -> Int {
+    if (mode.originPosition - originSnapRadius...mode.originPosition + originSnapRadius).contains(position) {
+      return 0
+    }
+
+    if position > mode.originPosition {
+      guard mode.maxStep > 0 else { return 0 }
+      let distance = mode.positionRange.upperBound - mode.originPosition
+      guard distance > 0 else { return 0 }
+      let ratio = ((position - mode.originPosition) / distance).clamped(to: 0...1)
+      return Int((ratio * Double(mode.maxStep)).rounded())
+        .clamped(to: 0...mode.maxStep)
+    } else {
+      guard mode.minStep < 0 else { return 0 }
+      let distance = mode.originPosition - mode.positionRange.lowerBound
+      guard distance > 0 else { return 0 }
+      let ratio = ((mode.originPosition - position) / distance).clamped(to: 0...1)
+      let step = Int((ratio * Double(abs(mode.minStep))).rounded())
+        .clamped(to: 0...abs(mode.minStep))
+      return -step
+    }
+  }
+
+  private func sliderPosition(forStep step: Int) -> Double {
+    if step > 0 {
+      guard mode.maxStep > 0 else { return mode.originPosition }
+      let distance = mode.positionRange.upperBound - mode.originPosition
+      return mode.originPosition + distance * Double(step) / Double(mode.maxStep)
+    } else if step < 0 {
+      guard mode.minStep < 0 else { return mode.originPosition }
+      let distance = mode.originPosition - mode.positionRange.lowerBound
+      return mode.originPosition - distance * Double(abs(step)) / Double(abs(mode.minStep))
+    } else {
+      return mode.originPosition
+    }
+  }
+
+  private var originSnapRadius: Double {
+    let unitDistances = [
+      mode.maxStep > 0 ? (mode.positionRange.upperBound - mode.originPosition) / Double(mode.maxStep) : nil,
+      mode.minStep < 0 ? (mode.originPosition - mode.positionRange.lowerBound) / Double(abs(mode.minStep)) : nil,
+    ].compactMap { $0 }
+
+    guard let unitDistance = unitDistances.min() else {
+      return PixelEditorStepSliderMetrics.originSnapEpsilon
+    }
+
+    return unitDistance * PixelEditorStepSliderMetrics.originSnapStepRatio + PixelEditorStepSliderMetrics.originSnapEpsilon
   }
 }
 
 private enum PixelEditorStepSliderMetrics {
-  static let deadZone: Double = 0.05
+  static let originSnapStepRatio: Double = 0.5
+  static let originSnapEpsilon: Double = 0.000_1
+}
+
+private enum PixelEditorAdjustmentSliderMetrics {
+  static let displayRange: ClosedRange<Double> = -100...100
 }
 
 private extension BrightroomSteppedSliderStyle {
@@ -915,6 +1107,7 @@ private extension BrightroomSteppedSliderStyle {
     tickWidth: 2,
     tickSpacing: 4,
     tickHeight: 10,
+    activeTickWidth: 3,
     activeTickHeight: 18,
     majorTickInterval: 10
   )
@@ -1345,6 +1538,14 @@ private extension PixelEditorFilterKind {
     }
   }
 
+  func displayValue(in filters: EditingStack.Edit.Filters?) -> Double {
+    displayValue(forNativeValue: value(in: filters))
+  }
+
+  func setDisplayValue(_ value: Double, editingStack: EditingStack) {
+    setValue(nativeValue(forDisplayValue: value), editingStack: editingStack)
+  }
+
   func setValue(_ value: Double, editingStack: EditingStack) {
     editingStack.set(filters: { filters in
       switch self {
@@ -1383,6 +1584,43 @@ private extension PixelEditorFilterKind {
       }
     })
   }
+
+  private func displayValue(forNativeValue value: Double) -> Double {
+    guard value != 0 else {
+      return 0
+    }
+
+    let nativeRange = range
+
+    if value > 0 {
+      guard nativeRange.upperBound != 0 else {
+        return 0
+      }
+      return (value / nativeRange.upperBound * 100)
+        .clamped(to: PixelEditorAdjustmentSliderMetrics.displayRange)
+    } else {
+      guard nativeRange.lowerBound != 0 else {
+        return 0
+      }
+      return (value / abs(nativeRange.lowerBound) * 100)
+        .clamped(to: PixelEditorAdjustmentSliderMetrics.displayRange)
+    }
+  }
+
+  private func nativeValue(forDisplayValue value: Double) -> Double {
+    let displayValue = value.clamped(to: PixelEditorAdjustmentSliderMetrics.displayRange)
+    guard displayValue != 0 else {
+      return 0
+    }
+
+    let nativeRange = range
+
+    if displayValue > 0 {
+      return nativeRange.upperBound * displayValue / 100
+    } else {
+      return abs(nativeRange.lowerBound) * displayValue / 100
+    }
+  }
 }
 
 private extension Double {
@@ -1396,6 +1634,13 @@ private extension Double {
       return nil
     }
     return makeFilter(self)
+  }
+}
+
+private extension Int {
+
+  func clamped(to range: ClosedRange<Int>) -> Int {
+    Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
   }
 }
 

--- a/Sources/BrightroomUI/builtin/PixelEditor/SwiftUIPixelEditorView.swift
+++ b/Sources/BrightroomUI/builtin/PixelEditor/SwiftUIPixelEditorView.swift
@@ -517,7 +517,15 @@ private struct PixelEditorControlPanel: View {
     case .root:
       setDetailControlVisible(false, animated: animated)
 
-    case .crop, .masking, .filter(_):
+    case .crop:
+      if route != presentedDetailRoute || !isDetailControlVisible {
+        detailEntryRevision = nil
+        detailSessionID += 1
+      }
+      presentedDetailRoute = route
+      setDetailControlVisible(true, animated: animated)
+
+    case .masking, .filter(_):
       if route != presentedDetailRoute || !isDetailControlVisible {
         detailEntryRevision = viewModel.editingStack.currentRevision
         detailSessionID += 1
@@ -601,9 +609,6 @@ private struct PixelEditorRootControl: View {
         .accessibilityIdentifier("swiftui.pixel.edit")
       }
       .frame(height: 50)
-    }
-    .onAppear {
-      viewModel.setMode(.preview)
     }
   }
 }
@@ -794,7 +799,6 @@ private struct PixelEditorMaskControl: View {
   var body: some View {
     VStack(spacing: 0) {
       VStack(spacing: 16) {
-
         Circle()
           .fill(PixelEditorColor.primary)
           .stroke(PixelEditorColor.primary, lineWidth: 1)
@@ -802,18 +806,14 @@ private struct PixelEditorMaskControl: View {
           .frame(width: brushSize, height: brushSize)
           .frame(width: 50, height: 50)
 
-        HStack(spacing: 10) {
-
-          PixelEditorBrushSizeSlider(
-            value: brushSize,
-            onChange: { size in
-              viewModel.setBrushSize(size)
-            }
-          )
-          .frame(maxWidth: .infinity)
-          .frame(height: 44)
-
-        }
+        PixelEditorBrushSizeSlider(
+          value: brushSize,
+          onChange: { size in
+            viewModel.setBrushSize(size)
+          }
+        )
+        .frame(maxWidth: .infinity)
+        .frame(height: 44)
         .padding(.horizontal, 36)
 
         Button(viewModel.localizedStrings.clear) {
@@ -822,7 +822,6 @@ private struct PixelEditorMaskControl: View {
         }
         .font(.system(size: 17, weight: .bold))
         .foregroundStyle(PixelEditorColor.primary)
-
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
 
@@ -1641,13 +1640,6 @@ private extension Int {
 
   func clamped(to range: ClosedRange<Int>) -> Int {
     Swift.min(Swift.max(self, range.lowerBound), range.upperBound)
-  }
-}
-
-private extension ClosedRange where Bound == Double {
-
-  var length: Double {
-    upperBound - lowerBound
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace `BrightroomSteppedSlider` SwiftUI `ScrollView` implementation with a UIKit `UIScrollView`-backed control that owns coordinate-based offset, snapping, double-tap reset, haptics, and accessibility adjustment.
- Preserve the existing SwiftUI `topMarker` / `tick` closures through hosting, while driving active tick scaling from UIKit scroll coordinates.
- Update PhotosCrop and PixelEditor slider usage for reset values, neutral/origin behavior, PixelEditor `-100...100` display values, and root/detail panel state retention.
- Clean up follow-up leftover code after review: redundant mode updates, unused helpers, single-child wrapper layout, and duplicate style calculations.

## Validation

- `git diff --check`
- `xcodebuild -project Dev/Brightroom.xcodeproj -scheme BrightroomUI -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' build`

## Notes

- Draft PR because manual PixelEditor / PhotosCrop interaction QA on simulator is still worth doing before merge, especially initial centering, Cancel/Done restoration, double-tap reset animation, and iPad-width layout changes.