### PR TITLE
[codex] Add BrightroomParametric module

### DIFF
--- a/Dev/Brightroom.xcodeproj/project.pbxproj
+++ b/Dev/Brightroom.xcodeproj/project.pbxproj
@@ -59,8 +59,11 @@
 		4BF934412614D08300E0637A /* screenshot-8bit-p3-alpha.png in Resources */ = {isa = PBXBuildFile; fileRef = 4BF934402614D08300E0637A /* screenshot-8bit-p3-alpha.png */; };
 		B027724C2FC2B70A006D7796 /* Reveal-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = B027724B2FC2B70A006D7796 /* Reveal-SDK */; };
 		B08FEAC52F2C76B2002E67C4 /* Reveal-SDK in Frameworks */ = {isa = PBXBuildFile; productRef = B08FEAC42F2C76B2002E67C4 /* Reveal-SDK */; };
+		EEFA1F2CFBEE4B5AB3189151 /* BrightroomParametric in Frameworks */ = {isa = PBXBuildFile; productRef = E41DF318FBB3443697FEC673 /* BrightroomParametric */; };
 		FC06C87F2A53AF4500215B89 /* BrightroomEngine in Frameworks */ = {isa = PBXBuildFile; productRef = FC06C87E2A53AF4500215B89 /* BrightroomEngine */; };
 		FC06C8812A53AF4500215B89 /* BrightroomUI in Frameworks */ = {isa = PBXBuildFile; productRef = FC06C8802A53AF4500215B89 /* BrightroomUI */; };
+		8803B369987D47B7BEDAE2AA /* BrightroomParametric in Frameworks */ = {isa = PBXBuildFile; productRef = 23449504C30943C981A14D75 /* BrightroomParametric */; };
+		8F5D27B649664EF38B9F4C08 /* BrightroomParametric in Frameworks */ = {isa = PBXBuildFile; productRef = BC5DE159959545B49CA01241 /* BrightroomParametric */; };
 		FC110D8F2660FD5500CC45EA /* 5633ed9d0eb700d0093bf85d86a95ebf.jpg in Resources */ = {isa = PBXBuildFile; fileRef = FC110D2D2660FD2200CC45EA /* 5633ed9d0eb700d0093bf85d86a95ebf.jpg */; };
 		FC110D902660FD5500CC45EA /* acce3629083f0e348e94fb58f952d3de.jpg in Resources */ = {isa = PBXBuildFile; fileRef = FC110D2E2660FD2200CC45EA /* acce3629083f0e348e94fb58f952d3de.jpg */; };
 		FC110D922660FD5500CC45EA /* 7acc832f70b2ca62e58a953f3b90fd82.jpg in Resources */ = {isa = PBXBuildFile; fileRef = FC110D302660FD2300CC45EA /* 7acc832f70b2ca62e58a953f3b90fd82.jpg */; };
@@ -476,6 +479,7 @@
 		4B600B3E216B7CE9001E1456 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		4B9369E725F940E600B18571 /* nasa.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = nasa.jpg; sourceTree = "<group>"; };
 		4B98CCB925EFF31300E4F61F /* SwiftUIDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUIDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B38D61DFBC1456792F529BB /* ParametricMacDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ParametricMacDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4BB4B104260F8589007617D7 /* LUT_64_Neutral.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = LUT_64_Neutral.png; path = Resources/LUT_64_Neutral.png; sourceTree = SOURCE_ROOT; };
 		4BB7B9C8277A439B0014B62A /* LUT_64_Dark_HighContrast_v3.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LUT_64_Dark_HighContrast_v3.png; sourceTree = "<group>"; };
 		4BB7B9CB277A452A0014B62A /* LUT_64_Gloss.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LUT_64_Gloss.png; sourceTree = "<group>"; };
@@ -898,6 +902,7 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		5462C745534F43D9AF56EE28 /* ParametricMacDemo */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = ParametricMacDemo; sourceTree = "<group>"; };
 		B036D2DC2FC2A64400C834BA /* Sources */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B036D2F12FC2A64500C834BA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, B036D2F22FC2A64500C834BA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Sources; sourceTree = "<group>"; };
 		B036D2FF2FC2A67700C834BA /* Tests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (B036D30B2FC2A67800C834BA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tests; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -907,6 +912,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EEFA1F2CFBEE4B5AB3189151 /* BrightroomParametric in Frameworks */,
 				FC06C87F2A53AF4500215B89 /* BrightroomEngine in Frameworks */,
 				B08FEAC52F2C76B2002E67C4 /* Reveal-SDK in Frameworks */,
 				B027724C2FC2B70A006D7796 /* Reveal-SDK in Frameworks */,
@@ -919,6 +925,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				4B487E5F28EEC0670026A8CF /* BrightroomEngine in Frameworks */,
+				8803B369987D47B7BEDAE2AA /* BrightroomParametric in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		343D35A6DAD74B728C225FC3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F5D27B649664EF38B9F4C08 /* BrightroomParametric in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -986,6 +1001,7 @@
 			children = (
 				4B524FE129B8F6A600C1A416 /* Packages */,
 				4BE9B3D1260BA72D000A3D09 /* Bundle */,
+				5462C745534F43D9AF56EE28 /* ParametricMacDemo */,
 				B036D2DC2FC2A64400C834BA /* Sources */,
 				B036D2FF2FC2A67700C834BA /* Tests */,
 				4B600AFE216B7A94001E1456 /* Products */,
@@ -999,6 +1015,7 @@
 			isa = PBXGroup;
 			children = (
 				4B98CCB925EFF31300E4F61F /* SwiftUIDemo.app */,
+				6B38D61DFBC1456792F529BB /* ParametricMacDemo.app */,
 				4BDEE09825F8CF5800FA22CB /* BrightroomEngineTests.xctest */,
 				4BED49C8261C9BBD0011A98F /* Import LUT.appex */,
 				4BED49E0261C9CE20011A98F /* ShareLUT.appex */,
@@ -1471,6 +1488,7 @@
 			);
 			name = SwiftUIDemo;
 			packageProductDependencies = (
+				E41DF318FBB3443697FEC673 /* BrightroomParametric */,
 				FC06C87E2A53AF4500215B89 /* BrightroomEngine */,
 				FC06C8802A53AF4500215B89 /* BrightroomUI */,
 				B08FEAC42F2C76B2002E67C4 /* Reveal-SDK */,
@@ -1498,10 +1516,34 @@
 			name = BrightroomEngineTests;
 			packageProductDependencies = (
 				4B487E5E28EEC0670026A8CF /* BrightroomEngine */,
+				23449504C30943C981A14D75 /* BrightroomParametric */,
 			);
 			productName = PixelEngineTests;
 			productReference = 4BDEE09825F8CF5800FA22CB /* BrightroomEngineTests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		07F65785A7D046C59571D0DA /* ParametricMacDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4B5EC9EDB4A64C4A90F0F2CF /* Build configuration list for PBXNativeTarget "ParametricMacDemo" */;
+			buildPhases = (
+				C83159EA590F42CD9C3A522E /* Sources */,
+				343D35A6DAD74B728C225FC3 /* Frameworks */,
+				9137E31FED744F129A0FD278 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				5462C745534F43D9AF56EE28 /* ParametricMacDemo */,
+			);
+			name = ParametricMacDemo;
+			packageProductDependencies = (
+				BC5DE159959545B49CA01241 /* BrightroomParametric */,
+			);
+			productName = ParametricMacDemo;
+			productReference = 6B38D61DFBC1456792F529BB /* ParametricMacDemo.app */;
+			productType = "com.apple.product-type.application";
 		};
 		4BED49C7261C9BBD0011A98F /* Import LUT */ = {
 			isa = PBXNativeTarget;
@@ -1553,6 +1595,9 @@
 					4BDEE09725F8CF5800FA22CB = {
 						CreatedOnToolsVersion = 12.4;
 					};
+					07F65785A7D046C59571D0DA = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					4BED49C7261C9BBD0011A98F = {
 						CreatedOnToolsVersion = 12.4;
 					};
@@ -1579,6 +1624,7 @@
 			targets = (
 				4BDEE09725F8CF5800FA22CB /* BrightroomEngineTests */,
 				4B98CCB825EFF31300E4F61F /* SwiftUIDemo */,
+				07F65785A7D046C59571D0DA /* ParametricMacDemo */,
 				4BED49C7261C9BBD0011A98F /* Import LUT */,
 				4BED49DF261C9CE20011A98F /* ShareLUT */,
 			);
@@ -2016,6 +2062,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9137E31FED744F129A0FD278 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4BED49C6261C9BBD0011A98F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2044,6 +2097,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		4BDEE09425F8CF5800FA22CB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C83159EA590F42CD9C3A522E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2250,6 +2310,58 @@
 			};
 			name = Release;
 		};
+		45686D40D781452D8F290221 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = JX92XL88RZ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Parametric Mac Demo";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.muukii.brightroom.ParametricMacDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		7D01513049A3457588506C28 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = JX92XL88RZ;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Parametric Mac Demo";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = app.muukii.brightroom.ParametricMacDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
 		4BDEE09D25F8CF5800FA22CB /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2389,6 +2501,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		4B5EC9EDB4A64C4A90F0F2CF /* Build configuration list for PBXNativeTarget "ParametricMacDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				45686D40D781452D8F290221 /* Debug */,
+				7D01513049A3457588506C28 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4BDEE09F25F8CF5800FA22CB /* Build configuration list for PBXNativeTarget "BrightroomEngineTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2434,6 +2555,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = BrightroomEngine;
 		};
+		23449504C30943C981A14D75 /* BrightroomParametric */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BrightroomParametric;
+		};
 		B027724B2FC2B70A006D7796 /* Reveal-SDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = B027724A2FC2B70A006D7796 /* XCRemoteSwiftPackageReference "Reveal-SDK" */;
@@ -2442,6 +2567,14 @@
 		B08FEAC42F2C76B2002E67C4 /* Reveal-SDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = "Reveal-SDK";
+		};
+		BC5DE159959545B49CA01241 /* BrightroomParametric */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BrightroomParametric;
+		};
+		E41DF318FBB3443697FEC673 /* BrightroomParametric */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BrightroomParametric;
 		};
 		FC06C87E2A53AF4500215B89 /* BrightroomEngine */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Dev/Brightroom.xcodeproj/xcshareddata/xcschemes/ParametricMacDemo.xcscheme
+++ b/Dev/Brightroom.xcodeproj/xcshareddata/xcschemes/ParametricMacDemo.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "07F65785A7D046C59571D0DA"
+               BuildableName = "ParametricMacDemo.app"
+               BlueprintName = "ParametricMacDemo"
+               ReferencedContainer = "container:Brightroom.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "07F65785A7D046C59571D0DA"
+            BuildableName = "ParametricMacDemo.app"
+            BlueprintName = "ParametricMacDemo"
+            ReferencedContainer = "container:Brightroom.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "07F65785A7D046C59571D0DA"
+            BuildableName = "ParametricMacDemo.app"
+            BlueprintName = "ParametricMacDemo"
+            ReferencedContainer = "container:Brightroom.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Dev/ParametricMacDemo/ParametricMacDemoApp.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct ParametricMacDemoApp: App {
+
+  var body: some Scene {
+    WindowGroup {
+      ParametricMacDemoView()
+    }
+    .defaultSize(width: 1180, height: 780)
+  }
+}

--- a/Dev/ParametricMacDemo/ParametricMacDemoView.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoView.swift
@@ -6,25 +6,15 @@ import UniformTypeIdentifiers
 
 struct ParametricMacDemoView: View {
 
-  @State private var firstCropInset = 48.0
-  @State private var localExposure = 0.55
-  @State private var localBlurRadius = 4.0
-  @State private var brushDiameter = 220.0
-  @State private var maskFeatherRadius = 18.0
-  @State private var secondCropInset = 34.0
-  @State private var globalBrightness = 0.03
-  @State private var globalSaturation = 0.22
-  @State private var globalVignette = 0.45
-  @State private var featureOrder = ParametricMacEditableFeature.defaultOrder
+  @State private var settings = ParametricMacPreviewSettings.initial
   @State private var draggedFeature: ParametricMacEditableFeature?
-  @State private var suppressedFeatureIDs: Set<FeatureID> = []
 
   private let renderer = ParametricMacPreviewRenderer()
 
   var body: some View {
-    let settings = makeSettings()
+    let previewSettings = settings
     let rendered = Result {
-      try renderer.render(settings: settings)
+      try renderer.render(settings: previewSettings)
     }
     let output = try? rendered.get()
 
@@ -105,12 +95,12 @@ struct ParametricMacDemoView: View {
         Spacer()
 
         Button {
-          suppressedFeatureIDs.removeAll()
+          settings.suppressedFeatureIDs.removeAll()
         } label: {
           Label("Enable All", systemImage: "checkmark.circle")
         }
         .buttonStyle(.borderless)
-        .disabled(suppressedFeatureIDs.isEmpty)
+        .disabled(settings.suppressedFeatureIDs.isEmpty)
       }
 
       ScrollView {
@@ -129,7 +119,7 @@ struct ParametricMacDemoView: View {
             detail: "source -> output"
           )
 
-          ForEach(featureOrder) { feature in
+          ForEach(settings.featureOrder) { feature in
             featureEditorRow(
               feature,
               summary: output?.treeLine(for: feature.featureID)
@@ -172,7 +162,7 @@ struct ParametricMacDemoView: View {
     summary: ParametricMacTreeLine?
   ) -> some View {
     let featureID = feature.featureID
-    let isSuppressed = suppressedFeatureIDs.contains(featureID)
+    let isSuppressed = settings.suppressedFeatureIDs.contains(featureID)
     let detail = summary?.detail ?? feature.defaultDetail
 
     return HStack(spacing: 10) {
@@ -235,7 +225,7 @@ struct ParametricMacDemoView: View {
       of: [UTType.text],
       delegate: ParametricMacFeatureDropDelegate(
         targetFeature: feature,
-        featureOrder: $featureOrder,
+        featureOrder: $settings.featureOrder,
         draggedFeature: $draggedFeature
       )
     )
@@ -247,103 +237,103 @@ struct ParametricMacDemoView: View {
     case .crop1:
       parameterSlider(
         title: "Inset",
-        value: $firstCropInset,
+        value: $settings.firstCropInset,
         range: 0...140,
         step: 1,
-        valueText: "\(Int(firstCropInset))"
+        valueText: "\(Int(settings.firstCropInset))"
       )
 
     case .localAdjustment:
       VStack(alignment: .leading, spacing: 10) {
         nestedFeatureToggle(
           title: "Brush Mask",
-          detail: "diameter \(Int(brushDiameter))",
+          detail: "diameter \(Int(settings.brushDiameter))",
           featureID: ParametricMacPreviewFeatureID.brushMask
         )
         parameterSlider(
           title: "Brush",
-          value: $brushDiameter,
+          value: $settings.brushDiameter,
           range: 40...360,
           step: 1,
-          valueText: "\(Int(brushDiameter))"
+          valueText: "\(Int(settings.brushDiameter))"
         )
 
         nestedFeatureToggle(
           title: "Feather Mask",
-          detail: "radius \(Int(maskFeatherRadius))",
+          detail: "radius \(Int(settings.maskFeatherRadius))",
           featureID: ParametricMacPreviewFeatureID.featherMask
         )
         parameterSlider(
           title: "Feather",
-          value: $maskFeatherRadius,
+          value: $settings.maskFeatherRadius,
           range: 0...48,
           step: 1,
-          valueText: "\(Int(maskFeatherRadius))"
+          valueText: "\(Int(settings.maskFeatherRadius))"
         )
 
         Divider()
 
         nestedFeatureToggle(
           title: "Exposure",
-          detail: localExposure.formatted(.number.precision(.fractionLength(2))),
+          detail: settings.localExposure.formatted(.number.precision(.fractionLength(2))),
           featureID: ParametricMacPreviewFeatureID.localExposure
         )
         parameterSlider(
           title: "Exposure",
-          value: $localExposure,
+          value: $settings.localExposure,
           range: -1...1,
           step: 0.01,
-          valueText: localExposure.formatted(.number.precision(.fractionLength(2)))
+          valueText: settings.localExposure.formatted(.number.precision(.fractionLength(2)))
         )
 
         nestedFeatureToggle(
           title: "Blur",
-          detail: "\(Int(localBlurRadius)) px",
+          detail: "\(Int(settings.localBlurRadius)) px",
           featureID: ParametricMacPreviewFeatureID.localBlur
         )
         parameterSlider(
           title: "Blur",
-          value: $localBlurRadius,
+          value: $settings.localBlurRadius,
           range: 0...24,
           step: 1,
-          valueText: "\(Int(localBlurRadius)) px"
+          valueText: "\(Int(settings.localBlurRadius)) px"
         )
       }
 
     case .globalBrightness:
       parameterSlider(
         title: "Brightness",
-        value: $globalBrightness,
+        value: $settings.globalBrightness,
         range: -0.25...0.25,
         step: 0.01,
-        valueText: globalBrightness.formatted(.number.precision(.fractionLength(2)))
+        valueText: settings.globalBrightness.formatted(.number.precision(.fractionLength(2)))
       )
 
     case .globalSaturation:
       parameterSlider(
         title: "Saturation",
-        value: $globalSaturation,
+        value: $settings.globalSaturation,
         range: -0.75...0.75,
         step: 0.01,
-        valueText: globalSaturation.formatted(.number.precision(.fractionLength(2)))
+        valueText: settings.globalSaturation.formatted(.number.precision(.fractionLength(2)))
       )
 
     case .crop2:
       parameterSlider(
         title: "Inset",
-        value: $secondCropInset,
+        value: $settings.secondCropInset,
         range: 0...96,
         step: 1,
-        valueText: "\(Int(secondCropInset))"
+        valueText: "\(Int(settings.secondCropInset))"
       )
 
     case .globalVignette:
       parameterSlider(
         title: "Vignette",
-        value: $globalVignette,
+        value: $settings.globalVignette,
         range: 0...1.2,
         step: 0.01,
-        valueText: globalVignette.formatted(.number.precision(.fractionLength(2)))
+        valueText: settings.globalVignette.formatted(.number.precision(.fractionLength(2)))
       )
     }
   }
@@ -396,7 +386,7 @@ struct ParametricMacDemoView: View {
       }
       .buttonStyle(.borderless)
       .controlSize(.mini)
-      .disabled(featureOrder.first == feature)
+      .disabled(settings.featureOrder.first == feature)
       .help("Move earlier")
 
       Button {
@@ -406,7 +396,7 @@ struct ParametricMacDemoView: View {
       }
       .buttonStyle(.borderless)
       .controlSize(.mini)
-      .disabled(featureOrder.last == feature)
+      .disabled(settings.featureOrder.last == feature)
       .help("Move later")
     }
     .frame(width: 22)
@@ -416,57 +406,55 @@ struct ParametricMacDemoView: View {
     _ feature: ParametricMacEditableFeature,
     by offset: Int
   ) {
-    guard let sourceIndex = featureOrder.firstIndex(of: feature) else {
+    guard let sourceIndex = settings.featureOrder.firstIndex(of: feature) else {
       return
     }
     let destinationIndex = min(
       max(sourceIndex + offset, 0),
-      featureOrder.count - 1
+      settings.featureOrder.count - 1
     )
     guard sourceIndex != destinationIndex else {
       return
     }
 
     withAnimation(.snappy) {
-      let movedFeature = featureOrder.remove(at: sourceIndex)
-      featureOrder.insert(movedFeature, at: destinationIndex)
+      let movedFeature = settings.featureOrder.remove(at: sourceIndex)
+      settings.featureOrder.insert(movedFeature, at: destinationIndex)
     }
   }
 
   private func featureEnabledBinding(for featureID: FeatureID) -> Binding<Bool> {
     Binding(
       get: {
-        suppressedFeatureIDs.contains(featureID) == false
+        settings.suppressedFeatureIDs.contains(featureID) == false
       },
       set: { isEnabled in
         if isEnabled {
-          suppressedFeatureIDs.remove(featureID)
+          settings.suppressedFeatureIDs.remove(featureID)
         } else {
-          suppressedFeatureIDs.insert(featureID)
+          settings.suppressedFeatureIDs.insert(featureID)
         }
       }
-    )
-  }
-
-  private func makeSettings() -> ParametricMacPreviewSettings {
-    ParametricMacPreviewSettings(
-      featureOrder: featureOrder,
-      firstCropInset: firstCropInset,
-      localExposure: localExposure,
-      localBlurRadius: localBlurRadius,
-      brushDiameter: brushDiameter,
-      maskFeatherRadius: maskFeatherRadius,
-      secondCropInset: secondCropInset,
-      globalBrightness: globalBrightness,
-      globalSaturation: globalSaturation,
-      globalVignette: globalVignette,
-      suppressedFeatureIDs: suppressedFeatureIDs
     )
   }
 }
 
 /// User-editable values that define the macOS parametric preview document.
 struct ParametricMacPreviewSettings {
+
+  static let initial = ParametricMacPreviewSettings(
+    featureOrder: ParametricMacEditableFeature.defaultOrder,
+    firstCropInset: 48,
+    localExposure: 0.55,
+    localBlurRadius: 4,
+    brushDiameter: 220,
+    maskFeatherRadius: 18,
+    secondCropInset: 34,
+    globalBrightness: 0.03,
+    globalSaturation: 0.22,
+    globalVignette: 0.45,
+    suppressedFeatureIDs: []
+  )
 
   var featureOrder: [ParametricMacEditableFeature]
   var firstCropInset: Double
@@ -503,7 +491,6 @@ struct ParametricMacPreviewOutput {
 struct ParametricMacTreeLine: Identifiable {
 
   var id: String
-  var level: Int
   var kind: ParametricMacTreeKind
   var title: String
   var detail: String
@@ -513,8 +500,6 @@ struct ParametricMacTreeLine: Identifiable {
 /// Display categories used by the macOS feature tree editor.
 enum ParametricMacTreeKind: String {
 
-  case source
-  case main
   case domain
   case local
   case mask
@@ -526,10 +511,6 @@ enum ParametricMacTreeKind: String {
 
   var color: Color {
     switch self {
-    case .source:
-      .secondary
-    case .main:
-      .primary
     case .domain:
       .cyan
     case .local:
@@ -538,23 +519,6 @@ enum ParametricMacTreeKind: String {
       .pink
     case .effect:
       .green
-    }
-  }
-
-  var systemImage: String {
-    switch self {
-    case .source:
-      "photo"
-    case .main:
-      "arrow.right"
-    case .domain:
-      "crop"
-    case .local:
-      "scope"
-    case .mask:
-      "paintbrush"
-    case .effect:
-      "slider.horizontal.3"
     }
   }
 }
@@ -720,24 +684,7 @@ struct ParametricMacPreviewRenderer {
     settings: ParametricMacPreviewSettings
   ) throws -> (document: FeatureDocument, treeLines: [ParametricMacTreeLine]) {
     var features: [FeatureTreeNode] = []
-    var treeLines: [ParametricMacTreeLine] = [
-      .init(
-        id: "source",
-        level: 0,
-        kind: .source,
-        title: "Source",
-        detail: sizeDescription(Self.sourceSize),
-        featureID: nil
-      ),
-      .init(
-        id: "main",
-        level: 0,
-        kind: .main,
-        title: "Main",
-        detail: "source -> output",
-        featureID: nil
-      ),
-    ]
+    var treeLines: [ParametricMacTreeLine] = []
     var currentSize = Self.sourceSize
 
     for editableFeature in settings.featureOrder {
@@ -821,7 +768,6 @@ struct ParametricMacPreviewRenderer {
       cropRect.size,
       .init(
         id: featureID.rawValue,
-        level: 1,
         kind: .domain,
         title: title,
         detail: "inset \(Int(inset)) -> \(sizeDescription(cropRect.size))",
@@ -883,7 +829,6 @@ struct ParametricMacPreviewRenderer {
       [
         .init(
           id: localAdjustmentID.rawValue,
-          level: 1,
           kind: .local,
           title: "Local Adjustment",
           detail: "alpha blend branch",
@@ -891,7 +836,6 @@ struct ParametricMacPreviewRenderer {
         ),
         .init(
           id: brushID.rawValue,
-          level: 2,
           kind: .mask,
           title: "Brush Mask",
           detail: "diameter \(Int(settings.brushDiameter))",
@@ -899,7 +843,6 @@ struct ParametricMacPreviewRenderer {
         ),
         .init(
           id: featherID.rawValue,
-          level: 2,
           kind: .mask,
           title: "Feather Mask",
           detail: "radius \(Int(settings.maskFeatherRadius))",
@@ -907,7 +850,6 @@ struct ParametricMacPreviewRenderer {
         ),
         .init(
           id: exposureID.rawValue,
-          level: 2,
           kind: .effect,
           title: "Exposure",
           detail: settings.localExposure.formatted(.number.precision(.fractionLength(2))),
@@ -915,7 +857,6 @@ struct ParametricMacPreviewRenderer {
         ),
         .init(
           id: blurID.rawValue,
-          level: 2,
           kind: .effect,
           title: "Blur",
           detail: "\(Int(settings.localBlurRadius)) px",
@@ -938,7 +879,6 @@ struct ParametricMacPreviewRenderer {
       ),
       .init(
         id: featureID.rawValue,
-        level: 1,
         kind: .effect,
         title: "Brightness",
         detail: settings.globalBrightness.formatted(.number.precision(.fractionLength(2))),
@@ -960,7 +900,6 @@ struct ParametricMacPreviewRenderer {
       ),
       .init(
         id: featureID.rawValue,
-        level: 1,
         kind: .effect,
         title: "Saturation",
         detail: settings.globalSaturation.formatted(.number.precision(.fractionLength(2))),
@@ -983,7 +922,6 @@ struct ParametricMacPreviewRenderer {
       ),
       .init(
         id: featureID.rawValue,
-        level: 1,
         kind: .effect,
         title: "Vignette",
         detail: settings.globalVignette.formatted(.number.precision(.fractionLength(2))),

--- a/Dev/ParametricMacDemo/ParametricMacDemoView.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoView.swift
@@ -2,90 +2,46 @@ import AppKit
 import BrightroomParametric
 import CoreImage
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ParametricMacDemoView: View {
 
-  @State private var isFirstCropEnabled = true
   @State private var firstCropInset = 48.0
-  @State private var isLocalAdjustmentEnabled = true
   @State private var localExposure = 0.55
   @State private var localBlurRadius = 4.0
   @State private var brushDiameter = 220.0
   @State private var maskFeatherRadius = 18.0
-  @State private var isSecondCropEnabled = true
   @State private var secondCropInset = 34.0
   @State private var globalBrightness = 0.03
   @State private var globalSaturation = 0.22
   @State private var globalVignette = 0.45
+  @State private var featureOrder = ParametricMacEditableFeature.defaultOrder
+  @State private var draggedFeature: ParametricMacEditableFeature?
   @State private var suppressedFeatureIDs: Set<FeatureID> = []
 
   private let renderer = ParametricMacPreviewRenderer()
 
   var body: some View {
-    HStack(spacing: 0) {
-      controlPanel
-        .frame(width: 320)
-        .background(.regularMaterial)
-
-      Divider()
-
-      previewPanel
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-  }
-
-  private var controlPanel: some View {
-    Form {
-      Section("Domain") {
-        Toggle("Crop 1", isOn: $isFirstCropEnabled)
-        Slider(value: $firstCropInset, in: 0...140, step: 1) {
-          Text("Inset")
-        }
-
-        Toggle("Crop 2", isOn: $isSecondCropEnabled)
-        Slider(value: $secondCropInset, in: 0...96, step: 1) {
-          Text("Inset")
-        }
-      }
-
-      Section("Local") {
-        Toggle("Local Adjustment", isOn: $isLocalAdjustmentEnabled)
-        Slider(value: $localExposure, in: -1...1, step: 0.01) {
-          Text("Exposure")
-        }
-        Slider(value: $localBlurRadius, in: 0...24, step: 1) {
-          Text("Blur")
-        }
-        Slider(value: $brushDiameter, in: 40...360, step: 1) {
-          Text("Brush")
-        }
-        Slider(value: $maskFeatherRadius, in: 0...48, step: 1) {
-          Text("Feather")
-        }
-      }
-
-      Section("Global") {
-        Slider(value: $globalBrightness, in: -0.25...0.25, step: 0.01) {
-          Text("Brightness")
-        }
-        Slider(value: $globalSaturation, in: -0.75...0.75, step: 0.01) {
-          Text("Saturation")
-        }
-        Slider(value: $globalVignette, in: 0...1.2, step: 0.01) {
-          Text("Vignette")
-        }
-      }
-    }
-    .formStyle(.grouped)
-  }
-
-  private var previewPanel: some View {
     let settings = makeSettings()
     let rendered = Result {
       try renderer.render(settings: settings)
     }
+    let output = try? rendered.get()
 
-    return VStack(alignment: .leading, spacing: 18) {
+    return HStack(spacing: 0) {
+      featureEditorPanel(output: output)
+        .frame(width: 380)
+        .background(.regularMaterial)
+
+      Divider()
+
+      previewPanel(rendered: rendered)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+
+  private func previewPanel(rendered: Result<ParametricMacPreviewOutput, Error>) -> some View {
+    VStack(alignment: .leading, spacing: 18) {
       Text("Parametric Mac Demo")
         .font(.title.bold())
 
@@ -97,8 +53,6 @@ struct ParametricMacDemoView: View {
         }
         .frame(minHeight: 300)
         .frame(maxHeight: .infinity)
-
-        treeView(lines: output.treeLines)
 
       case let .failure(error):
         ContentUnavailableView(
@@ -137,11 +91,16 @@ struct ParametricMacDemoView: View {
     }
   }
 
-  private func treeView(lines: [ParametricMacTreeLine]) -> some View {
-    VStack(alignment: .leading, spacing: 10) {
+  private func featureEditorPanel(output: ParametricMacPreviewOutput?) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
       HStack(spacing: 8) {
-        Text("Feature Tree")
-          .font(.headline)
+        VStack(alignment: .leading, spacing: 3) {
+          Text("Feature Editor")
+            .font(.title3.bold())
+          Text("Drag rows to change evaluation order.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
 
         Spacer()
 
@@ -155,40 +114,89 @@ struct ParametricMacDemoView: View {
       }
 
       ScrollView {
-        VStack(alignment: .leading, spacing: 6) {
-          ForEach(lines) { line in
-            treeLineView(line)
+        VStack(alignment: .leading, spacing: 8) {
+          if let output {
+            documentSummaryRow(
+              icon: "photo",
+              title: "Source",
+              detail: "\(Int(output.sourceExtent.width)) x \(Int(output.sourceExtent.height))"
+            )
+          }
+
+          documentSummaryRow(
+            icon: "arrow.right",
+            title: "Main",
+            detail: "source -> output"
+          )
+
+          ForEach(featureOrder) { feature in
+            featureEditorRow(
+              feature,
+              summary: output?.treeLine(for: feature.featureID)
+            )
           }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
       }
-      .frame(maxHeight: 280)
     }
-    .frame(maxWidth: 520, alignment: .leading)
+    .padding(20)
   }
 
-  private func treeLineView(_ line: ParametricMacTreeLine) -> some View {
-    let isSuppressed = line.featureID.map { suppressedFeatureIDs.contains($0) } ?? false
+  private func documentSummaryRow(
+    icon: String,
+    title: String,
+    detail: String
+  ) -> some View {
+    HStack(spacing: 10) {
+      Image(systemName: icon)
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+        .frame(width: 28)
+
+      VStack(alignment: .leading, spacing: 3) {
+        Text(title)
+          .font(.caption.weight(.semibold))
+        Text(detail)
+          .font(.caption.monospacedDigit())
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, 8)
+    .padding(.horizontal, 10)
+  }
+
+  private func featureEditorRow(
+    _ feature: ParametricMacEditableFeature,
+    summary: ParametricMacTreeLine?
+  ) -> some View {
+    let featureID = feature.featureID
+    let isSuppressed = suppressedFeatureIDs.contains(featureID)
+    let detail = summary?.detail ?? feature.defaultDetail
 
     return HStack(spacing: 10) {
-      if let featureID = line.featureID {
-        Toggle("", isOn: featureEnabledBinding(for: featureID))
-          .labelsHidden()
-          .toggleStyle(.switch)
-          .controlSize(.small)
-          .help(isSuppressed ? "Restore this feature" : "Suppress this feature")
-      } else {
-        Image(systemName: line.kind.systemImage)
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(line.kind.color)
-          .frame(width: 28)
-      }
+      Image(systemName: "line.3.horizontal")
+        .font(.caption.weight(.bold))
+        .foregroundStyle(.tertiary)
+        .frame(width: 16)
+        .help("Drag to reorder")
+        .onDrag {
+          draggedFeature = feature
+          return NSItemProvider(object: feature.rawValue as NSString)
+        }
+
+      Toggle("", isOn: featureEnabledBinding(for: featureID))
+        .labelsHidden()
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .help(isSuppressed ? "Restore this feature" : "Suppress this feature")
 
       VStack(alignment: .leading, spacing: 3) {
         HStack(spacing: 6) {
-          Text(line.kind.title)
+          Text(feature.kind.title)
             .font(.caption2.monospaced().weight(.semibold))
-            .foregroundStyle(line.kind.color)
+            .foregroundStyle(feature.kind.color)
 
           if isSuppressed {
             Text("Suppressed")
@@ -201,24 +209,228 @@ struct ParametricMacDemoView: View {
         }
 
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-          Text(line.title)
+          Text(feature.title)
             .font(.caption.weight(.semibold))
             .foregroundStyle(isSuppressed ? .secondary : .primary)
 
-          Text(line.detail)
+          Text(detail)
             .font(.caption.monospacedDigit())
             .foregroundStyle(.secondary)
         }
+
+        featureParameterControls(for: feature)
+          .padding(.top, 8)
       }
 
       Spacer(minLength: 0)
+
+      featureMoveControls(for: feature)
     }
-    .padding(.leading, CGFloat(line.level) * 18)
     .padding(.vertical, 8)
     .padding(.horizontal, 10)
     .background(isSuppressed ? Color.secondary.opacity(0.08) : Color(nsColor: .controlBackgroundColor).opacity(0.78))
     .clipShape(RoundedRectangle(cornerRadius: 8))
     .opacity(isSuppressed ? 0.58 : 1)
+    .onDrop(
+      of: [UTType.text],
+      delegate: ParametricMacFeatureDropDelegate(
+        targetFeature: feature,
+        featureOrder: $featureOrder,
+        draggedFeature: $draggedFeature
+      )
+    )
+  }
+
+  @ViewBuilder
+  private func featureParameterControls(for feature: ParametricMacEditableFeature) -> some View {
+    switch feature {
+    case .crop1:
+      parameterSlider(
+        title: "Inset",
+        value: $firstCropInset,
+        range: 0...140,
+        step: 1,
+        valueText: "\(Int(firstCropInset))"
+      )
+
+    case .localAdjustment:
+      VStack(alignment: .leading, spacing: 10) {
+        nestedFeatureToggle(
+          title: "Brush Mask",
+          detail: "diameter \(Int(brushDiameter))",
+          featureID: ParametricMacPreviewFeatureID.brushMask
+        )
+        parameterSlider(
+          title: "Brush",
+          value: $brushDiameter,
+          range: 40...360,
+          step: 1,
+          valueText: "\(Int(brushDiameter))"
+        )
+
+        nestedFeatureToggle(
+          title: "Feather Mask",
+          detail: "radius \(Int(maskFeatherRadius))",
+          featureID: ParametricMacPreviewFeatureID.featherMask
+        )
+        parameterSlider(
+          title: "Feather",
+          value: $maskFeatherRadius,
+          range: 0...48,
+          step: 1,
+          valueText: "\(Int(maskFeatherRadius))"
+        )
+
+        Divider()
+
+        nestedFeatureToggle(
+          title: "Exposure",
+          detail: localExposure.formatted(.number.precision(.fractionLength(2))),
+          featureID: ParametricMacPreviewFeatureID.localExposure
+        )
+        parameterSlider(
+          title: "Exposure",
+          value: $localExposure,
+          range: -1...1,
+          step: 0.01,
+          valueText: localExposure.formatted(.number.precision(.fractionLength(2)))
+        )
+
+        nestedFeatureToggle(
+          title: "Blur",
+          detail: "\(Int(localBlurRadius)) px",
+          featureID: ParametricMacPreviewFeatureID.localBlur
+        )
+        parameterSlider(
+          title: "Blur",
+          value: $localBlurRadius,
+          range: 0...24,
+          step: 1,
+          valueText: "\(Int(localBlurRadius)) px"
+        )
+      }
+
+    case .globalBrightness:
+      parameterSlider(
+        title: "Brightness",
+        value: $globalBrightness,
+        range: -0.25...0.25,
+        step: 0.01,
+        valueText: globalBrightness.formatted(.number.precision(.fractionLength(2)))
+      )
+
+    case .globalSaturation:
+      parameterSlider(
+        title: "Saturation",
+        value: $globalSaturation,
+        range: -0.75...0.75,
+        step: 0.01,
+        valueText: globalSaturation.formatted(.number.precision(.fractionLength(2)))
+      )
+
+    case .crop2:
+      parameterSlider(
+        title: "Inset",
+        value: $secondCropInset,
+        range: 0...96,
+        step: 1,
+        valueText: "\(Int(secondCropInset))"
+      )
+
+    case .globalVignette:
+      parameterSlider(
+        title: "Vignette",
+        value: $globalVignette,
+        range: 0...1.2,
+        step: 0.01,
+        valueText: globalVignette.formatted(.number.precision(.fractionLength(2)))
+      )
+    }
+  }
+
+  private func parameterSlider(
+    title: String,
+    value: Binding<Double>,
+    range: ClosedRange<Double>,
+    step: Double,
+    valueText: String
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Text(title)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        Spacer()
+        Text(valueText)
+          .font(.caption.monospacedDigit())
+          .foregroundStyle(.secondary)
+      }
+      Slider(value: value, in: range, step: step)
+    }
+  }
+
+  private func nestedFeatureToggle(
+    title: String,
+    detail: String,
+    featureID: FeatureID
+  ) -> some View {
+    HStack(spacing: 8) {
+      Toggle("", isOn: featureEnabledBinding(for: featureID))
+        .labelsHidden()
+        .toggleStyle(.checkbox)
+      Text(title)
+        .font(.caption.weight(.semibold))
+      Text(detail)
+        .font(.caption.monospacedDigit())
+        .foregroundStyle(.secondary)
+      Spacer(minLength: 0)
+    }
+  }
+
+  private func featureMoveControls(for feature: ParametricMacEditableFeature) -> some View {
+    VStack(spacing: 2) {
+      Button {
+        moveFeature(feature, by: -1)
+      } label: {
+        Image(systemName: "chevron.up")
+      }
+      .buttonStyle(.borderless)
+      .controlSize(.mini)
+      .disabled(featureOrder.first == feature)
+      .help("Move earlier")
+
+      Button {
+        moveFeature(feature, by: 1)
+      } label: {
+        Image(systemName: "chevron.down")
+      }
+      .buttonStyle(.borderless)
+      .controlSize(.mini)
+      .disabled(featureOrder.last == feature)
+      .help("Move later")
+    }
+    .frame(width: 22)
+  }
+
+  private func moveFeature(
+    _ feature: ParametricMacEditableFeature,
+    by offset: Int
+  ) {
+    guard let sourceIndex = featureOrder.firstIndex(of: feature) else {
+      return
+    }
+    let destinationIndex = min(
+      max(sourceIndex + offset, 0),
+      featureOrder.count - 1
+    )
+    guard sourceIndex != destinationIndex else {
+      return
+    }
+
+    withAnimation(.snappy) {
+      let movedFeature = featureOrder.remove(at: sourceIndex)
+      featureOrder.insert(movedFeature, at: destinationIndex)
+    }
   }
 
   private func featureEnabledBinding(for featureID: FeatureID) -> Binding<Bool> {
@@ -238,14 +450,12 @@ struct ParametricMacDemoView: View {
 
   private func makeSettings() -> ParametricMacPreviewSettings {
     ParametricMacPreviewSettings(
-      isFirstCropEnabled: isFirstCropEnabled,
+      featureOrder: featureOrder,
       firstCropInset: firstCropInset,
-      isLocalAdjustmentEnabled: isLocalAdjustmentEnabled,
       localExposure: localExposure,
       localBlurRadius: localBlurRadius,
       brushDiameter: brushDiameter,
       maskFeatherRadius: maskFeatherRadius,
-      isSecondCropEnabled: isSecondCropEnabled,
       secondCropInset: secondCropInset,
       globalBrightness: globalBrightness,
       globalSaturation: globalSaturation,
@@ -258,14 +468,12 @@ struct ParametricMacDemoView: View {
 /// User-editable values that define the macOS parametric preview document.
 struct ParametricMacPreviewSettings {
 
-  var isFirstCropEnabled: Bool
+  var featureOrder: [ParametricMacEditableFeature]
   var firstCropInset: Double
-  var isLocalAdjustmentEnabled: Bool
   var localExposure: Double
   var localBlurRadius: Double
   var brushDiameter: Double
   var maskFeatherRadius: Double
-  var isSecondCropEnabled: Bool
   var secondCropInset: Double
   var globalBrightness: Double
   var globalSaturation: Double
@@ -285,6 +493,10 @@ struct ParametricMacPreviewOutput {
   var sourceExtent: CGRect
   var outputExtent: CGRect
   var treeLines: [ParametricMacTreeLine]
+
+  func treeLine(for featureID: FeatureID) -> ParametricMacTreeLine? {
+    treeLines.first { $0.featureID == featureID }
+  }
 }
 
 /// A single visible row in the interactive feature tree inspector.
@@ -344,6 +556,124 @@ enum ParametricMacTreeKind: String {
     case .effect:
       "slider.horizontal.3"
     }
+  }
+}
+
+/// Top-level editable actions in the macOS parametric demo.
+///
+/// The order of this list is the order used by the generated
+/// `FeatureDocument`, so dragging rows in the editor changes the real
+/// evaluation sequence instead of only rearranging display rows.
+enum ParametricMacEditableFeature: String, CaseIterable, Identifiable {
+
+  case crop1
+  case localAdjustment
+  case globalBrightness
+  case globalSaturation
+  case crop2
+  case globalVignette
+
+  static let defaultOrder: [ParametricMacEditableFeature] = [
+    .crop1,
+    .localAdjustment,
+    .globalBrightness,
+    .globalSaturation,
+    .crop2,
+    .globalVignette,
+  ]
+
+  var id: String {
+    rawValue
+  }
+
+  var featureID: FeatureID {
+    switch self {
+    case .crop1:
+      ParametricMacPreviewFeatureID.crop1
+    case .localAdjustment:
+      ParametricMacPreviewFeatureID.localAdjustment
+    case .globalBrightness:
+      ParametricMacPreviewFeatureID.globalBrightness
+    case .globalSaturation:
+      ParametricMacPreviewFeatureID.globalSaturation
+    case .crop2:
+      ParametricMacPreviewFeatureID.crop2
+    case .globalVignette:
+      ParametricMacPreviewFeatureID.globalVignette
+    }
+  }
+
+  var kind: ParametricMacTreeKind {
+    switch self {
+    case .crop1, .crop2:
+      .domain
+    case .localAdjustment:
+      .local
+    case .globalBrightness, .globalSaturation, .globalVignette:
+      .effect
+    }
+  }
+
+  var title: String {
+    switch self {
+    case .crop1:
+      "Crop 1"
+    case .localAdjustment:
+      "Local Adjustment"
+    case .globalBrightness:
+      "Brightness"
+    case .globalSaturation:
+      "Saturation"
+    case .crop2:
+      "Crop 2"
+    case .globalVignette:
+      "Vignette"
+    }
+  }
+
+  var defaultDetail: String {
+    switch self {
+    case .crop1, .crop2:
+      "current domain crop"
+    case .localAdjustment:
+      "mask + effect branch"
+    case .globalBrightness, .globalSaturation, .globalVignette:
+      "global effect"
+    }
+  }
+}
+
+/// Reorders top-level feature rows during a macOS drag operation.
+struct ParametricMacFeatureDropDelegate: DropDelegate {
+
+  let targetFeature: ParametricMacEditableFeature
+  @Binding var featureOrder: [ParametricMacEditableFeature]
+  @Binding var draggedFeature: ParametricMacEditableFeature?
+
+  func dropEntered(info: DropInfo) {
+    guard let draggedFeature,
+          draggedFeature != targetFeature,
+          let sourceIndex = featureOrder.firstIndex(of: draggedFeature),
+          let targetIndex = featureOrder.firstIndex(of: targetFeature)
+    else {
+      return
+    }
+
+    withAnimation(.snappy) {
+      featureOrder.move(
+        fromOffsets: IndexSet(integer: sourceIndex),
+        toOffset: targetIndex > sourceIndex ? targetIndex + 1 : targetIndex
+      )
+    }
+  }
+
+  func dropUpdated(info: DropInfo) -> DropProposal? {
+    DropProposal(operation: .move)
+  }
+
+  func performDrop(info: DropInfo) -> Bool {
+    draggedFeature = nil
+    return true
   }
 }
 
@@ -410,174 +740,61 @@ struct ParametricMacPreviewRenderer {
     ]
     var currentSize = Self.sourceSize
 
-    if settings.isFirstCropEnabled {
-      let featureID = ParametricMacPreviewFeatureID.crop1
-      let isEnabled = settings.isFeatureEnabled(featureID)
-      let cropRect = insetRect(size: currentSize, inset: settings.firstCropInset)
-      features.append(
-        .domain(
-          try FeatureNode(
-            BrightroomFeatureDefinitions.Crop.self,
-            id: featureID,
-            isEnabled: isEnabled,
-            payload: .init(cropRect: cropRect)
-          )
-        )
-      )
-      if isEnabled {
-        currentSize = cropRect.size
-      }
-      treeLines.append(
-        .init(
-          id: featureID.rawValue,
-          level: 1,
-          kind: .domain,
+    for editableFeature in settings.featureOrder {
+      switch editableFeature {
+      case .crop1:
+        let output = try makeCropFeature(
+          featureID: ParametricMacPreviewFeatureID.crop1,
           title: "Crop 1",
-          detail: "inset \(Int(settings.firstCropInset)) -> \(sizeDescription(cropRect.size))",
-          featureID: featureID
+          inset: settings.firstCropInset,
+          currentSize: currentSize,
+          settings: settings
         )
-      )
-    }
+        features.append(.domain(output.feature))
+        treeLines.append(output.treeLine)
+        if output.feature.isEnabled {
+          currentSize = output.outputSize
+        }
 
-    if settings.isLocalAdjustmentEnabled {
-      let localAdjustmentID = ParametricMacPreviewFeatureID.localAdjustment
-      let brushID = ParametricMacPreviewFeatureID.brushMask
-      let featherID = ParametricMacPreviewFeatureID.featherMask
-      let exposureID = ParametricMacPreviewFeatureID.localExposure
-      let blurID = ParametricMacPreviewFeatureID.localBlur
-      let brush = try makeBrushMask(
-        size: currentSize,
-        settings: settings,
-        id: brushID,
-        isEnabled: settings.isFeatureEnabled(brushID)
-      )
-      let featheredMask = try FeatureNode(
-        BrightroomFeatureDefinitions.FeatherMask.self,
-        id: featherID,
-        isEnabled: settings.isFeatureEnabled(featherID),
-        payload: .init(input: brush, radius: settings.maskFeatherRadius)
-      )
-      var effects: [FeatureNode] = [
-        try FeatureNode(
-          BrightroomFeatureDefinitions.Exposure.self,
-          id: exposureID,
-          isEnabled: settings.isFeatureEnabled(exposureID),
-          payload: .init(value: settings.localExposure)
-        ),
-      ]
-      if settings.localBlurRadius > 0.1 {
-        effects.append(
-          try FeatureNode(
-            BrightroomFeatureDefinitions.GaussianBlur.self,
-            id: blurID,
-            isEnabled: settings.isFeatureEnabled(blurID),
-            payload: .init(radius: .absolute(settings.localBlurRadius))
-          )
+      case .localAdjustment:
+        let output = try makeLocalAdjustment(
+          currentSize: currentSize,
+          settings: settings
         )
-      }
+        if let feature = output.feature {
+          features.append(.localAdjustment(feature))
+        }
+        treeLines.append(contentsOf: output.treeLines)
 
-      if effects.contains(where: \.isEnabled) {
-        features.append(
-          .localAdjustment(
-            FeatureLocalAdjustment(
-              id: localAdjustmentID,
-              isEnabled: settings.isFeatureEnabled(localAdjustmentID),
-              mask: featheredMask,
-              effectPipeline: FeatureEffectPipeline(effects: effects)
-            )
-          )
-        )
-      }
-      treeLines.append(
-        .init(
-          id: localAdjustmentID.rawValue,
-          level: 1,
-          kind: .local,
-          title: "Local Adjustment",
-          detail: "alpha blend branch",
-          featureID: localAdjustmentID
-        )
-      )
-      treeLines.append(
-        .init(
-          id: brushID.rawValue,
-          level: 2,
-          kind: .mask,
-          title: "Brush Mask",
-          detail: "diameter \(Int(settings.brushDiameter))",
-          featureID: brushID
-        )
-      )
-      treeLines.append(
-        .init(
-          id: featherID.rawValue,
-          level: 2,
-          kind: .mask,
-          title: "Feather Mask",
-          detail: "radius \(Int(settings.maskFeatherRadius))",
-          featureID: featherID
-        )
-      )
-      treeLines.append(
-        .init(
-          id: exposureID.rawValue,
-          level: 2,
-          kind: .effect,
-          title: "Exposure",
-          detail: settings.localExposure.formatted(.number.precision(.fractionLength(2))),
-          featureID: exposureID
-        )
-      )
-      if settings.localBlurRadius > 0.1 {
-        treeLines.append(
-          .init(
-            id: blurID.rawValue,
-            level: 2,
-            kind: .effect,
-            title: "Blur",
-            detail: "\(Int(settings.localBlurRadius)) px",
-            featureID: blurID
-          )
-        )
-      }
-    }
+      case .globalBrightness:
+        let output = try makeBrightnessEffect(settings: settings)
+        features.append(.effect(output.feature))
+        treeLines.append(output.treeLine)
 
-    let preCropEffects = try makeGlobalColorEffects(settings: settings)
-    features.append(contentsOf: preCropEffects.features.map(FeatureTreeNode.effect))
-    treeLines.append(contentsOf: preCropEffects.treeLines)
+      case .globalSaturation:
+        let output = try makeSaturationEffect(settings: settings)
+        features.append(.effect(output.feature))
+        treeLines.append(output.treeLine)
 
-    if settings.isSecondCropEnabled {
-      let featureID = ParametricMacPreviewFeatureID.crop2
-      let isEnabled = settings.isFeatureEnabled(featureID)
-      let cropRect = insetRect(size: currentSize, inset: settings.secondCropInset)
-      features.append(
-        .domain(
-          try FeatureNode(
-            BrightroomFeatureDefinitions.Crop.self,
-            id: featureID,
-            isEnabled: isEnabled,
-            payload: .init(cropRect: cropRect)
-          )
-        )
-      )
-      if isEnabled {
-        currentSize = cropRect.size
-      }
-      treeLines.append(
-        .init(
-          id: featureID.rawValue,
-          level: 1,
-          kind: .domain,
+      case .crop2:
+        let output = try makeCropFeature(
+          featureID: ParametricMacPreviewFeatureID.crop2,
           title: "Crop 2",
-          detail: "inset \(Int(settings.secondCropInset)) -> \(sizeDescription(cropRect.size))",
-          featureID: featureID
+          inset: settings.secondCropInset,
+          currentSize: currentSize,
+          settings: settings
         )
-      )
-    }
+        features.append(.domain(output.feature))
+        treeLines.append(output.treeLine)
+        if output.feature.isEnabled {
+          currentSize = output.outputSize
+        }
 
-    if let vignette = try makeVignetteEffect(settings: settings) {
-      features.append(.effect(vignette.feature))
-      treeLines.append(vignette.treeLine)
+      case .globalVignette:
+        let output = try makeVignetteEffect(settings: settings)
+        features.append(.effect(output.feature))
+        treeLines.append(output.treeLine)
+      }
     }
 
     return (
@@ -586,65 +803,175 @@ struct ParametricMacPreviewRenderer {
     )
   }
 
-  private func makeGlobalColorEffects(
+  private func makeCropFeature(
+    featureID: FeatureID,
+    title: String,
+    inset: Double,
+    currentSize: CGSize,
     settings: ParametricMacPreviewSettings
-  ) throws -> (features: [FeatureNode], treeLines: [ParametricMacTreeLine]) {
-    var features: [FeatureNode] = []
-    var treeLines: [ParametricMacTreeLine] = []
+  ) throws -> (feature: FeatureNode, outputSize: CGSize, treeLine: ParametricMacTreeLine) {
+    let cropRect = insetRect(size: currentSize, inset: inset)
+    return (
+      try FeatureNode(
+        BrightroomFeatureDefinitions.Crop.self,
+        id: featureID,
+        isEnabled: settings.isFeatureEnabled(featureID),
+        payload: .init(cropRect: cropRect)
+      ),
+      cropRect.size,
+      .init(
+        id: featureID.rawValue,
+        level: 1,
+        kind: .domain,
+        title: title,
+        detail: "inset \(Int(inset)) -> \(sizeDescription(cropRect.size))",
+        featureID: featureID
+      )
+    )
+  }
 
-    if abs(settings.globalBrightness) > 0.001 {
-      let featureID = ParametricMacPreviewFeatureID.globalBrightness
-      features.append(
-        try FeatureNode(
-          BrightroomFeatureDefinitions.Brightness.self,
-          id: featureID,
-          isEnabled: settings.isFeatureEnabled(featureID),
-          payload: .init(value: settings.globalBrightness)
-        )
+  private func makeLocalAdjustment(
+    currentSize: CGSize,
+    settings: ParametricMacPreviewSettings
+  ) throws -> (feature: FeatureLocalAdjustment?, treeLines: [ParametricMacTreeLine]) {
+    let localAdjustmentID = ParametricMacPreviewFeatureID.localAdjustment
+    let brushID = ParametricMacPreviewFeatureID.brushMask
+    let featherID = ParametricMacPreviewFeatureID.featherMask
+    let exposureID = ParametricMacPreviewFeatureID.localExposure
+    let blurID = ParametricMacPreviewFeatureID.localBlur
+    let brush = try makeBrushMask(
+      size: currentSize,
+      settings: settings,
+      id: brushID,
+      isEnabled: settings.isFeatureEnabled(brushID)
+    )
+    let featheredMask = try FeatureNode(
+      BrightroomFeatureDefinitions.FeatherMask.self,
+      id: featherID,
+      isEnabled: settings.isFeatureEnabled(featherID),
+      payload: .init(input: brush, radius: settings.maskFeatherRadius)
+    )
+    let effects: [FeatureNode] = [
+      try FeatureNode(
+        BrightroomFeatureDefinitions.Exposure.self,
+        id: exposureID,
+        isEnabled: settings.isFeatureEnabled(exposureID),
+        payload: .init(value: settings.localExposure)
+      ),
+      try FeatureNode(
+        BrightroomFeatureDefinitions.GaussianBlur.self,
+        id: blurID,
+        isEnabled: settings.isFeatureEnabled(blurID),
+        payload: .init(radius: .absolute(settings.localBlurRadius))
+      ),
+    ]
+
+    let localAdjustment: FeatureLocalAdjustment?
+    if effects.contains(where: \.isEnabled) {
+      localAdjustment = FeatureLocalAdjustment(
+        id: localAdjustmentID,
+        isEnabled: settings.isFeatureEnabled(localAdjustmentID),
+        mask: featheredMask,
+        effectPipeline: FeatureEffectPipeline(effects: effects)
       )
-      treeLines.append(
-        .init(
-          id: featureID.rawValue,
-          level: 1,
-          kind: .effect,
-          title: "Brightness",
-          detail: settings.globalBrightness.formatted(.number.precision(.fractionLength(2))),
-          featureID: featureID
-        )
-      )
+    } else {
+      localAdjustment = nil
     }
 
-    if abs(settings.globalSaturation) > 0.001 {
-      let featureID = ParametricMacPreviewFeatureID.globalSaturation
-      features.append(
-        try FeatureNode(
-          BrightroomFeatureDefinitions.Saturation.self,
-          id: featureID,
-          isEnabled: settings.isFeatureEnabled(featureID),
-          payload: .init(value: settings.globalSaturation)
-        )
-      )
-      treeLines.append(
+    return (
+      localAdjustment,
+      [
         .init(
-          id: featureID.rawValue,
+          id: localAdjustmentID.rawValue,
           level: 1,
+          kind: .local,
+          title: "Local Adjustment",
+          detail: "alpha blend branch",
+          featureID: localAdjustmentID
+        ),
+        .init(
+          id: brushID.rawValue,
+          level: 2,
+          kind: .mask,
+          title: "Brush Mask",
+          detail: "diameter \(Int(settings.brushDiameter))",
+          featureID: brushID
+        ),
+        .init(
+          id: featherID.rawValue,
+          level: 2,
+          kind: .mask,
+          title: "Feather Mask",
+          detail: "radius \(Int(settings.maskFeatherRadius))",
+          featureID: featherID
+        ),
+        .init(
+          id: exposureID.rawValue,
+          level: 2,
           kind: .effect,
-          title: "Saturation",
-          detail: settings.globalSaturation.formatted(.number.precision(.fractionLength(2))),
-          featureID: featureID
-        )
-      )
-    }
+          title: "Exposure",
+          detail: settings.localExposure.formatted(.number.precision(.fractionLength(2))),
+          featureID: exposureID
+        ),
+        .init(
+          id: blurID.rawValue,
+          level: 2,
+          kind: .effect,
+          title: "Blur",
+          detail: "\(Int(settings.localBlurRadius)) px",
+          featureID: blurID
+        ),
+      ]
+    )
+  }
 
-    return (features, treeLines)
+  private func makeBrightnessEffect(
+    settings: ParametricMacPreviewSettings
+  ) throws -> (feature: FeatureNode, treeLine: ParametricMacTreeLine) {
+    let featureID = ParametricMacPreviewFeatureID.globalBrightness
+    return (
+      try FeatureNode(
+        BrightroomFeatureDefinitions.Brightness.self,
+        id: featureID,
+        isEnabled: settings.isFeatureEnabled(featureID),
+        payload: .init(value: settings.globalBrightness)
+      ),
+      .init(
+        id: featureID.rawValue,
+        level: 1,
+        kind: .effect,
+        title: "Brightness",
+        detail: settings.globalBrightness.formatted(.number.precision(.fractionLength(2))),
+        featureID: featureID
+      )
+    )
+  }
+
+  private func makeSaturationEffect(
+    settings: ParametricMacPreviewSettings
+  ) throws -> (feature: FeatureNode, treeLine: ParametricMacTreeLine) {
+    let featureID = ParametricMacPreviewFeatureID.globalSaturation
+    return (
+      try FeatureNode(
+        BrightroomFeatureDefinitions.Saturation.self,
+        id: featureID,
+        isEnabled: settings.isFeatureEnabled(featureID),
+        payload: .init(value: settings.globalSaturation)
+      ),
+      .init(
+        id: featureID.rawValue,
+        level: 1,
+        kind: .effect,
+        title: "Saturation",
+        detail: settings.globalSaturation.formatted(.number.precision(.fractionLength(2))),
+        featureID: featureID
+      )
+    )
   }
 
   private func makeVignetteEffect(
     settings: ParametricMacPreviewSettings
-  ) throws -> (feature: FeatureNode, treeLine: ParametricMacTreeLine)? {
-    guard settings.globalVignette > 0.001 else {
-      return nil
-    }
+  ) throws -> (feature: FeatureNode, treeLine: ParametricMacTreeLine) {
     let featureID = ParametricMacPreviewFeatureID.globalVignette
 
     return (

--- a/Dev/ParametricMacDemo/ParametricMacDemoView.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoView.swift
@@ -1,0 +1,501 @@
+import AppKit
+import BrightroomParametric
+import CoreImage
+import SwiftUI
+
+struct ParametricMacDemoView: View {
+
+  @State private var isFirstCropEnabled = true
+  @State private var firstCropInset = 48.0
+  @State private var isLocalAdjustmentEnabled = true
+  @State private var localExposure = 0.55
+  @State private var localBlurRadius = 4.0
+  @State private var brushDiameter = 220.0
+  @State private var maskFeatherRadius = 18.0
+  @State private var isSecondCropEnabled = true
+  @State private var secondCropInset = 34.0
+  @State private var globalBrightness = 0.03
+  @State private var globalSaturation = 0.22
+  @State private var globalVignette = 0.45
+
+  private let renderer = ParametricMacPreviewRenderer()
+
+  var body: some View {
+    HStack(spacing: 0) {
+      controlPanel
+        .frame(width: 320)
+        .background(.regularMaterial)
+
+      Divider()
+
+      previewPanel
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+  }
+
+  private var controlPanel: some View {
+    Form {
+      Section("Domain") {
+        Toggle("Crop 1", isOn: $isFirstCropEnabled)
+        Slider(value: $firstCropInset, in: 0...140, step: 1) {
+          Text("Inset")
+        }
+
+        Toggle("Crop 2", isOn: $isSecondCropEnabled)
+        Slider(value: $secondCropInset, in: 0...96, step: 1) {
+          Text("Inset")
+        }
+      }
+
+      Section("Local") {
+        Toggle("Local Adjustment", isOn: $isLocalAdjustmentEnabled)
+        Slider(value: $localExposure, in: -1...1, step: 0.01) {
+          Text("Exposure")
+        }
+        Slider(value: $localBlurRadius, in: 0...24, step: 1) {
+          Text("Blur")
+        }
+        Slider(value: $brushDiameter, in: 40...360, step: 1) {
+          Text("Brush")
+        }
+        Slider(value: $maskFeatherRadius, in: 0...48, step: 1) {
+          Text("Feather")
+        }
+      }
+
+      Section("Global") {
+        Slider(value: $globalBrightness, in: -0.25...0.25, step: 0.01) {
+          Text("Brightness")
+        }
+        Slider(value: $globalSaturation, in: -0.75...0.75, step: 0.01) {
+          Text("Saturation")
+        }
+        Slider(value: $globalVignette, in: 0...1.2, step: 0.01) {
+          Text("Vignette")
+        }
+      }
+    }
+    .formStyle(.grouped)
+  }
+
+  private var previewPanel: some View {
+    let settings = makeSettings()
+    let rendered = Result {
+      try renderer.render(settings: settings)
+    }
+
+    return VStack(alignment: .leading, spacing: 18) {
+      Text("Parametric Mac Demo")
+        .font(.title.bold())
+
+      switch rendered {
+      case let .success(output):
+        HStack(alignment: .top, spacing: 18) {
+          imagePreview(title: "Source", image: output.sourceImage, extent: output.sourceExtent)
+          imagePreview(title: "Output", image: output.outputImage, extent: output.outputExtent)
+        }
+        .frame(maxHeight: .infinity)
+
+        treeView(lines: output.treeLines)
+
+      case let .failure(error):
+        ContentUnavailableView(
+          "Render failed",
+          systemImage: "exclamationmark.triangle",
+          description: Text(String(describing: error))
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+    }
+    .padding(24)
+  }
+
+  private func imagePreview(
+    title: String,
+    image: NSImage,
+    extent: CGRect
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text(title)
+          .font(.headline)
+        Spacer()
+        Text("\(Int(extent.width)) x \(Int(extent.height))")
+          .font(.caption.monospacedDigit())
+          .foregroundStyle(.secondary)
+      }
+
+      Image(nsImage: image)
+        .resizable()
+        .interpolation(.medium)
+        .aspectRatio(contentMode: .fit)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+  }
+
+  private func treeView(lines: [ParametricMacTreeLine]) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Feature Tree")
+        .font(.headline)
+
+      Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 4) {
+        ForEach(lines) { line in
+          GridRow {
+            Text(String(repeating: "  ", count: line.level) + line.kind)
+              .font(.caption.monospaced())
+              .foregroundStyle(line.color)
+            Text(line.value)
+              .font(.caption.monospaced())
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    }
+    .padding(14)
+    .background(.thinMaterial)
+    .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
+
+  private func makeSettings() -> ParametricMacPreviewSettings {
+    ParametricMacPreviewSettings(
+      isFirstCropEnabled: isFirstCropEnabled,
+      firstCropInset: firstCropInset,
+      isLocalAdjustmentEnabled: isLocalAdjustmentEnabled,
+      localExposure: localExposure,
+      localBlurRadius: localBlurRadius,
+      brushDiameter: brushDiameter,
+      maskFeatherRadius: maskFeatherRadius,
+      isSecondCropEnabled: isSecondCropEnabled,
+      secondCropInset: secondCropInset,
+      globalBrightness: globalBrightness,
+      globalSaturation: globalSaturation,
+      globalVignette: globalVignette
+    )
+  }
+}
+
+/// User-editable values that define the macOS parametric preview document.
+struct ParametricMacPreviewSettings {
+
+  var isFirstCropEnabled: Bool
+  var firstCropInset: Double
+  var isLocalAdjustmentEnabled: Bool
+  var localExposure: Double
+  var localBlurRadius: Double
+  var brushDiameter: Double
+  var maskFeatherRadius: Double
+  var isSecondCropEnabled: Bool
+  var secondCropInset: Double
+  var globalBrightness: Double
+  var globalSaturation: Double
+  var globalVignette: Double
+}
+
+/// A rendered source/output pair plus textual tree rows for inspection.
+struct ParametricMacPreviewOutput {
+
+  var sourceImage: NSImage
+  var outputImage: NSImage
+  var sourceExtent: CGRect
+  var outputExtent: CGRect
+  var treeLines: [ParametricMacTreeLine]
+}
+
+/// A single visible row in the feature tree inspector.
+struct ParametricMacTreeLine: Identifiable {
+
+  var id = UUID()
+  var level: Int
+  var kind: String
+  var value: String
+
+  var color: Color {
+    switch kind {
+    case "domain":
+      .cyan
+    case "local":
+      .orange
+    case "mask":
+      .pink
+    case "effect":
+      .green
+    default:
+      .primary
+    }
+  }
+}
+
+/// Builds and renders a registry-backed parametric document for the macOS demo.
+struct ParametricMacPreviewRenderer {
+
+  private static let sourceSize = CGSize(width: 960, height: 640)
+  private static let context = CIContext()
+
+  /// Renders the current settings into AppKit images for display.
+  func render(settings: ParametricMacPreviewSettings) throws -> ParametricMacPreviewOutput {
+    let sourceImage = makeSourceImage()
+    let document = try makeDocument(settings: settings)
+    let outputImage = try ParametricImageRenderer().makeImage(
+      from: sourceImage,
+      document: document.document
+    )
+
+    return ParametricMacPreviewOutput(
+      sourceImage: try makeNSImage(from: sourceImage),
+      outputImage: try makeNSImage(from: outputImage),
+      sourceExtent: sourceImage.extent,
+      outputExtent: outputImage.extent,
+      treeLines: document.treeLines
+    )
+  }
+
+  private func makeDocument(
+    settings: ParametricMacPreviewSettings
+  ) throws -> (document: FeatureDocument, treeLines: [ParametricMacTreeLine]) {
+    var features: [FeatureTreeNode] = []
+    var treeLines: [ParametricMacTreeLine] = [
+      .init(level: 0, kind: "source", value: sizeDescription(Self.sourceSize)),
+      .init(level: 0, kind: "main", value: "source -> output"),
+    ]
+    var currentSize = Self.sourceSize
+
+    if settings.isFirstCropEnabled {
+      let cropRect = insetRect(size: currentSize, inset: settings.firstCropInset)
+      features.append(
+        .domain(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.Crop.self,
+            id: FeatureID(rawValue: "mac-demo-crop-1"),
+            payload: .init(cropRect: cropRect)
+          )
+        )
+      )
+      currentSize = cropRect.size
+      treeLines.append(.init(level: 1, kind: "domain", value: "Crop 1 -> \(sizeDescription(currentSize))"))
+    }
+
+    if settings.isLocalAdjustmentEnabled {
+      let brush = try makeBrushMask(size: currentSize, settings: settings)
+      let featheredMask = try FeatureNode(
+        BrightroomFeatureDefinitions.FeatherMask.self,
+        id: FeatureID(rawValue: "mac-demo-feather-mask"),
+        payload: .init(input: brush, radius: settings.maskFeatherRadius)
+      )
+      var effects: [FeatureNode] = [
+        try FeatureNode(
+          BrightroomFeatureDefinitions.Exposure.self,
+          id: FeatureID(rawValue: "mac-demo-local-exposure"),
+          payload: .init(value: settings.localExposure)
+        ),
+      ]
+      if settings.localBlurRadius > 0.1 {
+        effects.append(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.GaussianBlur.self,
+            id: FeatureID(rawValue: "mac-demo-local-blur"),
+            payload: .init(radius: .absolute(settings.localBlurRadius))
+          )
+        )
+      }
+
+      features.append(
+        .localAdjustment(
+          FeatureLocalAdjustment(
+            id: FeatureID(rawValue: "mac-demo-local-adjustment"),
+            mask: featheredMask,
+            effectPipeline: FeatureEffectPipeline(effects: effects)
+          )
+        )
+      )
+      treeLines.append(.init(level: 1, kind: "local", value: "Local Adjustment"))
+      treeLines.append(.init(level: 2, kind: "mask", value: "Brush -> Feather \(Int(settings.maskFeatherRadius))"))
+      treeLines.append(.init(level: 2, kind: "effect", value: "Exposure \(settings.localExposure.formatted(.number.precision(.fractionLength(2))))"))
+      if settings.localBlurRadius > 0.1 {
+        treeLines.append(.init(level: 2, kind: "effect", value: "Blur \(Int(settings.localBlurRadius))"))
+      }
+    }
+
+    if settings.isSecondCropEnabled {
+      let cropRect = insetRect(size: currentSize, inset: settings.secondCropInset)
+      features.append(
+        .domain(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.Crop.self,
+            id: FeatureID(rawValue: "mac-demo-crop-2"),
+            payload: .init(cropRect: cropRect)
+          )
+        )
+      )
+      currentSize = cropRect.size
+      treeLines.append(.init(level: 1, kind: "domain", value: "Crop 2 -> \(sizeDescription(currentSize))"))
+    }
+
+    let globalEffects = try makeGlobalEffects(settings: settings)
+    features.append(contentsOf: globalEffects.features.map(FeatureTreeNode.effect))
+    treeLines.append(contentsOf: globalEffects.treeLines)
+
+    return (
+      FeatureDocument(mainTree: FeatureMainTree(features: features)),
+      treeLines
+    )
+  }
+
+  private func makeGlobalEffects(
+    settings: ParametricMacPreviewSettings
+  ) throws -> (features: [FeatureNode], treeLines: [ParametricMacTreeLine]) {
+    var features: [FeatureNode] = []
+    var treeLines: [ParametricMacTreeLine] = []
+
+    if abs(settings.globalBrightness) > 0.001 {
+      features.append(
+        try FeatureNode(
+          BrightroomFeatureDefinitions.Brightness.self,
+          id: FeatureID(rawValue: "mac-demo-global-brightness"),
+          payload: .init(value: settings.globalBrightness)
+        )
+      )
+      treeLines.append(.init(level: 1, kind: "effect", value: "Brightness \(settings.globalBrightness.formatted(.number.precision(.fractionLength(2))))"))
+    }
+
+    if abs(settings.globalSaturation) > 0.001 {
+      features.append(
+        try FeatureNode(
+          BrightroomFeatureDefinitions.Saturation.self,
+          id: FeatureID(rawValue: "mac-demo-global-saturation"),
+          payload: .init(value: settings.globalSaturation)
+        )
+      )
+      treeLines.append(.init(level: 1, kind: "effect", value: "Saturation \(settings.globalSaturation.formatted(.number.precision(.fractionLength(2))))"))
+    }
+
+    if settings.globalVignette > 0.001 {
+      features.append(
+        try FeatureNode(
+          BrightroomFeatureDefinitions.Vignette.self,
+          id: FeatureID(rawValue: "mac-demo-global-vignette"),
+          payload: .init(value: settings.globalVignette)
+        )
+      )
+      treeLines.append(.init(level: 1, kind: "effect", value: "Vignette \(settings.globalVignette.formatted(.number.precision(.fractionLength(2))))"))
+    }
+
+    return (features, treeLines)
+  }
+
+  private func makeBrushMask(
+    size: CGSize,
+    settings: ParametricMacPreviewSettings
+  ) throws -> FeatureNode {
+    let centerY = size.height * 0.56
+    let stamps = stride(from: 0.18, through: 0.82, by: 0.08).map { progress in
+      CGPoint(
+        x: size.width * progress,
+        y: centerY + sin(progress * .pi * 3) * size.height * 0.08
+      )
+    }
+    let stroke = BrushMaskStroke(
+      stamps: stamps,
+      brush: BrushMaskBrush(
+        diameter: settings.brushDiameter,
+        hardness: 0.35,
+        opacity: 1
+      )
+    )
+    return try FeatureNode(
+      BrightroomFeatureDefinitions.BrushMask.self,
+      id: FeatureID(rawValue: "mac-demo-brush-mask"),
+      payload: .init(strokes: [stroke])
+    )
+  }
+
+  private func insetRect(size: CGSize, inset: Double) -> CGRect {
+    let boundedInset = min(
+      max(inset, 0),
+      max(min(size.width, size.height) / 2 - 1, 0)
+    )
+    return CGRect(
+      x: boundedInset,
+      y: boundedInset,
+      width: max(size.width - boundedInset * 2, 1),
+      height: max(size.height - boundedInset * 2, 1)
+    )
+  }
+
+  private func makeSourceImage() -> CIImage {
+    let extent = CGRect(origin: .zero, size: Self.sourceSize)
+    let background = CIFilter(
+      name: "CILinearGradient",
+      parameters: [
+        "inputPoint0": CIVector(x: 0, y: 0),
+        "inputPoint1": CIVector(x: Self.sourceSize.width, y: Self.sourceSize.height),
+        "inputColor0": CIColor(red: 0.06, green: 0.09, blue: 0.13, alpha: 1),
+        "inputColor1": CIColor(red: 0.82, green: 0.54, blue: 0.28, alpha: 1),
+      ]
+    )!
+    .outputImage!
+    .cropped(to: extent)
+    let grid = CIFilter(
+      name: "CICheckerboardGenerator",
+      parameters: [
+        "inputCenter": CIVector(x: 0, y: 0),
+        "inputColor0": CIColor(red: 0.08, green: 0.14, blue: 0.2, alpha: 0.38),
+        "inputColor1": CIColor(red: 0.94, green: 0.88, blue: 0.72, alpha: 0.18),
+        "inputWidth": 52,
+        "inputSharpness": 0.82,
+      ]
+    )!
+    .outputImage!
+    .cropped(to: extent)
+    .composited(over: background)
+    let warmBand = CIImage(color: CIColor(red: 0.96, green: 0.24, blue: 0.18, alpha: 0.68))
+      .cropped(to: CGRect(x: 130, y: 0, width: 120, height: Self.sourceSize.height))
+      .composited(over: grid)
+    let coolBand = CIImage(color: CIColor(red: 0.02, green: 0.46, blue: 0.95, alpha: 0.7))
+      .cropped(to: CGRect(x: 600, y: 0, width: 150, height: Self.sourceSize.height))
+      .composited(over: warmBand)
+    let glow = CIFilter(
+      name: "CIRadialGradient",
+      parameters: [
+        "inputCenter": CIVector(x: 470, y: 340),
+        "inputRadius0": 16,
+        "inputRadius1": 260,
+        "inputColor0": CIColor(red: 1, green: 0.96, blue: 0.7, alpha: 0.92),
+        "inputColor1": CIColor(red: 1, green: 0.96, blue: 0.7, alpha: 0),
+      ]
+    )!
+    .outputImage!
+    .cropped(to: extent)
+
+    return glow
+      .composited(over: coolBand)
+      .cropped(to: extent)
+  }
+
+  private func makeNSImage(from image: CIImage) throws -> NSImage {
+    let outputExtent = image.extent.integral
+    let normalizedImage = image.transformed(
+      by: CGAffineTransform(
+        translationX: -outputExtent.minX,
+        y: -outputExtent.minY
+      )
+    )
+    let normalizedExtent = CGRect(origin: .zero, size: outputExtent.size)
+    guard let cgImage = Self.context.createCGImage(normalizedImage, from: normalizedExtent) else {
+      throw ParametricMacPreviewError.failedToCreateCGImage(outputExtent)
+    }
+    return NSImage(cgImage: cgImage, size: normalizedExtent.size)
+  }
+
+  private func sizeDescription(_ size: CGSize) -> String {
+    "\(Int(size.width)) x \(Int(size.height))"
+  }
+}
+
+/// Errors raised while materializing the macOS preview surface.
+enum ParametricMacPreviewError: Error {
+
+  /// Core Image could not create a displayable image for the requested extent.
+  case failedToCreateCGImage(CGRect)
+}

--- a/Dev/ParametricMacDemo/ParametricMacDemoView.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoView.swift
@@ -17,6 +17,7 @@ struct ParametricMacDemoView: View {
   @State private var globalBrightness = 0.03
   @State private var globalSaturation = 0.22
   @State private var globalVignette = 0.45
+  @State private var suppressedFeatureIDs: Set<FeatureID> = []
 
   private let renderer = ParametricMacPreviewRenderer()
 
@@ -94,6 +95,7 @@ struct ParametricMacDemoView: View {
           imagePreview(title: "Source", image: output.sourceImage, extent: output.sourceExtent)
           imagePreview(title: "Output", image: output.outputImage, extent: output.outputExtent)
         }
+        .frame(minHeight: 300)
         .frame(maxHeight: .infinity)
 
         treeView(lines: output.treeLines)
@@ -136,26 +138,102 @@ struct ParametricMacDemoView: View {
   }
 
   private func treeView(lines: [ParametricMacTreeLine]) -> some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text("Feature Tree")
-        .font(.headline)
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        Text("Feature Tree")
+          .font(.headline)
 
-      Grid(alignment: .leadingFirstTextBaseline, horizontalSpacing: 10, verticalSpacing: 4) {
-        ForEach(lines) { line in
-          GridRow {
-            Text(String(repeating: "  ", count: line.level) + line.kind)
-              .font(.caption.monospaced())
-              .foregroundStyle(line.color)
-            Text(line.value)
-              .font(.caption.monospaced())
-              .foregroundStyle(.secondary)
+        Spacer()
+
+        Button {
+          suppressedFeatureIDs.removeAll()
+        } label: {
+          Label("Enable All", systemImage: "checkmark.circle")
+        }
+        .buttonStyle(.borderless)
+        .disabled(suppressedFeatureIDs.isEmpty)
+      }
+
+      ScrollView {
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(lines) { line in
+            treeLineView(line)
           }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
+      .frame(maxHeight: 280)
     }
-    .padding(14)
-    .background(.thinMaterial)
+    .frame(maxWidth: 520, alignment: .leading)
+  }
+
+  private func treeLineView(_ line: ParametricMacTreeLine) -> some View {
+    let isSuppressed = line.featureID.map { suppressedFeatureIDs.contains($0) } ?? false
+
+    return HStack(spacing: 10) {
+      if let featureID = line.featureID {
+        Toggle("", isOn: featureEnabledBinding(for: featureID))
+          .labelsHidden()
+          .toggleStyle(.switch)
+          .controlSize(.small)
+          .help(isSuppressed ? "Restore this feature" : "Suppress this feature")
+      } else {
+        Image(systemName: line.kind.systemImage)
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(line.kind.color)
+          .frame(width: 28)
+      }
+
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 6) {
+          Text(line.kind.title)
+            .font(.caption2.monospaced().weight(.semibold))
+            .foregroundStyle(line.kind.color)
+
+          if isSuppressed {
+            Text("Suppressed")
+              .font(.caption2.weight(.semibold))
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .foregroundStyle(.secondary)
+              .background(.quaternary, in: Capsule())
+          }
+        }
+
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+          Text(line.title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(isSuppressed ? .secondary : .primary)
+
+          Text(line.detail)
+            .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(.leading, CGFloat(line.level) * 18)
+    .padding(.vertical, 8)
+    .padding(.horizontal, 10)
+    .background(isSuppressed ? Color.secondary.opacity(0.08) : Color(nsColor: .controlBackgroundColor).opacity(0.78))
     .clipShape(RoundedRectangle(cornerRadius: 8))
+    .opacity(isSuppressed ? 0.58 : 1)
+  }
+
+  private func featureEnabledBinding(for featureID: FeatureID) -> Binding<Bool> {
+    Binding(
+      get: {
+        suppressedFeatureIDs.contains(featureID) == false
+      },
+      set: { isEnabled in
+        if isEnabled {
+          suppressedFeatureIDs.remove(featureID)
+        } else {
+          suppressedFeatureIDs.insert(featureID)
+        }
+      }
+    )
   }
 
   private func makeSettings() -> ParametricMacPreviewSettings {
@@ -171,7 +249,8 @@ struct ParametricMacDemoView: View {
       secondCropInset: secondCropInset,
       globalBrightness: globalBrightness,
       globalSaturation: globalSaturation,
-      globalVignette: globalVignette
+      globalVignette: globalVignette,
+      suppressedFeatureIDs: suppressedFeatureIDs
     )
   }
 }
@@ -191,6 +270,11 @@ struct ParametricMacPreviewSettings {
   var globalBrightness: Double
   var globalSaturation: Double
   var globalVignette: Double
+  var suppressedFeatureIDs: Set<FeatureID>
+
+  func isFeatureEnabled(_ featureID: FeatureID) -> Bool {
+    suppressedFeatureIDs.contains(featureID) == false
+  }
 }
 
 /// A rendered source/output pair plus textual tree rows for inspection.
@@ -203,28 +287,79 @@ struct ParametricMacPreviewOutput {
   var treeLines: [ParametricMacTreeLine]
 }
 
-/// A single visible row in the feature tree inspector.
+/// A single visible row in the interactive feature tree inspector.
 struct ParametricMacTreeLine: Identifiable {
 
-  var id = UUID()
+  var id: String
   var level: Int
-  var kind: String
-  var value: String
+  var kind: ParametricMacTreeKind
+  var title: String
+  var detail: String
+  var featureID: FeatureID?
+}
+
+/// Display categories used by the macOS feature tree editor.
+enum ParametricMacTreeKind: String {
+
+  case source
+  case main
+  case domain
+  case local
+  case mask
+  case effect
+
+  var title: String {
+    rawValue.uppercased()
+  }
 
   var color: Color {
-    switch kind {
-    case "domain":
-      .cyan
-    case "local":
-      .orange
-    case "mask":
-      .pink
-    case "effect":
-      .green
-    default:
+    switch self {
+    case .source:
+      .secondary
+    case .main:
       .primary
+    case .domain:
+      .cyan
+    case .local:
+      .orange
+    case .mask:
+      .pink
+    case .effect:
+      .green
     }
   }
+
+  var systemImage: String {
+    switch self {
+    case .source:
+      "photo"
+    case .main:
+      "arrow.right"
+    case .domain:
+      "crop"
+    case .local:
+      "scope"
+    case .mask:
+      "paintbrush"
+    case .effect:
+      "slider.horizontal.3"
+    }
+  }
+}
+
+/// Stable feature IDs used by the macOS demo document and tree editor.
+enum ParametricMacPreviewFeatureID {
+
+  static let crop1 = FeatureID(rawValue: "mac-demo-crop-1")
+  static let localAdjustment = FeatureID(rawValue: "mac-demo-local-adjustment")
+  static let brushMask = FeatureID(rawValue: "mac-demo-brush-mask")
+  static let featherMask = FeatureID(rawValue: "mac-demo-feather-mask")
+  static let localExposure = FeatureID(rawValue: "mac-demo-local-exposure")
+  static let localBlur = FeatureID(rawValue: "mac-demo-local-blur")
+  static let globalBrightness = FeatureID(rawValue: "mac-demo-global-brightness")
+  static let globalSaturation = FeatureID(rawValue: "mac-demo-global-saturation")
+  static let crop2 = FeatureID(rawValue: "mac-demo-crop-2")
+  static let globalVignette = FeatureID(rawValue: "mac-demo-global-vignette")
 }
 
 /// Builds and renders a registry-backed parametric document for the macOS demo.
@@ -256,37 +391,77 @@ struct ParametricMacPreviewRenderer {
   ) throws -> (document: FeatureDocument, treeLines: [ParametricMacTreeLine]) {
     var features: [FeatureTreeNode] = []
     var treeLines: [ParametricMacTreeLine] = [
-      .init(level: 0, kind: "source", value: sizeDescription(Self.sourceSize)),
-      .init(level: 0, kind: "main", value: "source -> output"),
+      .init(
+        id: "source",
+        level: 0,
+        kind: .source,
+        title: "Source",
+        detail: sizeDescription(Self.sourceSize),
+        featureID: nil
+      ),
+      .init(
+        id: "main",
+        level: 0,
+        kind: .main,
+        title: "Main",
+        detail: "source -> output",
+        featureID: nil
+      ),
     ]
     var currentSize = Self.sourceSize
 
     if settings.isFirstCropEnabled {
+      let featureID = ParametricMacPreviewFeatureID.crop1
+      let isEnabled = settings.isFeatureEnabled(featureID)
       let cropRect = insetRect(size: currentSize, inset: settings.firstCropInset)
       features.append(
         .domain(
           try FeatureNode(
             BrightroomFeatureDefinitions.Crop.self,
-            id: FeatureID(rawValue: "mac-demo-crop-1"),
+            id: featureID,
+            isEnabled: isEnabled,
             payload: .init(cropRect: cropRect)
           )
         )
       )
-      currentSize = cropRect.size
-      treeLines.append(.init(level: 1, kind: "domain", value: "Crop 1 -> \(sizeDescription(currentSize))"))
+      if isEnabled {
+        currentSize = cropRect.size
+      }
+      treeLines.append(
+        .init(
+          id: featureID.rawValue,
+          level: 1,
+          kind: .domain,
+          title: "Crop 1",
+          detail: "inset \(Int(settings.firstCropInset)) -> \(sizeDescription(cropRect.size))",
+          featureID: featureID
+        )
+      )
     }
 
     if settings.isLocalAdjustmentEnabled {
-      let brush = try makeBrushMask(size: currentSize, settings: settings)
+      let localAdjustmentID = ParametricMacPreviewFeatureID.localAdjustment
+      let brushID = ParametricMacPreviewFeatureID.brushMask
+      let featherID = ParametricMacPreviewFeatureID.featherMask
+      let exposureID = ParametricMacPreviewFeatureID.localExposure
+      let blurID = ParametricMacPreviewFeatureID.localBlur
+      let brush = try makeBrushMask(
+        size: currentSize,
+        settings: settings,
+        id: brushID,
+        isEnabled: settings.isFeatureEnabled(brushID)
+      )
       let featheredMask = try FeatureNode(
         BrightroomFeatureDefinitions.FeatherMask.self,
-        id: FeatureID(rawValue: "mac-demo-feather-mask"),
+        id: featherID,
+        isEnabled: settings.isFeatureEnabled(featherID),
         payload: .init(input: brush, radius: settings.maskFeatherRadius)
       )
       var effects: [FeatureNode] = [
         try FeatureNode(
           BrightroomFeatureDefinitions.Exposure.self,
-          id: FeatureID(rawValue: "mac-demo-local-exposure"),
+          id: exposureID,
+          isEnabled: settings.isFeatureEnabled(exposureID),
           payload: .init(value: settings.localExposure)
         ),
       ]
@@ -294,26 +469,76 @@ struct ParametricMacPreviewRenderer {
         effects.append(
           try FeatureNode(
             BrightroomFeatureDefinitions.GaussianBlur.self,
-            id: FeatureID(rawValue: "mac-demo-local-blur"),
+            id: blurID,
+            isEnabled: settings.isFeatureEnabled(blurID),
             payload: .init(radius: .absolute(settings.localBlurRadius))
           )
         )
       }
 
-      features.append(
-        .localAdjustment(
-          FeatureLocalAdjustment(
-            id: FeatureID(rawValue: "mac-demo-local-adjustment"),
-            mask: featheredMask,
-            effectPipeline: FeatureEffectPipeline(effects: effects)
+      if effects.contains(where: \.isEnabled) {
+        features.append(
+          .localAdjustment(
+            FeatureLocalAdjustment(
+              id: localAdjustmentID,
+              isEnabled: settings.isFeatureEnabled(localAdjustmentID),
+              mask: featheredMask,
+              effectPipeline: FeatureEffectPipeline(effects: effects)
+            )
           )
         )
+      }
+      treeLines.append(
+        .init(
+          id: localAdjustmentID.rawValue,
+          level: 1,
+          kind: .local,
+          title: "Local Adjustment",
+          detail: "alpha blend branch",
+          featureID: localAdjustmentID
+        )
       )
-      treeLines.append(.init(level: 1, kind: "local", value: "Local Adjustment"))
-      treeLines.append(.init(level: 2, kind: "mask", value: "Brush -> Feather \(Int(settings.maskFeatherRadius))"))
-      treeLines.append(.init(level: 2, kind: "effect", value: "Exposure \(settings.localExposure.formatted(.number.precision(.fractionLength(2))))"))
+      treeLines.append(
+        .init(
+          id: brushID.rawValue,
+          level: 2,
+          kind: .mask,
+          title: "Brush Mask",
+          detail: "diameter \(Int(settings.brushDiameter))",
+          featureID: brushID
+        )
+      )
+      treeLines.append(
+        .init(
+          id: featherID.rawValue,
+          level: 2,
+          kind: .mask,
+          title: "Feather Mask",
+          detail: "radius \(Int(settings.maskFeatherRadius))",
+          featureID: featherID
+        )
+      )
+      treeLines.append(
+        .init(
+          id: exposureID.rawValue,
+          level: 2,
+          kind: .effect,
+          title: "Exposure",
+          detail: settings.localExposure.formatted(.number.precision(.fractionLength(2))),
+          featureID: exposureID
+        )
+      )
       if settings.localBlurRadius > 0.1 {
-        treeLines.append(.init(level: 2, kind: "effect", value: "Blur \(Int(settings.localBlurRadius))"))
+        treeLines.append(
+          .init(
+            id: blurID.rawValue,
+            level: 2,
+            kind: .effect,
+            title: "Blur",
+            detail: "\(Int(settings.localBlurRadius)) px",
+            featureID: blurID
+          )
+        )
       }
     }
 
@@ -322,18 +547,32 @@ struct ParametricMacPreviewRenderer {
     treeLines.append(contentsOf: preCropEffects.treeLines)
 
     if settings.isSecondCropEnabled {
+      let featureID = ParametricMacPreviewFeatureID.crop2
+      let isEnabled = settings.isFeatureEnabled(featureID)
       let cropRect = insetRect(size: currentSize, inset: settings.secondCropInset)
       features.append(
         .domain(
           try FeatureNode(
             BrightroomFeatureDefinitions.Crop.self,
-            id: FeatureID(rawValue: "mac-demo-crop-2"),
+            id: featureID,
+            isEnabled: isEnabled,
             payload: .init(cropRect: cropRect)
           )
         )
       )
-      currentSize = cropRect.size
-      treeLines.append(.init(level: 1, kind: "domain", value: "Crop 2 -> \(sizeDescription(currentSize))"))
+      if isEnabled {
+        currentSize = cropRect.size
+      }
+      treeLines.append(
+        .init(
+          id: featureID.rawValue,
+          level: 1,
+          kind: .domain,
+          title: "Crop 2",
+          detail: "inset \(Int(settings.secondCropInset)) -> \(sizeDescription(cropRect.size))",
+          featureID: featureID
+        )
+      )
     }
 
     if let vignette = try makeVignetteEffect(settings: settings) {
@@ -354,25 +593,47 @@ struct ParametricMacPreviewRenderer {
     var treeLines: [ParametricMacTreeLine] = []
 
     if abs(settings.globalBrightness) > 0.001 {
+      let featureID = ParametricMacPreviewFeatureID.globalBrightness
       features.append(
         try FeatureNode(
           BrightroomFeatureDefinitions.Brightness.self,
-          id: FeatureID(rawValue: "mac-demo-global-brightness"),
+          id: featureID,
+          isEnabled: settings.isFeatureEnabled(featureID),
           payload: .init(value: settings.globalBrightness)
         )
       )
-      treeLines.append(.init(level: 1, kind: "effect", value: "Brightness \(settings.globalBrightness.formatted(.number.precision(.fractionLength(2))))"))
+      treeLines.append(
+        .init(
+          id: featureID.rawValue,
+          level: 1,
+          kind: .effect,
+          title: "Brightness",
+          detail: settings.globalBrightness.formatted(.number.precision(.fractionLength(2))),
+          featureID: featureID
+        )
+      )
     }
 
     if abs(settings.globalSaturation) > 0.001 {
+      let featureID = ParametricMacPreviewFeatureID.globalSaturation
       features.append(
         try FeatureNode(
           BrightroomFeatureDefinitions.Saturation.self,
-          id: FeatureID(rawValue: "mac-demo-global-saturation"),
+          id: featureID,
+          isEnabled: settings.isFeatureEnabled(featureID),
           payload: .init(value: settings.globalSaturation)
         )
       )
-      treeLines.append(.init(level: 1, kind: "effect", value: "Saturation \(settings.globalSaturation.formatted(.number.precision(.fractionLength(2))))"))
+      treeLines.append(
+        .init(
+          id: featureID.rawValue,
+          level: 1,
+          kind: .effect,
+          title: "Saturation",
+          detail: settings.globalSaturation.formatted(.number.precision(.fractionLength(2))),
+          featureID: featureID
+        )
+      )
     }
 
     return (features, treeLines)
@@ -384,20 +645,31 @@ struct ParametricMacPreviewRenderer {
     guard settings.globalVignette > 0.001 else {
       return nil
     }
+    let featureID = ParametricMacPreviewFeatureID.globalVignette
 
     return (
       try FeatureNode(
         BrightroomFeatureDefinitions.Vignette.self,
-        id: FeatureID(rawValue: "mac-demo-global-vignette"),
+        id: featureID,
+        isEnabled: settings.isFeatureEnabled(featureID),
         payload: .init(value: settings.globalVignette)
       ),
-      .init(level: 1, kind: "effect", value: "Vignette \(settings.globalVignette.formatted(.number.precision(.fractionLength(2))))")
+      .init(
+        id: featureID.rawValue,
+        level: 1,
+        kind: .effect,
+        title: "Vignette",
+        detail: settings.globalVignette.formatted(.number.precision(.fractionLength(2))),
+        featureID: featureID
+      )
     )
   }
 
   private func makeBrushMask(
     size: CGSize,
-    settings: ParametricMacPreviewSettings
+    settings: ParametricMacPreviewSettings,
+    id: FeatureID,
+    isEnabled: Bool
   ) throws -> FeatureNode {
     let centerY = size.height * 0.56
     let stamps = stride(from: 0.18, through: 0.82, by: 0.08).map { progress in
@@ -416,7 +688,8 @@ struct ParametricMacPreviewRenderer {
     )
     return try FeatureNode(
       BrightroomFeatureDefinitions.BrushMask.self,
-      id: FeatureID(rawValue: "mac-demo-brush-mask"),
+      id: id,
+      isEnabled: isEnabled,
       payload: .init(strokes: [stroke])
     )
   }

--- a/Dev/ParametricMacDemo/ParametricMacDemoView.swift
+++ b/Dev/ParametricMacDemo/ParametricMacDemoView.swift
@@ -317,6 +317,10 @@ struct ParametricMacPreviewRenderer {
       }
     }
 
+    let preCropEffects = try makeGlobalColorEffects(settings: settings)
+    features.append(contentsOf: preCropEffects.features.map(FeatureTreeNode.effect))
+    treeLines.append(contentsOf: preCropEffects.treeLines)
+
     if settings.isSecondCropEnabled {
       let cropRect = insetRect(size: currentSize, inset: settings.secondCropInset)
       features.append(
@@ -332,9 +336,10 @@ struct ParametricMacPreviewRenderer {
       treeLines.append(.init(level: 1, kind: "domain", value: "Crop 2 -> \(sizeDescription(currentSize))"))
     }
 
-    let globalEffects = try makeGlobalEffects(settings: settings)
-    features.append(contentsOf: globalEffects.features.map(FeatureTreeNode.effect))
-    treeLines.append(contentsOf: globalEffects.treeLines)
+    if let vignette = try makeVignetteEffect(settings: settings) {
+      features.append(.effect(vignette.feature))
+      treeLines.append(vignette.treeLine)
+    }
 
     return (
       FeatureDocument(mainTree: FeatureMainTree(features: features)),
@@ -342,7 +347,7 @@ struct ParametricMacPreviewRenderer {
     )
   }
 
-  private func makeGlobalEffects(
+  private func makeGlobalColorEffects(
     settings: ParametricMacPreviewSettings
   ) throws -> (features: [FeatureNode], treeLines: [ParametricMacTreeLine]) {
     var features: [FeatureNode] = []
@@ -370,18 +375,24 @@ struct ParametricMacPreviewRenderer {
       treeLines.append(.init(level: 1, kind: "effect", value: "Saturation \(settings.globalSaturation.formatted(.number.precision(.fractionLength(2))))"))
     }
 
-    if settings.globalVignette > 0.001 {
-      features.append(
-        try FeatureNode(
-          BrightroomFeatureDefinitions.Vignette.self,
-          id: FeatureID(rawValue: "mac-demo-global-vignette"),
-          payload: .init(value: settings.globalVignette)
-        )
-      )
-      treeLines.append(.init(level: 1, kind: "effect", value: "Vignette \(settings.globalVignette.formatted(.number.precision(.fractionLength(2))))"))
+    return (features, treeLines)
+  }
+
+  private func makeVignetteEffect(
+    settings: ParametricMacPreviewSettings
+  ) throws -> (feature: FeatureNode, treeLine: ParametricMacTreeLine)? {
+    guard settings.globalVignette > 0.001 else {
+      return nil
     }
 
-    return (features, treeLines)
+    return (
+      try FeatureNode(
+        BrightroomFeatureDefinitions.Vignette.self,
+        id: FeatureID(rawValue: "mac-demo-global-vignette"),
+        payload: .init(value: settings.globalVignette)
+      ),
+      .init(level: 1, kind: "effect", value: "Vignette \(settings.globalVignette.formatted(.number.precision(.fractionLength(2))))")
+    )
   }
 
   private func makeBrushMask(

--- a/Dev/Sources/SwiftUIDemo/ContentView.swift
+++ b/Dev/Sources/SwiftUIDemo/ContentView.swift
@@ -66,6 +66,14 @@ struct ContentView: View {
             RenderingDemoView()
           }
 
+          NavigationLink("Parametric Features") {
+            ParametricFeaturePreviewView()
+          }
+
+          NavigationLink("Parametric Video") {
+            ParametricVideoRenderPlaygroundView()
+          }
+
           Section("Restoration Horizontal") {
             Button("Masking") {
               fullScreenView = .init {

--- a/Dev/Sources/SwiftUIDemo/ParametricFeaturePreviewView.swift
+++ b/Dev/Sources/SwiftUIDemo/ParametricFeaturePreviewView.swift
@@ -1,0 +1,427 @@
+import BrightroomEngine
+import BrightroomParametric
+import BrightroomUI
+import CoreImage
+import Foundation
+import SwiftUI
+import UIKit
+
+struct ParametricFeaturePreviewView: View {
+
+  @State private var isFirstCropEnabled = true
+  @State private var firstCropInset: Double = 28
+  @State private var isSecondCropEnabled = true
+  @State private var secondCropInset: Double = 20
+
+  @State private var isLocalExposureEnabled = true
+  @State private var localExposureValue: Double = 0.9
+  @State private var localExposureX: Double = 0.34
+  @State private var localExposureY: Double = 0.5
+  @State private var localExposureDiameter: Double = 0.34
+
+  @State private var isLocalBlurEnabled = true
+  @State private var localBlurRadius: Double = 10
+  @State private var localBlurX: Double = 0.68
+  @State private var localBlurY: Double = 0.5
+  @State private var localBlurDiameter: Double = 0.42
+
+  @State private var globalBrightness: Double = 0.04
+  @State private var previewLayer: ParametricPreviewLayer = .output
+
+  var body: some View {
+    VStack(spacing: 0) {
+      Form {
+        Section("Preview") {
+          Picker("Layer", selection: $previewLayer) {
+            ForEach(ParametricPreviewLayer.allCases) { layer in
+              Text(layer.title).tag(layer)
+            }
+          }
+        }
+
+        Section("Crop") {
+          Toggle("Crop A", isOn: $isFirstCropEnabled)
+          Slider(
+            value: $firstCropInset,
+            in: 0...120,
+            step: 1
+          ) {
+            Text("Inset A")
+          }
+
+          Toggle("Crop B", isOn: $isSecondCropEnabled)
+          Slider(
+            value: $secondCropInset,
+            in: 0...100,
+            step: 1
+          ) {
+            Text("Inset B")
+          }
+        }
+
+        Section("Local Exposure") {
+          Toggle("Enabled", isOn: $isLocalExposureEnabled)
+          Slider(value: $localExposureValue, in: -1...2, step: 0.05) {
+            Text("EV")
+          }
+          Slider(value: $localExposureX, in: 0...1, step: 0.01) {
+            Text("X")
+          }
+          Slider(value: $localExposureY, in: 0...1, step: 0.01) {
+            Text("Y")
+          }
+          Slider(value: $localExposureDiameter, in: 0.08...0.9, step: 0.01) {
+            Text("Size")
+          }
+        }
+
+        Section("Local Blur") {
+          Toggle("Enabled", isOn: $isLocalBlurEnabled)
+          Slider(value: $localBlurRadius, in: 0...40, step: 1) {
+            Text("Radius")
+          }
+          Slider(value: $localBlurX, in: 0...1, step: 0.01) {
+            Text("X")
+          }
+          Slider(value: $localBlurY, in: 0...1, step: 0.01) {
+            Text("Y")
+          }
+          Slider(value: $localBlurDiameter, in: 0.08...0.9, step: 0.01) {
+            Text("Size")
+          }
+        }
+
+        Section("Global") {
+          Slider(value: $globalBrightness, in: -0.25...0.25, step: 0.01) {
+            Text("Brightness")
+          }
+        }
+
+        Section("Tree") {
+          Text(treeDescription)
+            .font(.caption.monospaced())
+        }
+      }
+      .frame(maxHeight: 520)
+
+      previewSurface
+    }
+    .navigationTitle("Parametric Features")
+  }
+
+  @ViewBuilder
+  private var previewSurface: some View {
+    switch makePreviewImage() {
+    case let .image(image):
+      SwiftUIMetalImageView(
+        image: image,
+        contentMode: .scaleAspectFit,
+        displayBackground: .color(.black)
+      )
+      .background(Color.black)
+    case let .failure(message):
+      Text(message)
+        .font(.footnote.monospaced())
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.black)
+    }
+  }
+
+  private var treeDescription: String {
+    let outputSize = currentDomainSize
+    return [
+      isFirstCropEnabled ? "Crop A inset=\(Int(firstCropInset))" : "Crop A disabled",
+      isSecondCropEnabled ? "Crop B inset=\(Int(secondCropInset))" : "Crop B disabled",
+      isLocalExposureEnabled ? "Local Exposure ev=\(formatted(localExposureValue))" : "Local Exposure disabled",
+      isLocalBlurEnabled ? "Local Blur radius=\(Int(localBlurRadius))" : "Local Blur disabled",
+      "Global Brightness=\(formatted(globalBrightness))",
+      "Output domain \(Int(outputSize.width)) x \(Int(outputSize.height))",
+    ]
+    .joined(separator: "\n")
+  }
+
+  private func makePreviewImage() -> ParametricPreviewImage {
+    do {
+      let renderer = ParametricImageRenderer()
+      let output = try renderer.makeOutput(
+        from: Self.sourceImage,
+        document: makeDocument()
+      )
+
+      switch previewLayer {
+      case .source:
+        return .image(Self.sourceImage)
+      case .output:
+        return .image(output.image)
+      case .localExposureMask:
+        return .image(
+          output.localAdjustmentMasks[Self.localExposureID]
+            ?? CIImage.parametricPreviewTransparent(extent: output.image.extent)
+        )
+      case .localBlurMask:
+        return .image(
+          output.localAdjustmentMasks[Self.localBlurID]
+            ?? CIImage.parametricPreviewTransparent(extent: output.image.extent)
+        )
+      }
+    } catch {
+      return .failure(String(describing: error))
+    }
+  }
+
+  private func makeDocument() -> EditingDocument {
+    var features: [MainFeature] = [
+      .domain(
+        .crop(
+          CropFeature(
+            id: Self.firstCropID,
+            isEnabled: isFirstCropEnabled,
+            cropRect: firstCropRect
+          )
+        )
+      ),
+      .domain(
+        .crop(
+          CropFeature(
+            id: Self.secondCropID,
+            isEnabled: isSecondCropEnabled,
+            cropRect: secondCropRect
+          )
+        )
+      ),
+      .localAdjustment(
+        LocalAdjustmentFeature(
+          id: Self.localExposureID,
+          isEnabled: isLocalExposureEnabled,
+          maskTree: MaskTree(root: localExposureMask),
+          effectPipeline: EffectPipeline(
+            effects: [
+              .exposure(
+                ExposureFeature(
+                  id: FeatureID(rawValue: "preview-local-exposure-effect"),
+                  value: localExposureValue
+                )
+              ),
+            ]
+          )
+        )
+      ),
+      .localAdjustment(
+        LocalAdjustmentFeature(
+          id: Self.localBlurID,
+          isEnabled: isLocalBlurEnabled,
+          maskTree: MaskTree(root: localBlurMask),
+          effectPipeline: EffectPipeline(
+            effects: [
+              .gaussianBlur(
+                GaussianBlurFeature(
+                  id: FeatureID(rawValue: "preview-local-blur-effect"),
+                  radius: localBlurRadius
+                )
+              ),
+            ]
+          )
+        )
+      ),
+    ]
+
+    if abs(globalBrightness) > 0.001 {
+      features.append(
+        .effect(
+          .brightness(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "preview-global-brightness"),
+              value: globalBrightness
+            )
+          )
+        )
+      )
+    }
+
+    return EditingDocument(mainTree: MainTree(features: features))
+  }
+
+  private var firstCropRect: CGRect {
+    let inset = CGFloat(firstCropInset)
+    return CGRect(
+      x: inset,
+      y: inset * 0.5,
+      width: max(Self.sourceExtent.width - inset * 2, 1),
+      height: max(Self.sourceExtent.height - inset, 1)
+    )
+  }
+
+  private var secondCropRect: CGRect {
+    let baseSize = sizeAfterFirstCrop
+    let inset = CGFloat(secondCropInset)
+    return CGRect(
+      x: inset,
+      y: inset * 0.5,
+      width: max(baseSize.width - inset * 2, 1),
+      height: max(baseSize.height - inset, 1)
+    )
+  }
+
+  private var sizeAfterFirstCrop: CGSize {
+    guard isFirstCropEnabled else {
+      return Self.sourceExtent.size
+    }
+    return firstCropRect.size
+  }
+
+  private var currentDomainSize: CGSize {
+    guard isSecondCropEnabled else {
+      return sizeAfterFirstCrop
+    }
+    return secondCropRect.size
+  }
+
+  private var localExposureMask: MaskNode {
+    .brush(
+      BrushMask(
+        id: FeatureID(rawValue: "preview-local-exposure-mask"),
+        strokes: [
+          BrushMaskStroke(
+            stamps: [normalizedPoint(x: localExposureX, y: localExposureY)],
+            brush: BrushMaskBrush(
+              diameter: normalizedDiameter(localExposureDiameter),
+              hardness: 0.55,
+              opacity: 1
+            )
+          ),
+        ]
+      )
+    )
+  }
+
+  private var localBlurMask: MaskNode {
+    .feather(
+      MaskFeather(
+        id: FeatureID(rawValue: "preview-local-blur-feather"),
+        input: .brush(
+          BrushMask(
+            id: FeatureID(rawValue: "preview-local-blur-mask"),
+            strokes: [
+              BrushMaskStroke(
+                stamps: [normalizedPoint(x: localBlurX, y: localBlurY)],
+                brush: BrushMaskBrush(
+                  diameter: normalizedDiameter(localBlurDiameter),
+                  hardness: 0.45,
+                  opacity: 1
+                )
+              ),
+            ]
+          )
+        ),
+        radius: 6
+      )
+    )
+  }
+
+  private func normalizedPoint(x: Double, y: Double) -> CGPoint {
+    CGPoint(
+      x: currentDomainSize.width * CGFloat(x),
+      y: currentDomainSize.height * CGFloat(y)
+    )
+  }
+
+  private func normalizedDiameter(_ value: Double) -> Double {
+    Double(min(currentDomainSize.width, currentDomainSize.height)) * value
+  }
+
+  private func formatted(_ value: Double) -> String {
+    String(format: "%.2f", value)
+  }
+
+  private static let firstCropID = FeatureID(rawValue: "preview-crop-a")
+  private static let secondCropID = FeatureID(rawValue: "preview-crop-b")
+  private static let localExposureID = FeatureID(rawValue: "preview-local-exposure")
+  private static let localBlurID = FeatureID(rawValue: "preview-local-blur")
+
+  private static let sourceExtent = CGRect(x: 0, y: 0, width: 512, height: 320)
+
+  private static let sourceImage: CIImage = {
+    let checker = CIFilter(
+      name: "CICheckerboardGenerator",
+      parameters: [
+        "inputCenter": CIVector(x: 0, y: 0),
+        "inputColor0": CIColor(red: 0.12, green: 0.18, blue: 0.23, alpha: 1),
+        "inputColor1": CIColor(red: 0.62, green: 0.68, blue: 0.58, alpha: 1),
+        "inputWidth": 48,
+        "inputSharpness": 0.7,
+      ]
+    )!
+    .outputImage!
+    .cropped(to: sourceExtent)
+
+    let warmBand = CIImage(color: CIColor(red: 0.95, green: 0.35, blue: 0.18, alpha: 0.78))
+      .cropped(to: CGRect(x: 214, y: 0, width: 42, height: sourceExtent.height))
+      .applyingFilter(
+        "CISourceOverCompositing",
+        parameters: [kCIInputBackgroundImageKey: checker]
+      )
+
+    let coolBand = CIImage(color: CIColor(red: 0.06, green: 0.46, blue: 0.9, alpha: 0.72))
+      .cropped(to: CGRect(x: 360, y: 0, width: 60, height: sourceExtent.height))
+      .applyingFilter(
+        "CISourceOverCompositing",
+        parameters: [kCIInputBackgroundImageKey: warmBand]
+      )
+
+    return CIFilter(
+      name: "CIRadialGradient",
+      parameters: [
+        "inputCenter": CIVector(x: 128, y: 214),
+        "inputRadius0": 20,
+        "inputRadius1": 154,
+        "inputColor0": CIColor(red: 1, green: 1, blue: 1, alpha: 0.82),
+        "inputColor1": CIColor(red: 1, green: 1, blue: 1, alpha: 0),
+      ]
+    )!
+    .outputImage!
+    .cropped(to: sourceExtent)
+    .applyingFilter(
+      "CISourceOverCompositing",
+      parameters: [kCIInputBackgroundImageKey: coolBand]
+    )
+    .cropped(to: sourceExtent)
+  }()
+}
+
+/// Image evaluation state for the parametric feature preview.
+private enum ParametricPreviewImage {
+  case image(CIImage)
+  case failure(String)
+}
+
+/// Layers that can be inspected in the parametric feature preview.
+private enum ParametricPreviewLayer: CaseIterable, Identifiable {
+  case source
+  case output
+  case localExposureMask
+  case localBlurMask
+
+  var id: Self { self }
+
+  var title: String {
+    switch self {
+    case .source:
+      "Source"
+    case .output:
+      "Output"
+    case .localExposureMask:
+      "Exposure Mask"
+    case .localBlurMask:
+      "Blur Mask"
+    }
+  }
+}
+
+private extension CIImage {
+
+  static func parametricPreviewTransparent(extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+      .cropped(to: extent)
+  }
+}

--- a/Dev/Sources/SwiftUIDemo/ParametricVideoRenderPlaygroundView.swift
+++ b/Dev/Sources/SwiftUIDemo/ParametricVideoRenderPlaygroundView.swift
@@ -1,0 +1,441 @@
+import AVFoundation
+import AVKit
+import BrightroomEngine
+import BrightroomParametric
+import CoreGraphics
+import CoreImage
+import SwiftUI
+
+struct ParametricVideoRenderPlaygroundView: View {
+
+  @State private var player: AVPlayer?
+  @State private var asset: AVURLAsset?
+  @State private var isPreparingVideo = false
+  @State private var isPlaying = true
+  @State private var errorMessage: String?
+
+  @State private var renderSizeMode: ParametricVideoPlaygroundRenderSizeMode = .source
+  @State private var isCropEnabled = true
+  @State private var cropInset: Double = 28
+  @State private var brightness: Double = 0.04
+  @State private var saturation: Double = 0.12
+  @State private var blurRadius: Double = 0
+
+  var body: some View {
+    VStack(spacing: 0) {
+      Form {
+        Section("Playback") {
+          Picker("Render Size", selection: $renderSizeMode) {
+            ForEach(ParametricVideoPlaygroundRenderSizeMode.allCases) { mode in
+              Text(mode.title).tag(mode)
+            }
+          }
+          .pickerStyle(.segmented)
+
+          Button(isPlaying ? "Pause" : "Play") {
+            togglePlayback()
+          }
+        }
+
+        Section("Crop") {
+          Toggle("Enabled", isOn: $isCropEnabled)
+          Slider(value: $cropInset, in: 0...88, step: 1) {
+            Text("Inset")
+          }
+        }
+
+        Section("Effects") {
+          Slider(value: $brightness, in: -0.25...0.25, step: 0.01) {
+            Text("Brightness")
+          }
+          Slider(value: $saturation, in: -0.75...0.75, step: 0.01) {
+            Text("Saturation")
+          }
+          Slider(value: $blurRadius, in: 0...18, step: 1) {
+            Text("Blur")
+          }
+        }
+
+        if let errorMessage {
+          Section("Error") {
+            Text(errorMessage)
+              .font(.caption.monospaced())
+          }
+        }
+      }
+      .frame(maxHeight: 430)
+
+      playerSurface
+    }
+    .navigationTitle("Parametric Video")
+    .task {
+      await prepareVideoIfNeeded()
+    }
+    .onChange(of: settings) { _, _ in
+      applyVideoComposition()
+    }
+    .onDisappear {
+      player?.pause()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime)) { notification in
+      guard let item = player?.currentItem,
+            notification.object as? AVPlayerItem === item
+      else {
+        return
+      }
+
+      item.seek(to: .zero) { _ in
+        if isPlaying {
+          player?.play()
+        }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var playerSurface: some View {
+    ZStack {
+      Color.black
+
+      if let player {
+        VideoPlayer(player: player)
+      } else if isPreparingVideo {
+        ProgressView()
+          .tint(.white)
+      } else if let errorMessage {
+        Text(errorMessage)
+          .font(.caption.monospaced())
+          .foregroundStyle(.white)
+          .padding()
+      }
+    }
+    .aspectRatio(Self.videoSize.width / Self.videoSize.height, contentMode: .fit)
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+  }
+
+  private var settings: ParametricVideoPlaygroundSettings {
+    ParametricVideoPlaygroundSettings(
+      renderSizeMode: renderSizeMode,
+      isCropEnabled: isCropEnabled,
+      cropInset: cropInset,
+      brightness: brightness,
+      saturation: saturation,
+      blurRadius: blurRadius
+    )
+  }
+
+  @MainActor
+  private func prepareVideoIfNeeded() async {
+    guard asset == nil else {
+      return
+    }
+
+    isPreparingVideo = true
+    defer {
+      isPreparingVideo = false
+    }
+
+    do {
+      let url = try await Task.detached(priority: .userInitiated) {
+        try Self.makeDemoVideoURL()
+      }
+      .value
+      let asset = AVURLAsset(url: url)
+      let item = AVPlayerItem(asset: asset)
+      let player = AVPlayer(playerItem: item)
+
+      self.asset = asset
+      self.player = player
+      applyVideoComposition()
+      player.play()
+    } catch {
+      errorMessage = String(describing: error)
+    }
+  }
+
+  @MainActor
+  private func applyVideoComposition() {
+    guard let asset,
+          let item = player?.currentItem
+    else {
+      return
+    }
+
+    do {
+      item.videoComposition = try ParametricVideoRenderer().makeVideoComposition(
+        for: asset,
+        document: makeFeatureDocument(),
+        renderSizeMode: renderSizeMode.rendererMode
+      )
+      errorMessage = nil
+    } catch {
+      errorMessage = String(describing: error)
+    }
+  }
+
+  private func togglePlayback() {
+    guard let player else {
+      return
+    }
+
+    isPlaying.toggle()
+
+    if isPlaying {
+      player.play()
+    } else {
+      player.pause()
+    }
+  }
+
+  private func makeFeatureDocument() throws -> FeatureDocument {
+    var features: [FeatureTreeNode] = []
+
+    if isCropEnabled {
+      features.append(
+        .domain(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.Crop.self,
+            id: Self.cropID,
+            payload: .init(cropRect: cropRect)
+          )
+        )
+      )
+    }
+
+    if abs(brightness) > 0.001 {
+      features.append(
+        .effect(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.Brightness.self,
+            id: Self.brightnessID,
+            payload: .init(value: brightness)
+          )
+        )
+      )
+    }
+
+    if abs(saturation) > 0.001 {
+      features.append(
+        .effect(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.Saturation.self,
+            id: Self.saturationID,
+            payload: .init(value: saturation)
+          )
+        )
+      )
+    }
+
+    if blurRadius > 0.1 {
+      features.append(
+        .effect(
+          try FeatureNode(
+            BrightroomFeatureDefinitions.GaussianBlur.self,
+            id: Self.blurID,
+            payload: .init(radius: .absolute(blurRadius))
+          )
+        )
+      )
+    }
+
+    return FeatureDocument(
+      mainTree: FeatureMainTree(features: features)
+    )
+  }
+
+  private var cropRect: CGRect {
+    let inset = CGFloat(cropInset)
+    return CGRect(
+      x: inset,
+      y: inset * 0.5,
+      width: max(Self.videoSize.width - inset * 2, 1),
+      height: max(Self.videoSize.height - inset, 1)
+    )
+  }
+
+  nonisolated private static func makeDemoVideoURL() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("brightroom-parametric-video-\(UUID().uuidString)")
+      .appendingPathExtension("mov")
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+    let input = AVAssetWriterInput(
+      mediaType: .video,
+      outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: Int(videoSize.width),
+        AVVideoHeightKey: Int(videoSize.height),
+      ]
+    )
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: Int(videoSize.width),
+        kCVPixelBufferHeightKey as String: Int(videoSize.height),
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ]
+    )
+    let context = CIContext()
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+    guard writer.canAdd(input) else {
+      throw ParametricVideoPlaygroundError.cannotAddInput
+    }
+
+    writer.add(input)
+
+    guard writer.startWriting() else {
+      throw writer.error ?? ParametricVideoPlaygroundError.cannotStartWriting
+    }
+
+    writer.startSession(atSourceTime: .zero)
+
+    for frameIndex in 0..<90 {
+      while !input.isReadyForMoreMediaData {
+        Thread.sleep(forTimeInterval: 0.005)
+      }
+
+      let pixelBuffer = try makePixelBuffer()
+      let frameImage = makeFrameImage(frameIndex: frameIndex)
+      context.render(
+        frameImage,
+        to: pixelBuffer,
+        bounds: CGRect(origin: .zero, size: videoSize),
+        colorSpace: colorSpace
+      )
+
+      guard adaptor.append(
+        pixelBuffer,
+        withPresentationTime: CMTime(value: CMTimeValue(frameIndex), timescale: 30)
+      ) else {
+        throw writer.error ?? ParametricVideoPlaygroundError.cannotAppendFrame
+      }
+    }
+
+    input.markAsFinished()
+
+    let semaphore = DispatchSemaphore(value: 0)
+    writer.finishWriting {
+      semaphore.signal()
+    }
+    semaphore.wait()
+
+    guard writer.status == .completed else {
+      throw writer.error ?? ParametricVideoPlaygroundError.cannotFinishWriting(writer.status)
+    }
+
+    return url
+  }
+
+  nonisolated private static func makePixelBuffer() throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let result = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      Int(videoSize.width),
+      Int(videoSize.height),
+      kCVPixelFormatType_32BGRA,
+      [
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ] as CFDictionary,
+      &pixelBuffer
+    )
+
+    guard result == kCVReturnSuccess, let pixelBuffer else {
+      throw ParametricVideoPlaygroundError.cannotCreatePixelBuffer(result)
+    }
+
+    return pixelBuffer
+  }
+
+  nonisolated private static func makeFrameImage(frameIndex: Int) -> CIImage {
+    let extent = CGRect(origin: .zero, size: videoSize)
+    let progress = CGFloat(frameIndex) / 90
+    let checker = CIFilter(
+      name: "CICheckerboardGenerator",
+      parameters: [
+        "inputCenter": CIVector(x: 0, y: 0),
+        "inputColor0": CIColor(red: 0.08, green: 0.12, blue: 0.17, alpha: 1),
+        "inputColor1": CIColor(red: 0.32, green: 0.38, blue: 0.31, alpha: 1),
+        "inputWidth": 36,
+        "inputSharpness": 0.78,
+      ]
+    )!
+    .outputImage!
+    .cropped(to: extent)
+    let bandX = progress * (videoSize.width + 96) - 48
+    let warmBand = CIImage(color: CIColor(red: 0.95, green: 0.36, blue: 0.16, alpha: 0.82))
+      .cropped(to: CGRect(x: bandX, y: 0, width: 48, height: videoSize.height))
+      .composited(over: checker)
+    let coolBand = CIImage(color: CIColor(red: 0.05, green: 0.46, blue: 0.9, alpha: 0.78))
+      .cropped(to: CGRect(x: videoSize.width - bandX - 52, y: 0, width: 52, height: videoSize.height))
+      .composited(over: warmBand)
+    let glow = CIFilter(
+      name: "CIRadialGradient",
+      parameters: [
+        "inputCenter": CIVector(
+          x: 72 + cos(progress * .pi * 2) * 42,
+          y: 96 + sin(progress * .pi * 2) * 34
+        ),
+        "inputRadius0": 8,
+        "inputRadius1": 74,
+        "inputColor0": CIColor(red: 1, green: 0.94, blue: 0.68, alpha: 0.95),
+        "inputColor1": CIColor(red: 1, green: 0.94, blue: 0.68, alpha: 0),
+      ]
+    )!
+    .outputImage!
+    .cropped(to: extent)
+
+    return glow
+      .composited(over: coolBand)
+      .cropped(to: extent)
+  }
+
+  nonisolated private static let videoSize = CGSize(width: 320, height: 200)
+  nonisolated private static let cropID = FeatureID(rawValue: "video-playground-crop")
+  nonisolated private static let brightnessID = FeatureID(rawValue: "video-playground-brightness")
+  nonisolated private static let saturationID = FeatureID(rawValue: "video-playground-saturation")
+  nonisolated private static let blurID = FeatureID(rawValue: "video-playground-blur")
+}
+
+private struct ParametricVideoPlaygroundSettings: Equatable {
+  var renderSizeMode: ParametricVideoPlaygroundRenderSizeMode
+  var isCropEnabled: Bool
+  var cropInset: Double
+  var brightness: Double
+  var saturation: Double
+  var blurRadius: Double
+}
+
+private enum ParametricVideoPlaygroundRenderSizeMode: String, CaseIterable, Identifiable {
+  case source
+  case featureOutput
+
+  var id: Self { self }
+
+  var title: String {
+    switch self {
+    case .source:
+      "Source"
+    case .featureOutput:
+      "Feature"
+    }
+  }
+
+  var rendererMode: ParametricVideoRenderer.RenderSizeMode {
+    switch self {
+    case .source:
+      .source
+    case .featureOutput:
+      .featureOutput
+    }
+  }
+}
+
+private enum ParametricVideoPlaygroundError: Error {
+  case cannotAddInput
+  case cannotStartWriting
+  case cannotAppendFrame
+  case cannotFinishWriting(AVAssetWriter.Status)
+  case cannotCreatePixelBuffer(CVReturn)
+}

--- a/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
@@ -418,6 +418,77 @@ final class ParametricFeatureTreeTests: XCTestCase {
     XCTAssertEqual(output.image.extent, CGRect(x: 0, y: 0, width: 25, height: 30))
   }
 
+  func testImageEffectReceivesCurrentExtentAfterCrop() throws {
+    var registry = FeatureRegistry.brightroomDefault
+    registry.registerImageEffect(TestExtentProbeFeature.self)
+    let compiler = FeatureGraphCompiler(featureRegistry: registry)
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .domain(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Crop.self,
+              id: FeatureID(rawValue: "extent-probe-crop"),
+              payload: .init(cropRect: CGRect(x: 10, y: 8, width: 40, height: 20))
+            )
+          ),
+          .effect(
+            try FeatureNode(
+              TestExtentProbeFeature.self,
+              id: FeatureID(rawValue: "extent-probe-effect"),
+              payload: .init()
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 80, height: 60)
+    )
+
+    let output = try compiler.makeOutput(from: input, document: document)
+
+    XCTAssertEqual(output.image.extent, CGRect(x: 0, y: 0, width: 40, height: 20))
+    let rendered = try Self.render(output.image)
+    let pixel = Self.rgba(in: rendered, x: 20, y: 10)
+    XCTAssertLessThanOrEqual(abs(Int(pixel.red) - 102), 2)
+    XCTAssertLessThanOrEqual(abs(Int(pixel.green) - 51), 2)
+  }
+
+  func testVignetteUsesCurrentExtentAfterCrop() throws {
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .domain(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Crop.self,
+              id: FeatureID(rawValue: "vignette-crop"),
+              payload: .init(cropRect: CGRect(x: 10, y: 8, width: 40, height: 20))
+            )
+          ),
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Vignette.self,
+              id: FeatureID(rawValue: "vignette-after-crop"),
+              payload: .init(value: 0.5)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 80, height: 60)
+    )
+    let cropped = input
+      .cropped(to: CGRect(x: 10, y: 8, width: 40, height: 20))
+      .transformed(by: CGAffineTransform(translationX: -10, y: -8))
+    let expected = Self.vignetteEffectImage(value: 0.5, image: cropped)
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    try Self.assertImagesMatch(expected, output.image, tolerance: 2)
+  }
+
   func testLocalAdjustmentsAndGlobalEffectEvaluateInOrder() throws {
     let localExposure = LocalAdjustmentFeature(
       id: FeatureID(rawValue: "local-exposure"),
@@ -843,6 +914,21 @@ final class ParametricFeatureTreeTests: XCTestCase {
     }
   }
 
+  private static func vignetteEffectImage(value: Double, image: CIImage) -> CIImage {
+    let extent = image.extent
+    let radius = max(extent.width, extent.height) * 0.5
+    return image.applyingFilter(
+      "CIVignetteEffect",
+      parameters: [
+        kCIInputCenterKey: CIVector(x: extent.midX, y: extent.midY),
+        kCIInputRadiusKey: radius,
+        kCIInputIntensityKey: value,
+        "inputFalloff": 0.5,
+      ]
+    )
+    .cropped(to: extent)
+  }
+
   private static func makeColorCubeData(dimension: Int) -> Data {
     var values: [Float] = []
     values.reserveCapacity(dimension * dimension * dimension * 4)
@@ -1009,6 +1095,33 @@ final class ParametricFeatureTreeTests: XCTestCase {
           "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
           "inputBiasVector": CIVector(x: CGFloat(payload.amount), y: 0, z: 0, w: 0),
         ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  private enum TestExtentProbeFeature: ImageEffectFeatureDefinition {
+
+    static let typeID: FeatureTypeID = "test.effect.extentProbe"
+    static let currentSchemaVersion = 1
+
+    struct Payload: Codable, Equatable, Sendable {
+      init() {}
+    }
+
+    static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      CIImage(
+        color: CIColor(
+          red: min(image.extent.width / 100, 1),
+          green: min(image.extent.height / 100, 1),
+          blue: 0,
+          alpha: 1
+        )
       )
       .cropped(to: image.extent)
     }

--- a/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
@@ -1,0 +1,1092 @@
+import AVFoundation
+import CoreImage
+import XCTest
+
+@testable import BrightroomEngine
+@testable import BrightroomParametric
+
+final class ParametricFeatureTreeTests: XCTestCase {
+
+  func testDocumentCodableRoundTrip() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            .crop(
+              CropFeature(
+                id: FeatureID(rawValue: "crop-a"),
+                cropRect: CGRect(x: 4, y: 5, width: 30, height: 20)
+              )
+            )
+          ),
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "local-a"),
+              maskTree: MaskTree(
+                root: .feather(
+                  MaskFeather(
+                    id: FeatureID(rawValue: "feather-a"),
+                    input: .brush(
+                      BrushMask(
+                        id: FeatureID(rawValue: "mask-a"),
+                        strokes: [
+                          BrushMaskStroke(
+                            stamps: [CGPoint(x: 10, y: 8)],
+                            brush: BrushMaskBrush(diameter: 12, hardness: 0.5, opacity: 0.75)
+                          ),
+                        ]
+                      )
+                    ),
+                    radius: 2
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  .brightness(BrightnessFeature(id: FeatureID(rawValue: "brightness-a"), value: 0.1)),
+                  .gaussianBlur(GaussianBlurFeature(id: FeatureID(rawValue: "blur-a"), radius: 3)),
+                ]
+              )
+            )
+          ),
+          .effect(
+            .exposure(
+              ExposureFeature(id: FeatureID(rawValue: "exposure-a"), value: 0.25)
+            )
+          ),
+          .effect(.contrast(ContrastFeature(id: FeatureID(rawValue: "contrast-a"), value: 0.08))),
+          .effect(.saturation(SaturationFeature(id: FeatureID(rawValue: "saturation-a"), value: 0.12))),
+          .effect(.highlights(HighlightsFeature(id: FeatureID(rawValue: "highlights-a"), value: 0.2))),
+          .effect(.shadows(ShadowsFeature(id: FeatureID(rawValue: "shadows-a"), value: 0.15))),
+          .effect(
+            .highlightShadowTint(
+              HighlightShadowTintFeature(
+                id: FeatureID(rawValue: "highlight-shadow-tint-a"),
+                highlightColor: ParametricRGBAColor(red: 1, green: 0.2, blue: 0.1, alpha: 0.05),
+                shadowColor: ParametricRGBAColor(red: 0.1, green: 0.2, blue: 1, alpha: 0.04)
+              )
+            )
+          ),
+          .effect(.temperature(TemperatureFeature(id: FeatureID(rawValue: "temperature-a"), value: 450))),
+          .effect(.sharpen(SharpenFeature(id: FeatureID(rawValue: "sharpen-a"), sharpness: 0.2, radius: 4))),
+          .effect(.unsharpMask(UnsharpMaskFeature(id: FeatureID(rawValue: "unsharp-a"), intensity: 0.1, radius: 0.25))),
+          .effect(.vignette(VignetteFeature(id: FeatureID(rawValue: "vignette-a"), value: 0.35))),
+          .effect(.fade(FadeFeature(id: FeatureID(rawValue: "fade-a"), intensity: 0.05))),
+        ]
+      )
+    )
+
+    let data = try JSONEncoder().encode(document)
+    let decoded = try JSONDecoder().decode(EditingDocument.self, from: data)
+
+    XCTAssertEqual(decoded, document)
+  }
+
+  func testFeatureDocumentRoundTripAndMatchesEnumDocument() throws {
+    let enumDocument = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            .crop(
+              CropFeature(
+                id: FeatureID(rawValue: "node-crop"),
+                cropRect: CGRect(x: 4, y: 3, width: 36, height: 24)
+              )
+            )
+          ),
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "node-local"),
+              maskTree: MaskTree(
+                root: .feather(
+                  MaskFeather(
+                    id: FeatureID(rawValue: "node-feather"),
+                    input: .brush(
+                      BrushMask(
+                        id: FeatureID(rawValue: "node-brush"),
+                        strokes: [
+                          BrushMaskStroke(
+                            stamps: [CGPoint(x: 16, y: 12)],
+                            brush: BrushMaskBrush(diameter: 14, hardness: 0.6, opacity: 0.8)
+                          ),
+                        ]
+                      )
+                    ),
+                    radius: 2
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  .exposure(ExposureFeature(id: FeatureID(rawValue: "node-local-exposure"), value: 0.5)),
+                ]
+              )
+            )
+          ),
+          .effect(.brightness(BrightnessFeature(id: FeatureID(rawValue: "node-brightness"), value: 0.05))),
+        ]
+      )
+    )
+    let featureDocument = try FeatureDocument(editingDocument: enumDocument)
+    let data = try JSONEncoder().encode(featureDocument)
+    let decoded = try JSONDecoder().decode(FeatureDocument.self, from: data)
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 48, height: 36)
+    )
+
+    let enumOutput = try Self.compiler.makeOutput(from: input, document: enumDocument)
+    let featureOutput = try Self.compiler.makeOutput(from: input, document: decoded)
+
+    XCTAssertEqual(decoded, featureDocument)
+    try Self.assertImagesMatch(
+      enumOutput.image,
+      featureOutput.image,
+      tolerance: 2
+    )
+  }
+
+  func testCustomRegistryFeatureRendersLikeDefaultFeatures() throws {
+    var registry = FeatureRegistry.brightroomDefault
+    registry.registerImageEffect(TestRedBoostFeature.self)
+    let compiler = FeatureGraphCompiler(featureRegistry: registry)
+    let customFeature = try FeatureNode(
+      TestRedBoostFeature.self,
+      id: FeatureID(rawValue: "custom-red-boost"),
+      payload: TestRedBoostFeature.Payload(amount: 0.25)
+    )
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .effect(customFeature),
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Brightness.self,
+              id: FeatureID(rawValue: "registry-brightness"),
+              payload: .init(value: 0.02)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 32, height: 24)
+    )
+    let expected = input
+      .applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+          "inputBiasVector": CIVector(x: 0.25, y: 0, z: 0, w: 0),
+        ]
+      )
+      .cropped(to: input.extent)
+      .applyingFilter(
+        "CIColorControls",
+        parameters: ["inputBrightness": 0.02]
+      )
+      .cropped(to: input.extent)
+
+    let data = try JSONEncoder().encode(document)
+    let decoded = try JSONDecoder().decode(FeatureDocument.self, from: data)
+    let output = try compiler.makeOutput(from: input, document: decoded)
+
+    try Self.assertImagesMatch(
+      expected,
+      output.image,
+      tolerance: 2
+    )
+  }
+
+  func testParametricImageRendererMatchesFeatureGraphCompiler() throws {
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Brightness.self,
+              id: FeatureID(rawValue: "image-renderer-brightness"),
+              payload: .init(value: 0.05)
+            )
+          ),
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Saturation.self,
+              id: FeatureID(rawValue: "image-renderer-saturation"),
+              payload: .init(value: 0.12)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 36, height: 24)
+    )
+    let expected = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let output = try ParametricImageRenderer().makeImage(
+      from: input,
+      document: document
+    )
+
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  func testVideoFrameRendererMatchesFeatureDocumentRendering() throws {
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Exposure.self,
+              id: FeatureID(rawValue: "video-exposure"),
+              payload: .init(value: 0.4)
+            )
+          ),
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Brightness.self,
+              id: FeatureID(rawValue: "video-brightness"),
+              payload: .init(value: 0.04)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 44, height: 30)
+    )
+    let expected = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let output = try ParametricVideoRenderer().makeFrameImage(
+      from: input,
+      document: document
+    )
+
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  func testVideoRendererResolvesCropOutputRenderSize() throws {
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .domain(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Crop.self,
+              id: FeatureID(rawValue: "video-crop"),
+              payload: .init(cropRect: CGRect(x: 8, y: 6, width: 24, height: 18))
+            )
+          ),
+        ]
+      )
+    )
+
+    let renderSize = try ParametricVideoRenderer().resolveRenderSize(
+      sourceRenderSize: CGSize(width: 48, height: 36),
+      document: document,
+      mode: .featureOutput
+    )
+
+    XCTAssertEqual(renderSize, CGSize(width: 24, height: 18))
+  }
+
+  func testVideoRendererCreatesVideoComposition() throws {
+    let assetSize = CGSize(width: 48, height: 36)
+    let asset = try Self.makeTestVideoAsset(size: assetSize)
+    defer {
+      try? FileManager.default.removeItem(at: asset.url)
+    }
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Brightness.self,
+              id: FeatureID(rawValue: "video-composition-brightness"),
+              payload: .init(value: 0.03)
+            )
+          ),
+        ]
+      )
+    )
+
+    let composition = try ParametricVideoRenderer().makeVideoComposition(
+      for: asset,
+      document: document,
+      renderSizeMode: .source
+    )
+
+    XCTAssertEqual(composition.renderSize, assetSize)
+  }
+
+  func testVideoFrameRendererPlacesOutputInsideRenderExtent() throws {
+    let document = FeatureDocument(
+      mainTree: FeatureMainTree(
+        features: [
+          .domain(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Crop.self,
+              id: FeatureID(rawValue: "video-crop-place"),
+              payload: .init(cropRect: CGRect(x: 8, y: 6, width: 24, height: 18))
+            )
+          ),
+          .effect(
+            try FeatureNode(
+              BrightroomFeatureDefinitions.Brightness.self,
+              id: FeatureID(rawValue: "video-crop-brightness"),
+              payload: .init(value: 0.05)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 48, height: 36)
+    )
+    let renderExtent = CGRect(x: 0, y: 0, width: 48, height: 36)
+    let featureOutput = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let expected = featureOutput
+      .composited(
+        over: CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+          .cropped(to: renderExtent)
+      )
+      .cropped(to: renderExtent)
+    let output = try ParametricVideoRenderer().makeFrameImage(
+      from: input,
+      document: document,
+      renderExtent: renderExtent
+    )
+
+    XCTAssertEqual(output.extent, renderExtent)
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  func testMultipleCropsEvaluateInCurrentDomain() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            .crop(
+              CropFeature(
+                id: FeatureID(rawValue: "crop-a"),
+                cropRect: CGRect(x: 10, y: 10, width: 80, height: 80)
+              )
+            )
+          ),
+          .domain(
+            .crop(
+              CropFeature(
+                id: FeatureID(rawValue: "crop-b"),
+                cropRect: CGRect(x: 20, y: 20, width: 25, height: 30)
+              )
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricTestImage(
+      white: 1,
+      extent: CGRect(x: 0, y: 0, width: 100, height: 100)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    XCTAssertEqual(output.image.extent, CGRect(x: 0, y: 0, width: 25, height: 30))
+  }
+
+  func testLocalAdjustmentsAndGlobalEffectEvaluateInOrder() throws {
+    let localExposure = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "local-exposure"),
+      maskTree: MaskTree(
+        root: .brush(
+          BrushMask(
+            id: FeatureID(rawValue: "exposure-mask"),
+            strokes: [
+              BrushMaskStroke(
+                stamps: [CGPoint(x: 10, y: 10)],
+                brush: BrushMaskBrush(diameter: 16, hardness: 1, opacity: 1)
+              ),
+            ]
+          )
+        )
+      ),
+      effectPipeline: EffectPipeline(
+        effects: [
+          .exposure(ExposureFeature(id: FeatureID(rawValue: "local-exposure-effect"), value: 1)),
+        ]
+      )
+    )
+    let localBlur = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "local-blur"),
+      maskTree: MaskTree(
+        root: .brush(
+          BrushMask(
+            id: FeatureID(rawValue: "blur-mask"),
+            strokes: [
+              BrushMaskStroke(
+                stamps: [CGPoint(x: 20, y: 10)],
+                brush: BrushMaskBrush(diameter: 18, hardness: 1, opacity: 1)
+              ),
+            ]
+          )
+        )
+      ),
+      effectPipeline: EffectPipeline(
+        effects: [
+          .gaussianBlur(GaussianBlurFeature(id: FeatureID(rawValue: "blur-effect"), radius: 5)),
+        ]
+      )
+    )
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(localExposure),
+          .localAdjustment(localBlur),
+          .effect(.brightness(BrightnessFeature(id: FeatureID(rawValue: "global-brightness"), value: 0.05))),
+        ]
+      )
+    )
+    let input = CIImage.parametricVerticalStripeImage(
+      extent: CGRect(x: 0, y: 0, width: 40, height: 20),
+      backgroundWhite: 0.15,
+      stripeWhite: 0.9,
+      stripeRect: CGRect(x: 22, y: 0, width: 2, height: 20)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+    let renderedImage = try Self.render(output.image)
+    let localPixel = Self.rgba(in: renderedImage, x: 10, y: 10)
+    let outsidePixel = Self.rgba(in: renderedImage, x: 0, y: 10)
+    let blurredNeighborPixel = Self.rgba(in: renderedImage, x: 19, y: 10)
+    let stripePixel = Self.rgba(in: renderedImage, x: 22, y: 10)
+
+    XCTAssertGreaterThan(localPixel.red, outsidePixel.red)
+    XCTAssertGreaterThan(blurredNeighborPixel.red, outsidePixel.red)
+    XCTAssertLessThan(blurredNeighborPixel.red, stripePixel.red)
+  }
+
+  func testEditingStackFiltersBridgeMatchesLegacyFilterRendering() throws {
+    var filters = EditingStack.Edit.Filters()
+    filters.exposure = {
+      var filter = FilterExposure()
+      filter.value = 0.15
+      return filter
+    }()
+    filters.brightness = {
+      var filter = FilterBrightness()
+      filter.value = 0.03
+      return filter
+    }()
+    filters.temperature = {
+      var filter = FilterTemperature()
+      filter.value = 600
+      return filter
+    }()
+    filters.highlights = {
+      var filter = FilterHighlights()
+      filter.value = 0.2
+      return filter
+    }()
+    filters.shadows = {
+      var filter = FilterShadows()
+      filter.value = 0.15
+      return filter
+    }()
+    filters.saturation = {
+      var filter = FilterSaturation()
+      filter.value = 0.08
+      return filter
+    }()
+    filters.contrast = {
+      var filter = FilterContrast()
+      filter.value = 0.04
+      return filter
+    }()
+    filters.sharpen = {
+      var filter = FilterSharpen()
+      filter.sharpness = 0.2
+      filter.radius = 4
+      return filter
+    }()
+    filters.unsharpMask = {
+      var filter = FilterUnsharpMask()
+      filter.intensity = 0.1
+      filter.radius = 0.3
+      return filter
+    }()
+    filters.gaussianBlur = {
+      var filter = FilterGaussianBlur()
+      filter.value = 3
+      return filter
+    }()
+    filters.fade = {
+      var filter = FilterFade()
+      filter.intensity = 0.04
+      return filter
+    }()
+    filters.vignette = {
+      var filter = FilterVignette()
+      filter.value = 0.3
+      return filter
+    }()
+
+    let pipeline = try EffectPipeline(
+      editingStackFilters: filters,
+      idPrefix: "legacy-filter"
+    )
+    let document = EditingDocument(
+      mainTree: MainTree(features: pipeline.effects.map(MainFeature.effect))
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 80, height: 60)
+    )
+
+    let legacyImage = filters.apply(to: input)
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    try Self.assertImagesMatch(
+      legacyImage,
+      output.image,
+      tolerance: 2
+    )
+
+    let featurePipeline = try FeatureEffectPipeline(
+      editingStackFilters: filters,
+      idPrefix: "legacy-feature-node-filter"
+    )
+    let featureDocument = FeatureDocument(
+      mainTree: FeatureMainTree(features: featurePipeline.effects.map(FeatureTreeNode.effect))
+    )
+    let featureOutput = try Self.compiler.makeOutput(from: input, document: featureDocument)
+
+    try Self.assertImagesMatch(
+      legacyImage,
+      featureOutput.image,
+      tolerance: 2
+    )
+  }
+
+  func testPresetAndAdditionalFiltersBridgeWhenFiltersAreBuiltIn() throws {
+    var colorCube = FilterColorCube(
+      name: "Test Cube",
+      identifier: "test-cube",
+      cubeData: Self.makeColorCubeData(dimension: 2),
+      dimension: 2
+    )
+    colorCube.amount = 0.5
+    let preset = FilterPreset(
+      name: "Preset",
+      identifier: "preset",
+      filters: [colorCube.asAny()],
+      userInfo: [:]
+    )
+    var additionalFade = FilterFade()
+    additionalFade.intensity = 0.1
+    var additionalTint = FilterHighlightShadowTint()
+    additionalTint.highlightColor = CIColor(red: 1, green: 0.2, blue: 0.1, alpha: 0.05)
+    additionalTint.shadowColor = CIColor(red: 0.1, green: 0.2, blue: 1, alpha: 0.04)
+
+    var filters = EditingStack.Edit.Filters()
+    filters.preset = preset
+    filters.additionalFilters = [additionalFade.asAny(), additionalTint.asAny()]
+
+    let pipeline = try EffectPipeline(
+      editingStackFilters: filters,
+      idPrefix: "preset-filter"
+    )
+    let document = EditingDocument(
+      mainTree: MainTree(features: pipeline.effects.map(MainFeature.effect))
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 32, height: 32)
+    )
+
+    let legacyImage = filters.apply(to: input)
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    try Self.assertImagesMatch(
+      legacyImage,
+      output.image,
+      tolerance: 2
+    )
+
+    let featurePipeline = try FeatureEffectPipeline(
+      editingStackFilters: filters,
+      idPrefix: "preset-feature-node-filter"
+    )
+    let featureDocument = FeatureDocument(
+      mainTree: FeatureMainTree(features: featurePipeline.effects.map(FeatureTreeNode.effect))
+    )
+    let featureOutput = try Self.compiler.makeOutput(from: input, document: featureDocument)
+
+    try Self.assertImagesMatch(
+      legacyImage,
+      featureOutput.image,
+      tolerance: 2
+    )
+  }
+
+  func testInvertedMaskAppliesOutsideBrush() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "local-invert"),
+              maskTree: MaskTree(
+                root: .invert(
+                  .brush(
+                    BrushMask(
+                      id: FeatureID(rawValue: "center-mask"),
+                      strokes: [
+                        BrushMaskStroke(
+                          stamps: [CGPoint(x: 10, y: 10)],
+                          brush: BrushMaskBrush(diameter: 12, hardness: 1, opacity: 1)
+                        ),
+                      ]
+                    )
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  .exposure(ExposureFeature(id: FeatureID(rawValue: "invert-exposure"), value: 1)),
+                ]
+              )
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricTestImage(
+      white: 0.2,
+      extent: CGRect(x: 0, y: 0, width: 20, height: 20)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+    let renderedImage = try Self.render(output.image)
+    let center = Self.rgba(in: renderedImage, x: 10, y: 10)
+    let corner = Self.rgba(in: renderedImage, x: 1, y: 1)
+
+    XCTAssertGreaterThan(corner.red, center.red)
+  }
+
+  func testDuplicateIDsThrowValidationError() throws {
+    let id = FeatureID(rawValue: "duplicate")
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(.brightness(BrightnessFeature(id: id, value: 0.1))),
+          .effect(.exposure(ExposureFeature(id: id, value: 0.1))),
+        ]
+      )
+    )
+
+    XCTAssertThrowsError(
+      try Self.compiler.makeOutput(from: Self.smallInput, document: document)
+    ) { error in
+      XCTAssertEqual(error as? FeatureGraphCompilerError, .duplicateID(id))
+    }
+  }
+
+  func testEmptyLocalAdjustmentPipelineThrowsValidationError() throws {
+    let id = FeatureID(rawValue: "empty-local")
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: id,
+              maskTree: MaskTree(root: .brush(BrushMask(id: FeatureID(rawValue: "mask")))),
+              effectPipeline: EffectPipeline()
+            )
+          ),
+        ]
+      )
+    )
+
+    XCTAssertThrowsError(
+      try Self.compiler.makeOutput(from: Self.smallInput, document: document)
+    ) { error in
+      XCTAssertEqual(error as? FeatureGraphCompilerError, .emptyLocalAdjustmentEffectPipeline(id))
+    }
+  }
+
+  func testMetalKernelRegistryCanCreateBrushStampRecipe() throws {
+    let registry = ParametricKernelRegistry()
+
+    let image = try registry.makeBrushStamp(
+      extent: CGRect(x: 0, y: 0, width: 12, height: 12),
+      center: CGPoint(x: 6, y: 6),
+      radius: 4,
+      hardness: 0.5,
+      opacity: 1
+    )
+
+    XCTAssertEqual(image.extent, CGRect(x: 0, y: 0, width: 12, height: 12))
+  }
+
+  private static let compiler = FeatureGraphCompiler()
+
+  private static let smallInput = CIImage.parametricTestImage(
+    white: 0.5,
+    extent: CGRect(x: 0, y: 0, width: 8, height: 8)
+  )
+
+  private static let context = CIContext()
+
+  private static func render(_ image: CIImage) throws -> CGImage {
+    try XCTUnwrap(Self.context.createCGImage(image, from: image.extent))
+  }
+
+  private static func rgba(in image: CGImage, x: Int, y: Int) -> RGBA {
+    let width = image.width
+    let height = image.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context = CGContext(
+      data: &pixels,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: colorSpace,
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        | CGBitmapInfo.byteOrder32Big.rawValue
+    )!
+
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    let index = (y * width + x) * 4
+    return RGBA(
+      red: pixels[index],
+      green: pixels[index + 1],
+      blue: pixels[index + 2],
+      alpha: pixels[index + 3]
+    )
+  }
+
+  private static func assertImagesMatch(
+    _ lhs: CIImage,
+    _ rhs: CIImage,
+    tolerance: Int,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) throws {
+    XCTAssertEqual(lhs.extent, rhs.extent, file: file, line: line)
+
+    let lhsImage = try render(lhs)
+    let rhsImage = try render(rhs)
+    XCTAssertEqual(lhsImage.width, rhsImage.width, file: file, line: line)
+    XCTAssertEqual(lhsImage.height, rhsImage.height, file: file, line: line)
+
+    let sampleXs = [4, lhsImage.width / 3, lhsImage.width / 2, max(lhsImage.width - 5, 0)]
+    let sampleYs = [4, lhsImage.height / 3, lhsImage.height / 2, max(lhsImage.height - 5, 0)]
+
+    for y in sampleYs {
+      for x in sampleXs {
+        let lhsPixel = rgba(in: lhsImage, x: x, y: y)
+        let rhsPixel = rgba(in: rhsImage, x: x, y: y)
+        XCTAssertLessThanOrEqual(
+          abs(Int(lhsPixel.red) - Int(rhsPixel.red)),
+          tolerance,
+          "red mismatch at \(x),\(y)",
+          file: file,
+          line: line
+        )
+        XCTAssertLessThanOrEqual(
+          abs(Int(lhsPixel.green) - Int(rhsPixel.green)),
+          tolerance,
+          "green mismatch at \(x),\(y)",
+          file: file,
+          line: line
+        )
+        XCTAssertLessThanOrEqual(
+          abs(Int(lhsPixel.blue) - Int(rhsPixel.blue)),
+          tolerance,
+          "blue mismatch at \(x),\(y)",
+          file: file,
+          line: line
+        )
+        XCTAssertLessThanOrEqual(
+          abs(Int(lhsPixel.alpha) - Int(rhsPixel.alpha)),
+          tolerance,
+          "alpha mismatch at \(x),\(y)",
+          file: file,
+          line: line
+        )
+      }
+    }
+  }
+
+  private static func makeColorCubeData(dimension: Int) -> Data {
+    var values: [Float] = []
+    values.reserveCapacity(dimension * dimension * dimension * 4)
+
+    for blueIndex in 0..<dimension {
+      for greenIndex in 0..<dimension {
+        for redIndex in 0..<dimension {
+          let denominator = Float(max(dimension - 1, 1))
+          let red = Float(redIndex) / denominator
+          let green = Float(greenIndex) / denominator
+          let blue = Float(blueIndex) / denominator
+
+          values.append(1 - red)
+          values.append(green)
+          values.append(blue * 0.6)
+          values.append(1)
+        }
+      }
+    }
+
+    return values.withUnsafeBufferPointer { buffer in
+      Data(
+        bytes: buffer.baseAddress!,
+        count: buffer.count * MemoryLayout<Float>.size
+      )
+    }
+  }
+
+  private static func makeTestVideoAsset(size: CGSize) throws -> AVURLAsset {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("brightroom-parametric-\(UUID().uuidString)")
+      .appendingPathExtension("mov")
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+    let input = AVAssetWriterInput(
+      mediaType: .video,
+      outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: Int(size.width),
+        AVVideoHeightKey: Int(size.height),
+      ]
+    )
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: Int(size.width),
+        kCVPixelBufferHeightKey as String: Int(size.height),
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ]
+    )
+
+    guard writer.canAdd(input) else {
+      throw TestVideoAssetError.cannotAddInput
+    }
+
+    writer.add(input)
+
+    guard writer.startWriting() else {
+      throw writer.error ?? TestVideoAssetError.cannotStartWriting
+    }
+
+    writer.startSession(atSourceTime: .zero)
+
+    let pixelBuffer = try makeTestPixelBuffer(
+      width: Int(size.width),
+      height: Int(size.height)
+    )
+    while !input.isReadyForMoreMediaData {
+      RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+    }
+
+    guard adaptor.append(pixelBuffer, withPresentationTime: .zero) else {
+      throw writer.error ?? TestVideoAssetError.cannotAppendFrame
+    }
+
+    input.markAsFinished()
+
+    let semaphore = DispatchSemaphore(value: 0)
+    writer.finishWriting {
+      semaphore.signal()
+    }
+    semaphore.wait()
+
+    guard writer.status == .completed else {
+      throw writer.error ?? TestVideoAssetError.cannotFinishWriting(writer.status)
+    }
+
+    return AVURLAsset(url: url)
+  }
+
+  private static func makeTestPixelBuffer(width: Int, height: Int) throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let result = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_32BGRA,
+      [
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ] as CFDictionary,
+      &pixelBuffer
+    )
+
+    guard result == kCVReturnSuccess, let pixelBuffer else {
+      throw TestVideoAssetError.cannotCreatePixelBuffer(result)
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, [])
+    defer {
+      CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+    }
+
+    guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+      throw TestVideoAssetError.missingPixelBufferBaseAddress
+    }
+
+    let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+
+    for y in 0..<height {
+      let row = baseAddress
+        .advanced(by: y * bytesPerRow)
+        .assumingMemoryBound(to: UInt8.self)
+
+      for x in 0..<width {
+        let offset = x * 4
+        row[offset] = UInt8(80 + (x % 24))
+        row[offset + 1] = UInt8(100 + (y % 32))
+        row[offset + 2] = UInt8(160)
+        row[offset + 3] = UInt8(255)
+      }
+    }
+
+    return pixelBuffer
+  }
+
+  private struct RGBA: Equatable {
+    var red: UInt8
+    var green: UInt8
+    var blue: UInt8
+    var alpha: UInt8
+  }
+
+  private enum TestRedBoostFeature: ImageEffectFeatureDefinition {
+
+    static let typeID: FeatureTypeID = "test.effect.redBoost"
+    static let currentSchemaVersion = 1
+
+    struct Payload: Codable, Equatable, Sendable {
+      var amount: Double
+    }
+
+    static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+          "inputBiasVector": CIVector(x: CGFloat(payload.amount), y: 0, z: 0, w: 0),
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  private enum TestVideoAssetError: Error {
+    case cannotAddInput
+    case cannotStartWriting
+    case cannotAppendFrame
+    case cannotFinishWriting(AVAssetWriter.Status)
+    case cannotCreatePixelBuffer(CVReturn)
+    case missingPixelBufferBaseAddress
+  }
+}
+
+private extension CIImage {
+
+  static func parametricTestImage(white: CGFloat, extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: white, green: white, blue: white, alpha: 1))
+      .cropped(to: extent)
+  }
+
+  static func parametricVerticalStripeImage(
+    extent: CGRect,
+    backgroundWhite: CGFloat,
+    stripeWhite: CGFloat,
+    stripeRect: CGRect
+  ) -> CIImage {
+    let background = CIImage.parametricTestImage(
+      white: backgroundWhite,
+      extent: extent
+    )
+    let stripe = CIImage.parametricTestImage(white: stripeWhite, extent: stripeRect)
+
+    return stripe.applyingFilter(
+      "CISourceOverCompositing",
+      parameters: [kCIInputBackgroundImageKey: background]
+    )
+    .cropped(to: extent)
+  }
+
+  static func parametricColorPatchImage(extent: CGRect) -> CIImage {
+    let background = CIImage(color: CIColor(red: 0.18, green: 0.32, blue: 0.52, alpha: 1))
+      .cropped(to: extent)
+    let warmPatch = CIImage(color: CIColor(red: 0.86, green: 0.26, blue: 0.18, alpha: 0.82))
+      .cropped(
+        to: CGRect(
+          x: extent.minX + extent.width * 0.18,
+          y: extent.minY,
+          width: extent.width * 0.22,
+          height: extent.height
+        )
+      )
+    let coolPatch = CIImage(color: CIColor(red: 0.16, green: 0.45, blue: 0.92, alpha: 0.78))
+      .cropped(
+        to: CGRect(
+          x: extent.minX + extent.width * 0.56,
+          y: extent.minY,
+          width: extent.width * 0.28,
+          height: extent.height
+        )
+      )
+    let brightPatch = CIImage(color: CIColor(red: 0.95, green: 0.92, blue: 0.76, alpha: 0.65))
+      .cropped(
+        to: CGRect(
+          x: extent.minX,
+          y: extent.minY + extent.height * 0.2,
+          width: extent.width,
+          height: extent.height * 0.3
+        )
+      )
+
+    return [warmPatch, coolPatch, brightPatch].reduce(background) { image, patch in
+      patch.applyingFilter(
+        "CISourceOverCompositing",
+        parameters: [kCIInputBackgroundImageKey: image]
+      )
+    }
+    .cropped(to: extent)
+  }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,11 @@ import PackageDescription
 let package = Package(
   name: "Brightroom",
   platforms: [
-    .iOS(.v17)
+    .iOS(.v17),
+    .macOS(.v14),
   ],
   products: [
+    .library(name: "BrightroomParametric", targets: ["BrightroomParametric"]),
     .library(name: "BrightroomEngine", targets: ["BrightroomEngine"]),
     .library(name: "BrightroomUI", targets: ["BrightroomUI"]),
   ],
@@ -16,8 +18,12 @@ let package = Package(
   ],
   targets: [
     .target(
+      name: "BrightroomParametric"
+    ),
+    .target(
       name: "BrightroomEngine",
       dependencies: [
+        "BrightroomParametric",
         .product(name: "StateGraph", package: "swift-state-graph"),
       ]
     ),

--- a/Sources/BrightroomEngine/Filter/FilterVignette.swift
+++ b/Sources/BrightroomEngine/Filter/FilterVignette.swift
@@ -33,14 +33,22 @@ public struct FilterVignette: Filtering, Equatable, Codable, Sendable {
     
   public func apply(to image: CIImage, sourceImage: CIImage) -> CIImage {
 
-    let radius = RadiusCalculator.radius(value: value, max: FilterVignette.range.max, imageExtent: image.extent)
+    guard abs(value) > 0.0001 else {
+      return image
+    }
 
-    return
-      image.applyingFilter(
-        "CIVignette",
-        parameters: [
-          kCIInputRadiusKey: radius as AnyObject,
-          kCIInputIntensityKey: value as AnyObject,
-        ])
+    let extent = image.extent
+    let radius = max(extent.width, extent.height) * 0.5
+
+    return image.applyingFilter(
+      "CIVignetteEffect",
+      parameters: [
+        kCIInputCenterKey: CIVector(x: extent.midX, y: extent.midY),
+        kCIInputRadiusKey: radius,
+        kCIInputIntensityKey: value,
+        "inputFalloff": 0.5,
+      ]
+    )
+    .cropped(to: extent)
   }
 }

--- a/Sources/BrightroomEngine/Parametric/EditingStackParametricBridge.swift
+++ b/Sources/BrightroomEngine/Parametric/EditingStackParametricBridge.swift
@@ -1,0 +1,352 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+import BrightroomParametric
+
+/// Errors thrown while converting legacy `EditingStack.Edit.Filters` into
+/// parametric effect features.
+public enum ParametricEditingStackBridgeError: Error, Equatable, Sendable {
+
+  /// The bridge found an `AnyFilter` whose concrete type has no parametric
+  /// representation.
+  case unsupportedFilter(String)
+
+  /// The bridge could not serialize an image-backed color cube into cube data.
+  case failedToCreateColorCubeData(identifier: String, message: String)
+}
+
+public extension EffectPipeline {
+
+  /// Creates an effect pipeline from the filters supported by
+  /// `EditingStack.Edit.Filters`.
+  ///
+  /// The conversion preserves Brightroom's legacy filter order. `preset` and
+  /// `additionalFilters` are supported when their `AnyFilter` values contain
+  /// built-in Brightroom filters. Unknown custom `AnyFilter` values throw
+  /// `ParametricEditingStackBridgeError.unsupportedFilter`.
+  init(
+    editingStackFilters filters: EditingStack.Edit.Filters,
+    idPrefix: String = "editing-stack-filter"
+  ) throws {
+    self.init(
+      effects: try ImageEffectFeature.makeFeatures(
+        editingStackFilters: filters,
+        idPrefix: idPrefix
+      )
+    )
+  }
+}
+
+public extension FeatureEffectPipeline {
+
+  /// Creates a registry-backed effect pipeline from the filters supported by
+  /// `EditingStack.Edit.Filters`.
+  ///
+  /// The returned nodes use the same ordering as
+  /// `EditingStack.Edit.Filters.makeFilters()`.
+  init(
+    editingStackFilters filters: EditingStack.Edit.Filters,
+    idPrefix: String = "editing-stack-filter"
+  ) throws {
+    self.init(
+      effects: try ImageEffectFeature
+        .makeFeatures(editingStackFilters: filters, idPrefix: idPrefix)
+        .map(FeatureNode.init(imageEffect:))
+    )
+  }
+}
+
+public extension ImageEffectFeature {
+
+  /// Creates parametric effects from the filters supported by
+  /// `EditingStack.Edit.Filters`.
+  ///
+  /// The returned effects use the same ordering as
+  /// `EditingStack.Edit.Filters.makeFilters()`.
+  static func makeFeatures(
+    editingStackFilters filters: EditingStack.Edit.Filters,
+    idPrefix: String = "editing-stack-filter"
+  ) throws -> [ImageEffectFeature] {
+    var idFactory = ParametricFeatureIDFactory(prefix: idPrefix)
+    var effects: [ImageEffectFeature] = []
+
+    if let preset = filters.preset {
+      effects.append(
+        try makeFeature(
+          preset: preset,
+          id: idFactory.next("preset"),
+          idFactory: &idFactory
+        )
+      )
+    }
+
+    if let filter = filters.exposure {
+      effects.append(.exposure(ExposureFeature(id: idFactory.next("exposure"), value: filter.value)))
+    }
+
+    if let filter = filters.brightness {
+      effects.append(.brightness(BrightnessFeature(id: idFactory.next("brightness"), value: filter.value)))
+    }
+
+    if let filter = filters.temperature {
+      effects.append(.temperature(TemperatureFeature(id: idFactory.next("temperature"), value: filter.value)))
+    }
+
+    if let filter = filters.highlights {
+      effects.append(.highlights(HighlightsFeature(id: idFactory.next("highlights"), value: filter.value)))
+    }
+
+    if let filter = filters.shadows {
+      effects.append(.shadows(ShadowsFeature(id: idFactory.next("shadows"), value: filter.value)))
+    }
+
+    if let filter = filters.saturation {
+      effects.append(.saturation(SaturationFeature(id: idFactory.next("saturation"), value: filter.value)))
+    }
+
+    if let filter = filters.contrast {
+      effects.append(.contrast(ContrastFeature(id: idFactory.next("contrast"), value: filter.value)))
+    }
+
+    if let filter = filters.sharpen {
+      effects.append(
+        .sharpen(
+          SharpenFeature(
+            id: idFactory.next("sharpen"),
+            sharpness: filter.sharpness,
+            radius: filter.radius
+          )
+        )
+      )
+    }
+
+    if let filter = filters.unsharpMask {
+      effects.append(
+        .unsharpMask(
+          UnsharpMaskFeature(
+            id: idFactory.next("unsharp-mask"),
+            intensity: filter.intensity,
+            radius: filter.radius
+          )
+        )
+      )
+    }
+
+    if let filter = filters.gaussianBlur {
+      effects.append(
+        .gaussianBlur(
+          GaussianBlurFeature(
+            id: idFactory.next("gaussian-blur"),
+            value: filter.value
+          )
+        )
+      )
+    }
+
+    if let filter = filters.fade {
+      effects.append(.fade(FadeFeature(id: idFactory.next("fade"), intensity: filter.intensity)))
+    }
+
+    if let filter = filters.vignette {
+      effects.append(.vignette(VignetteFeature(id: idFactory.next("vignette"), value: filter.value)))
+    }
+
+    for filter in filters.additionalFilters {
+      effects.append(
+        try makeFeature(
+          anyFilter: filter,
+          idFactory: &idFactory
+        )
+      )
+    }
+
+    return effects
+  }
+}
+
+public extension ColorCubeFeature {
+
+  /// Creates a parametric color-cube feature from Brightroom's existing
+  /// `FilterColorCube`.
+  ///
+  /// Image-backed LUTs are serialized to cube data during conversion. Rendering
+  /// then uses the stored data directly and does not materialize a CGImage.
+  init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    filter: FilterColorCube
+  ) throws {
+    let cubeData: Data
+    switch filter.lookupTable {
+    case let .cubeData(data, _):
+      cubeData = data
+    case let .image(imageSource, dimension):
+      do {
+        cubeData = try ColorCubeHelper.createColorCubeData(
+          inputImage: imageSource.loadOriginalCGImage(),
+          cubeDimension: dimension
+        )
+      } catch {
+        throw ParametricEditingStackBridgeError.failedToCreateColorCubeData(
+          identifier: filter.identifier,
+          message: String(describing: error)
+        )
+      }
+    }
+
+    self.init(
+      id: id,
+      isEnabled: isEnabled,
+      name: filter.name,
+      identifier: filter.identifier,
+      amount: filter.amount,
+      dimension: filter.dimension,
+      cubeData: cubeData
+    )
+  }
+}
+
+private extension ImageEffectFeature {
+
+  static func makeFeature(
+    anyFilter: AnyFilter,
+    idFactory: inout ParametricFeatureIDFactory
+  ) throws -> ImageEffectFeature {
+    let base = anyFilter.base.base
+
+    switch base {
+    case let filter as FilterPreset:
+      return try makeFeature(
+        preset: filter,
+        id: idFactory.next("preset"),
+        idFactory: &idFactory
+      )
+    case let filter as FilterColorCube:
+      return .colorCube(
+        try ColorCubeFeature(
+          id: idFactory.next("color-cube"),
+          filter: filter
+        )
+      )
+    case let filter as FilterExposure:
+      return .exposure(ExposureFeature(id: idFactory.next("exposure"), value: filter.value))
+    case let filter as FilterBrightness:
+      return .brightness(BrightnessFeature(id: idFactory.next("brightness"), value: filter.value))
+    case let filter as FilterTemperature:
+      return .temperature(TemperatureFeature(id: idFactory.next("temperature"), value: filter.value))
+    case let filter as FilterHighlights:
+      return .highlights(HighlightsFeature(id: idFactory.next("highlights"), value: filter.value))
+    case let filter as FilterShadows:
+      return .shadows(ShadowsFeature(id: idFactory.next("shadows"), value: filter.value))
+    case let filter as FilterHighlightShadowTint:
+      return .highlightShadowTint(
+        HighlightShadowTintFeature(
+          id: idFactory.next("highlight-shadow-tint"),
+          highlightColor: ParametricRGBAColor(color: filter.highlightColor),
+          shadowColor: ParametricRGBAColor(color: filter.shadowColor)
+        )
+      )
+    case let filter as FilterSaturation:
+      return .saturation(SaturationFeature(id: idFactory.next("saturation"), value: filter.value))
+    case let filter as FilterContrast:
+      return .contrast(ContrastFeature(id: idFactory.next("contrast"), value: filter.value))
+    case let filter as FilterSharpen:
+      return .sharpen(
+        SharpenFeature(
+          id: idFactory.next("sharpen"),
+          sharpness: filter.sharpness,
+          radius: filter.radius
+        )
+      )
+    case let filter as FilterUnsharpMask:
+      return .unsharpMask(
+        UnsharpMaskFeature(
+          id: idFactory.next("unsharp-mask"),
+          intensity: filter.intensity,
+          radius: filter.radius
+        )
+      )
+    case let filter as FilterGaussianBlur:
+      return .gaussianBlur(
+        GaussianBlurFeature(
+          id: idFactory.next("gaussian-blur"),
+          value: filter.value
+        )
+      )
+    case let filter as FilterFade:
+      return .fade(FadeFeature(id: idFactory.next("fade"), intensity: filter.intensity))
+    case let filter as FilterVignette:
+      return .vignette(VignetteFeature(id: idFactory.next("vignette"), value: filter.value))
+    default:
+      throw ParametricEditingStackBridgeError.unsupportedFilter(
+        String(describing: type(of: base))
+      )
+    }
+  }
+
+  static func makeFeature(
+    preset: FilterPreset,
+    id: FeatureID,
+    idFactory: inout ParametricFeatureIDFactory
+  ) throws -> ImageEffectFeature {
+    let effects = try preset.filters.map { filter in
+      try makeFeature(anyFilter: filter, idFactory: &idFactory)
+    }
+
+    return .preset(
+      PresetFeature(
+        id: id,
+        name: preset.name,
+        identifier: preset.identifier,
+        effects: effects
+      )
+    )
+  }
+}
+
+private extension ParametricRGBAColor {
+
+  init(color: CIColor) {
+    self.init(
+      red: Double(color.red),
+      green: Double(color.green),
+      blue: Double(color.blue),
+      alpha: Double(color.alpha)
+    )
+  }
+}
+
+private struct ParametricFeatureIDFactory {
+
+  var prefix: String
+  private var index = 0
+
+  init(prefix: String) {
+    self.prefix = prefix
+  }
+
+  mutating func next(_ name: String) -> FeatureID {
+    defer { index += 1 }
+    return FeatureID(rawValue: "\(prefix)-\(index)-\(name)")
+  }
+}

--- a/Sources/BrightroomParametric/BrightroomFeatureDefinitions.swift
+++ b/Sources/BrightroomParametric/BrightroomFeatureDefinitions.swift
@@ -568,19 +568,7 @@ public enum BrightroomFeatureDefinitions {
       to image: CIImage,
       context: FeatureEvaluationContext
     ) throws -> CIImage {
-      let radius = ParametricRadiusCalculator.radius(
-        value: payload.value,
-        max: ParametricFilterConstants.vignetteSliderMax,
-        imageExtent: image.extent
-      )
-      return image.applyingFilter(
-        "CIVignette",
-        parameters: [
-          kCIInputRadiusKey: radius,
-          kCIInputIntensityKey: payload.value,
-        ]
-      )
-      .cropped(to: image.extent)
+      ParametricVignetteRenderer.apply(value: payload.value, to: image)
     }
   }
 

--- a/Sources/BrightroomParametric/BrightroomFeatureDefinitions.swift
+++ b/Sources/BrightroomParametric/BrightroomFeatureDefinitions.swift
@@ -1,0 +1,974 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// Brightroom's standard feature definitions.
+///
+/// These definitions are not special document cases. They are registered into
+/// `FeatureRegistry` the same way an app can register its own feature types.
+public enum BrightroomFeatureDefinitions {
+
+  /// Current-domain crop.
+  public enum Crop: DomainFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.domain.crop"
+    public static let currentSchemaVersion = 1
+
+    /// Serialized crop parameters.
+    public struct Payload: Codable, Equatable, Sendable {
+
+      /// The rectangle to keep, expressed in the current domain.
+      public var cropRect: CGRect
+
+      public init(cropRect: CGRect) {
+        self.cropRect = cropRect
+      }
+    }
+
+    public static func validate(payload: Payload, node: FeatureNode) throws {
+      guard payload.cropRect.isParametricValidExtent else {
+        throw FeatureGraphCompilerError.invalidCropRect(node.id, payload.cropRect)
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let cropRect = payload.cropRect
+      let absoluteCropRect = cropRect.offsetBy(
+        dx: image.extent.minX,
+        dy: image.extent.minY
+      )
+      return image
+        .cropped(to: absoluteCropRect)
+        .transformed(
+          by: CGAffineTransform(
+            translationX: -absoluteCropRect.minX,
+            y: -absoluteCropRect.minY
+          )
+        )
+    }
+  }
+
+  /// A named group of extent-preserving image effects.
+  public enum Preset: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.preset"
+    public static let currentSchemaVersion = 1
+
+    /// Serialized preset parameters.
+    public struct Payload: Codable, Equatable, Sendable {
+
+      /// The display name associated with the preset.
+      public var name: String
+
+      /// The stable preset identifier.
+      public var identifier: String
+
+      /// The effect nodes evaluated inside the preset, in order.
+      public var effects: [FeatureNode]
+
+      public init(
+        name: String,
+        identifier: String,
+        effects: [FeatureNode]
+      ) {
+        self.name = name
+        self.identifier = identifier
+        self.effects = effects
+      }
+    }
+
+    public static func childImageEffects(payload: Payload) -> [FeatureNode] {
+      payload.effects
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      try payload.effects.reduce(image) { image, effect in
+        try context.featureRegistry.applyImageEffect(effect, to: image, context: context)
+      }
+    }
+  }
+
+  /// A color-cube lookup-table effect.
+  public enum ColorCube: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.colorCube"
+    public static let currentSchemaVersion = 1
+
+    /// Serialized color-cube parameters.
+    public struct Payload: Codable, Equatable, Sendable {
+
+      /// The display name associated with the lookup table.
+      public var name: String
+
+      /// The stable lookup-table identifier.
+      public var identifier: String
+
+      /// The opacity used when compositing the color-cube result over its input.
+      public var amount: Double
+
+      /// The color-cube dimension.
+      public var dimension: Int
+
+      /// RGBA float cube data in `CIColorCubeWithColorSpace` layout.
+      public var cubeData: Data
+
+      public init(
+        name: String,
+        identifier: String,
+        amount: Double,
+        dimension: Int,
+        cubeData: Data
+      ) {
+        self.name = name
+        self.identifier = identifier
+        self.amount = amount
+        self.dimension = dimension
+        self.cubeData = cubeData
+      }
+    }
+
+    public static func validate(payload: Payload, node: FeatureNode) throws {
+      let expectedByteCount = colorCubeByteCount(dimension: payload.dimension)
+      guard payload.cubeData.count == expectedByteCount else {
+        throw FeatureGraphCompilerError.invalidColorCubeData(
+          node.id,
+          expectedByteCount: expectedByteCount,
+          actualByteCount: payload.cubeData.count
+        )
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let filter = ParametricColorCubeHelper.makeColorCubeFilter(
+        cubeData: payload.cubeData,
+        dimension: payload.dimension,
+        cacheKey: payload.identifier
+      )
+      filter.setValue(image, forKeyPath: kCIInputImageKey)
+
+      guard let filtered = filter.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CIColorCubeWithColorSpace")
+      }
+
+      let foreground = filtered.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: CGFloat(payload.amount)),
+          "inputBiasVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+        ]
+      )
+
+      guard let output = CIFilter(
+        name: "CISourceOverCompositing",
+        parameters: [
+          kCIInputImageKey: foreground,
+          kCIInputBackgroundImageKey: image,
+        ]
+      )?.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+      }
+
+      return output.cropped(to: image.extent)
+    }
+  }
+
+  /// Brightness adjustment.
+  public enum Brightness: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.brightness"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIColorControls",
+        parameters: ["inputBrightness": payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Contrast adjustment.
+  public enum Contrast: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.contrast"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIColorControls",
+        parameters: [kCIInputContrastKey: 1 + payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Saturation adjustment.
+  public enum Saturation: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.saturation"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIColorControls",
+        parameters: [kCIInputSaturationKey: 1 + payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Exposure adjustment.
+  public enum Exposure: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.exposure"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      guard abs(payload.value) > 0.0001 else {
+        return image
+      }
+      return image.applyingFilter(
+        "CIExposureAdjust",
+        parameters: [kCIInputEVKey: payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Highlight recovery adjustment.
+  public enum Highlights: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.highlights"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIHighlightShadowAdjust",
+        parameters: ["inputHighlightAmount": 1 - payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Shadow lift adjustment.
+  public enum Shadows: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.shadows"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CIHighlightShadowAdjust",
+        parameters: ["inputShadowAmount": payload.value]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Highlight and shadow tint overlay.
+  public enum HighlightShadowTint: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.highlightShadowTint"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var highlightColor: ParametricRGBAColor
+      public var shadowColor: ParametricRGBAColor
+      public init(
+        highlightColor: ParametricRGBAColor,
+        shadowColor: ParametricRGBAColor
+      ) {
+        self.highlightColor = highlightColor
+        self.shadowColor = shadowColor
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let shadow = CIImage(color: payload.shadowColor.ciColor)
+        .cropped(to: image.extent)
+      guard let shadowOutput = CIFilter(
+        name: "CISourceOverCompositing",
+        parameters: [
+          kCIInputImageKey: shadow,
+          kCIInputBackgroundImageKey: image,
+        ]
+      )?.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+      }
+
+      let highlight = CIImage(color: payload.highlightColor.ciColor)
+        .cropped(to: image.extent)
+      guard let highlightOutput = CIFilter(
+        name: "CISourceOverCompositing",
+        parameters: [
+          kCIInputImageKey: highlight,
+          kCIInputBackgroundImageKey: shadowOutput,
+        ]
+      )?.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+      }
+
+      return highlightOutput.cropped(to: image.extent)
+    }
+  }
+
+  /// Color temperature adjustment.
+  public enum Temperature: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.temperature"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      image.applyingFilter(
+        "CITemperatureAndTint",
+        parameters: [
+          "inputNeutral": CIVector(x: CGFloat(payload.value) + 6500, y: 0),
+          "inputTargetNeutral": CIVector(x: 6500, y: 0),
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Luminance sharpen adjustment.
+  public enum Sharpen: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.sharpen"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var sharpness: Double
+      public var radius: Double
+      public init(sharpness: Double, radius: Double) {
+        self.sharpness = sharpness
+        self.radius = radius
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let radius = ParametricRadiusCalculator.radius(
+        value: payload.radius,
+        max: ParametricFilterConstants.gaussianBlurSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CISharpenLuminance",
+        parameters: [
+          "inputRadius": radius,
+          "inputSharpness": payload.sharpness,
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Gaussian blur adjustment.
+  public enum GaussianBlur: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.gaussianBlur"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var radius: GaussianBlurRadius
+      public init(radius: GaussianBlurRadius) {
+        self.radius = radius
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let radius = resolve(payload.radius, extent: image.extent)
+      guard radius > 0.0001 else {
+        return image
+      }
+      return image
+        .clamped(to: image.extent)
+        .applyingFilter(
+          "CIGaussianBlur",
+          parameters: [kCIInputRadiusKey: radius]
+        )
+        .cropped(to: image.extent)
+    }
+  }
+
+  /// Unsharp mask adjustment.
+  public enum UnsharpMask: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.unsharpMask"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var intensity: Double
+      public var radius: Double
+      public init(intensity: Double, radius: Double) {
+        self.intensity = intensity
+        self.radius = radius
+      }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let radius = ParametricRadiusCalculator.radius(
+        value: payload.radius,
+        max: ParametricFilterConstants.unsharpMaskRadiusSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CIUnsharpMask",
+        parameters: [
+          "inputIntensity": payload.intensity,
+          "inputRadius": radius,
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Vignette adjustment.
+  public enum Vignette: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.vignette"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var value: Double
+      public init(value: Double) { self.value = value }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let radius = ParametricRadiusCalculator.radius(
+        value: payload.value,
+        max: ParametricFilterConstants.vignetteSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CIVignette",
+        parameters: [
+          kCIInputRadiusKey: radius,
+          kCIInputIntensityKey: payload.value,
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// Fade adjustment.
+  public enum Fade: ImageEffectFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.effect.fade"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var intensity: Double
+      public init(intensity: Double) { self.intensity = intensity }
+    }
+
+    public static func apply(
+      payload: Payload,
+      node: FeatureNode,
+      to image: CIImage,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let foreground = CIImage(
+        color: CIColor(
+          red: 1,
+          green: 1,
+          blue: 1,
+          alpha: CGFloat(payload.intensity)
+        )
+      )
+      .cropped(to: image.extent)
+
+      guard let output = CIFilter(
+        name: "CISourceOverCompositing",
+        parameters: [
+          kCIInputImageKey: foreground,
+          kCIInputBackgroundImageKey: image,
+        ]
+      )?.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+      }
+
+      return output.cropped(to: image.extent)
+    }
+  }
+
+  /// Brush-stroke mask.
+  public enum BrushMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.brush"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var strokes: [BrushMaskStroke]
+      public init(strokes: [BrushMaskStroke]) {
+        self.strokes = strokes
+      }
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      guard node.isEnabled else {
+        return CIImage.parametricTransparent(extent: extent)
+      }
+
+      var accumulated = CIImage.parametricTransparent(extent: extent)
+      for stroke in payload.strokes {
+        let radius = max(stroke.brush.diameter / 2, 0)
+        for stamp in stroke.stamps {
+          let stampImage = try context.kernelRegistry.makeBrushStamp(
+            extent: extent,
+            center: stamp,
+            radius: radius,
+            hardness: stroke.brush.hardness,
+            opacity: stroke.brush.opacity
+          )
+          accumulated = try blendMask(
+            foreground: stampImage,
+            background: accumulated,
+            kernel: .componentMax,
+            extent: extent
+          )
+        }
+      }
+      return accumulated.cropped(to: extent)
+    }
+  }
+
+  /// Inverted mask.
+  public enum InvertMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.invert"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var input: FeatureNode
+      public init(input: FeatureNode) {
+        self.input = input
+      }
+    }
+
+    public static func childMasks(payload: Payload) -> [FeatureNode] {
+      [payload.input]
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let inputImage = try context.featureRegistry.renderMask(payload.input, extent: extent, context: context)
+      guard node.isEnabled else {
+        return inputImage
+      }
+      return inputImage.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: -1),
+          "inputBiasVector": CIVector(x: 1, y: 1, z: 1, w: 1),
+        ]
+      )
+      .cropped(to: extent)
+    }
+  }
+
+  /// Feathered mask.
+  public enum FeatherMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.feather"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var input: FeatureNode
+      public var radius: Double
+      public init(input: FeatureNode, radius: Double) {
+        self.input = input
+        self.radius = radius
+      }
+    }
+
+    public static func childMasks(payload: Payload) -> [FeatureNode] {
+      [payload.input]
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let inputImage = try context.featureRegistry.renderMask(payload.input, extent: extent, context: context)
+      guard node.isEnabled, payload.radius > 0.0001 else {
+        return inputImage
+      }
+      return inputImage
+        .clamped(to: extent)
+        .applyingFilter(
+          "CIGaussianBlur",
+          parameters: [kCIInputRadiusKey: payload.radius]
+        )
+        .cropped(to: extent)
+    }
+  }
+
+  /// Union mask compositor.
+  public enum UnionMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.union"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var nodes: [FeatureNode]
+      public init(nodes: [FeatureNode]) {
+        self.nodes = nodes
+      }
+    }
+
+    public static func validate(payload: Payload, node: FeatureNode) throws {
+      guard payload.nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(node.id)
+      }
+    }
+
+    public static func childMasks(payload: Payload) -> [FeatureNode] {
+      payload.nodes
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      guard node.isEnabled else {
+        return CIImage.parametricTransparent(extent: extent)
+      }
+      return try payload.nodes.reduce(CIImage.parametricTransparent(extent: extent)) { accumulated, node in
+        let next = try context.featureRegistry.renderMask(node, extent: extent, context: context)
+        return try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMax,
+          extent: extent
+        )
+      }
+    }
+  }
+
+  /// Intersection mask compositor.
+  public enum IntersectMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.intersect"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var nodes: [FeatureNode]
+      public init(nodes: [FeatureNode]) {
+        self.nodes = nodes
+      }
+    }
+
+    public static func validate(payload: Payload, node: FeatureNode) throws {
+      guard payload.nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(node.id)
+      }
+    }
+
+    public static func childMasks(payload: Payload) -> [FeatureNode] {
+      payload.nodes
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      guard node.isEnabled else {
+        return CIImage.parametricTransparent(extent: extent)
+      }
+      guard let first = payload.nodes.first else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(node.id)
+      }
+      var accumulated = try context.featureRegistry.renderMask(first, extent: extent, context: context)
+      for node in payload.nodes.dropFirst() {
+        let next = try context.featureRegistry.renderMask(node, extent: extent, context: context)
+        accumulated = try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMultiply,
+          extent: extent
+        )
+      }
+      return accumulated.cropped(to: extent)
+    }
+  }
+
+  /// Subtract mask compositor.
+  public enum SubtractMask: MaskFeatureDefinition {
+
+    public static let typeID: FeatureTypeID = "brightroom.mask.subtract"
+    public static let currentSchemaVersion = 1
+
+    public struct Payload: Codable, Equatable, Sendable {
+      public var base: FeatureNode
+      public var removing: FeatureNode
+      public init(base: FeatureNode, removing: FeatureNode) {
+        self.base = base
+        self.removing = removing
+      }
+    }
+
+    public static func childMasks(payload: Payload) -> [FeatureNode] {
+      [payload.base, payload.removing]
+    }
+
+    public static func renderMask(
+      payload: Payload,
+      node: FeatureNode,
+      extent: CGRect,
+      context: FeatureEvaluationContext
+    ) throws -> CIImage {
+      let base = try context.featureRegistry.renderMask(payload.base, extent: extent, context: context)
+      guard node.isEnabled else {
+        return base
+      }
+      let removing = try context.featureRegistry.renderMask(payload.removing, extent: extent, context: context)
+      return try context.kernelRegistry.subtractMask(
+        base: base,
+        removing: removing,
+        extent: extent
+      )
+    }
+  }
+}
+
+public extension FeatureRegistry {
+
+  /// Brightroom's standard registry.
+  ///
+  /// Apps can start with this registry and register their own feature
+  /// definitions beside Brightroom's definitions.
+  static var brightroomDefault: FeatureRegistry {
+    var registry = FeatureRegistry()
+    registry.registerDomainFeature(BrightroomFeatureDefinitions.Crop.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Preset.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.ColorCube.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Brightness.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Contrast.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Saturation.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Exposure.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Highlights.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Shadows.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.HighlightShadowTint.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Temperature.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Sharpen.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.GaussianBlur.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.UnsharpMask.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Vignette.self)
+    registry.registerImageEffect(BrightroomFeatureDefinitions.Fade.self)
+    registry.registerMask(BrightroomFeatureDefinitions.BrushMask.self)
+    registry.registerMask(BrightroomFeatureDefinitions.InvertMask.self)
+    registry.registerMask(BrightroomFeatureDefinitions.FeatherMask.self)
+    registry.registerMask(BrightroomFeatureDefinitions.UnionMask.self)
+    registry.registerMask(BrightroomFeatureDefinitions.IntersectMask.self)
+    registry.registerMask(BrightroomFeatureDefinitions.SubtractMask.self)
+    return registry
+  }
+}
+
+private func resolve(_ radius: GaussianBlurRadius, extent: CGRect) -> Double {
+  switch radius {
+  case let .absolute(value):
+    value
+  case let .editingStackFilterValue(value):
+    ParametricRadiusCalculator.radius(
+      value: value,
+      max: ParametricFilterConstants.gaussianBlurSliderMax,
+      imageExtent: extent
+    )
+  }
+}
+
+private func colorCubeByteCount(dimension: Int) -> Int {
+  dimension * dimension * dimension * 4 * MemoryLayout<Float>.size
+}
+
+private func blendMask(
+  foreground: CIImage,
+  background: CIImage,
+  kernel: CIBlendKernel,
+  extent: CGRect
+) throws -> CIImage {
+  guard let output = kernel.apply(
+    foreground: foreground,
+    background: background
+  ) else {
+    throw FeatureGraphCompilerError.failedToCreateImage("CIBlendKernel")
+  }
+  return output.cropped(to: extent)
+}
+
+private extension ParametricRGBAColor {
+
+  var ciColor: CIColor {
+    CIColor(
+      red: CGFloat(red),
+      green: CGFloat(green),
+      blue: CGFloat(blue),
+      alpha: CGFloat(alpha)
+    )
+  }
+}
+
+private extension CGRect {
+
+  var isParametricValidExtent: Bool {
+    origin.x.isFinite
+      && origin.y.isFinite
+      && size.width.isFinite
+      && size.height.isFinite
+      && size.width > 0
+      && size.height > 0
+  }
+}

--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -1,0 +1,859 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Compiles a parametric editing document into a Core Image graph.
+///
+/// The compiler returns `CIImage` recipes and does not create intermediate
+/// `CGImage` or `CGContext` values. Callers choose when and how to materialize
+/// the returned image through `CIContext`.
+public struct FeatureGraphCompiler: Sendable {
+
+  /// Rendering options for the feature graph compiler.
+  public struct Options: Equatable, Sendable {
+
+    /// A Boolean value indicating whether the input image should be translated
+    /// to zero origin before the first feature is evaluated.
+    public var normalizesInputExtent: Bool
+
+    /// Creates compiler options.
+    public init(normalizesInputExtent: Bool = true) {
+      self.normalizesInputExtent = normalizesInputExtent
+    }
+  }
+
+  /// The options used during compilation.
+  public var options: Options
+
+  /// The kernel registry used for custom Core Image operations.
+  public var kernelRegistry: ParametricKernelRegistry
+
+  /// The feature registry used to resolve registry-backed feature nodes.
+  public var featureRegistry: FeatureRegistry
+
+  /// Creates a feature graph compiler.
+  public init(
+    options: Options = .init(),
+    kernelRegistry: ParametricKernelRegistry = .init(),
+    featureRegistry: FeatureRegistry = .brightroomDefault
+  ) {
+    self.options = options
+    self.kernelRegistry = kernelRegistry
+    self.featureRegistry = featureRegistry
+  }
+
+  /// Compiles and evaluates a document from an input image.
+  ///
+  /// - Parameters:
+  ///   - input: The source image used as the first graph node.
+  ///   - document: The parametric document to evaluate.
+  /// - Returns: The final image recipe and debug mask outputs.
+  public func makeOutput(
+    from input: CIImage,
+    document: EditingDocument
+  ) throws -> FeatureGraphOutput {
+    try validate(document)
+
+    var image = options.normalizesInputExtent ? ParametricImageGeometry.removingExtentOffset(input) : input
+    var localAdjustmentMasks: [FeatureID: CIImage] = [:]
+
+    for feature in document.mainTree.features where feature.isEnabled {
+      switch feature {
+      case let .domain(domainFeature):
+        image = try apply(domainFeature, to: image)
+
+      case let .effect(effect):
+        image = try apply(effect, to: image)
+
+      case let .localAdjustment(localAdjustment):
+        let output = try apply(localAdjustment, to: image)
+        image = output.image
+        localAdjustmentMasks[localAdjustment.id] = output.mask
+      }
+    }
+
+    return FeatureGraphOutput(
+      image: image,
+      localAdjustmentMasks: localAdjustmentMasks
+    )
+  }
+
+  /// Compiles and evaluates a registry-backed document from an input image.
+  ///
+  /// - Parameters:
+  ///   - input: The source image used as the first graph node.
+  ///   - document: The registry-backed parametric document to evaluate.
+  /// - Returns: The final image recipe and debug mask outputs.
+  public func makeOutput(
+    from input: CIImage,
+    document: FeatureDocument
+  ) throws -> FeatureGraphOutput {
+    try validate(document)
+
+    let context = FeatureEvaluationContext(
+      featureRegistry: featureRegistry,
+      kernelRegistry: kernelRegistry
+    )
+    var image = options.normalizesInputExtent ? ParametricImageGeometry.removingExtentOffset(input) : input
+    var localAdjustmentMasks: [FeatureID: CIImage] = [:]
+
+    for feature in document.mainTree.features where feature.isEnabled {
+      switch feature {
+      case let .domain(node):
+        image = try featureRegistry.applyDomainFeature(node, to: image, context: context)
+
+      case let .effect(node):
+        image = try featureRegistry.applyImageEffect(node, to: image, context: context)
+
+      case let .localAdjustment(localAdjustment):
+        let output = try apply(localAdjustment, to: image, context: context)
+        image = output.image
+        localAdjustmentMasks[localAdjustment.id] = output.mask
+      }
+    }
+
+    return FeatureGraphOutput(
+      image: image,
+      localAdjustmentMasks: localAdjustmentMasks
+    )
+  }
+}
+
+/// The result of compiling a parametric feature graph.
+public struct FeatureGraphOutput: Sendable {
+
+  /// The final output image recipe.
+  public var image: CIImage
+
+  /// Evaluated local adjustment masks keyed by their owning feature ID.
+  public var localAdjustmentMasks: [FeatureID: CIImage]
+
+  /// Creates compiler output.
+  public init(
+    image: CIImage,
+    localAdjustmentMasks: [FeatureID: CIImage] = [:]
+  ) {
+    self.image = image
+    self.localAdjustmentMasks = localAdjustmentMasks
+  }
+}
+
+/// Errors thrown while compiling a parametric feature graph.
+public enum FeatureGraphCompilerError: Error, Equatable, Sendable {
+
+  /// Two features or mask nodes use the same ID.
+  case duplicateID(FeatureID)
+
+  /// A local adjustment has no enabled effect to apply.
+  case emptyLocalAdjustmentEffectPipeline(FeatureID)
+
+  /// A composite mask operation has no children.
+  case emptyMaskComposite(FeatureID?)
+
+  /// A crop rectangle cannot produce a valid image extent.
+  case invalidCropRect(FeatureID, CGRect)
+
+  /// Core Image returned nil while applying a named filter or kernel.
+  case failedToCreateImage(String)
+
+  /// A color-cube feature contains data that cannot match its dimension.
+  case invalidColorCubeData(FeatureID, expectedByteCount: Int, actualByteCount: Int)
+}
+
+private extension FeatureGraphCompiler {
+
+  func apply(_ feature: DomainFeature, to image: CIImage) throws -> CIImage {
+    switch feature {
+    case let .crop(crop):
+      guard crop.isEnabled else {
+        return image
+      }
+      return try apply(crop, to: image)
+    }
+  }
+
+  func apply(_ crop: CropFeature, to image: CIImage) throws -> CIImage {
+    let cropRect = crop.cropRect
+    guard cropRect.isParametricValidExtent else {
+      throw FeatureGraphCompilerError.invalidCropRect(crop.id, cropRect)
+    }
+
+    let absoluteCropRect = cropRect.offsetBy(
+      dx: image.extent.minX,
+      dy: image.extent.minY
+    )
+    return image
+      .cropped(to: absoluteCropRect)
+      .transformed(
+        by: CGAffineTransform(
+          translationX: -absoluteCropRect.minX,
+          y: -absoluteCropRect.minY
+        )
+      )
+  }
+
+  func apply(_ effect: ImageEffectFeature, to image: CIImage) throws -> CIImage {
+    guard effect.isEnabled else {
+      return image
+    }
+
+    switch effect {
+    case let .preset(feature):
+      guard feature.isEnabled else {
+        return image
+      }
+      return try feature.effects.reduce(image) { image, effect in
+        try apply(effect, to: image)
+      }
+
+    case let .colorCube(feature):
+      guard feature.isEnabled else {
+        return image
+      }
+      return try apply(feature, to: image)
+
+    case let .brightness(feature):
+      return image.applyingFilter(
+        "CIColorControls",
+        parameters: ["inputBrightness": feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .contrast(feature):
+      return image.applyingFilter(
+        "CIColorControls",
+        parameters: [kCIInputContrastKey: 1 + feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .saturation(feature):
+      return image.applyingFilter(
+        "CIColorControls",
+        parameters: [kCIInputSaturationKey: 1 + feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .exposure(feature):
+      guard abs(feature.value) > 0.0001 else {
+        return image
+      }
+      return image.applyingFilter(
+        "CIExposureAdjust",
+        parameters: [kCIInputEVKey: feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .highlights(feature):
+      return image.applyingFilter(
+        "CIHighlightShadowAdjust",
+        parameters: ["inputHighlightAmount": 1 - feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .shadows(feature):
+      return image.applyingFilter(
+        "CIHighlightShadowAdjust",
+        parameters: ["inputShadowAmount": feature.value]
+      )
+      .cropped(to: image.extent)
+
+    case let .highlightShadowTint(feature):
+      return try apply(feature, to: image)
+
+    case let .temperature(feature):
+      return image.applyingFilter(
+        "CITemperatureAndTint",
+        parameters: [
+          "inputNeutral": CIVector(x: CGFloat(feature.value) + 6500, y: 0),
+          "inputTargetNeutral": CIVector(x: 6500, y: 0),
+        ]
+      )
+      .cropped(to: image.extent)
+
+    case let .sharpen(feature):
+      let radius = ParametricRadiusCalculator.radius(
+        value: feature.radius,
+        max: ParametricFilterConstants.gaussianBlurSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CISharpenLuminance",
+        parameters: [
+          "inputRadius": radius,
+          "inputSharpness": feature.sharpness,
+        ]
+      )
+      .cropped(to: image.extent)
+
+    case let .gaussianBlur(feature):
+      let radius = resolve(feature.radius, extent: image.extent)
+      guard radius > 0.0001 else {
+        return image
+      }
+      return image
+        .clamped(to: image.extent)
+        .applyingFilter(
+          "CIGaussianBlur",
+          parameters: [kCIInputRadiusKey: radius]
+        )
+        .cropped(to: image.extent)
+
+    case let .unsharpMask(feature):
+      let radius = ParametricRadiusCalculator.radius(
+        value: feature.radius,
+        max: ParametricFilterConstants.unsharpMaskRadiusSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CIUnsharpMask",
+        parameters: [
+          "inputIntensity": feature.intensity,
+          "inputRadius": radius,
+        ]
+      )
+      .cropped(to: image.extent)
+
+    case let .vignette(feature):
+      let radius = ParametricRadiusCalculator.radius(
+        value: feature.value,
+        max: ParametricFilterConstants.vignetteSliderMax,
+        imageExtent: image.extent
+      )
+      return image.applyingFilter(
+        "CIVignette",
+        parameters: [
+          kCIInputRadiusKey: radius,
+          kCIInputIntensityKey: feature.value,
+        ]
+      )
+      .cropped(to: image.extent)
+
+    case let .fade(feature):
+      let foreground = CIImage(
+        color: CIColor(
+          red: 1,
+          green: 1,
+          blue: 1,
+          alpha: CGFloat(feature.intensity)
+        )
+      )
+      .cropped(to: image.extent)
+
+      guard let output = CIFilter(
+        name: "CISourceOverCompositing",
+        parameters: [
+          kCIInputImageKey: foreground,
+          kCIInputBackgroundImageKey: image,
+        ]
+      )?.outputImage else {
+        throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+      }
+
+      return output.cropped(to: image.extent)
+    }
+  }
+
+  func apply(_ feature: ColorCubeFeature, to image: CIImage) throws -> CIImage {
+    let expectedByteCount = colorCubeByteCount(dimension: feature.dimension)
+    guard feature.cubeData.count == expectedByteCount else {
+      throw FeatureGraphCompilerError.invalidColorCubeData(
+        feature.id,
+        expectedByteCount: expectedByteCount,
+        actualByteCount: feature.cubeData.count
+      )
+    }
+
+    let filter = ParametricColorCubeHelper.makeColorCubeFilter(
+      cubeData: feature.cubeData,
+      dimension: feature.dimension,
+      cacheKey: feature.identifier
+    )
+    filter.setValue(image, forKeyPath: kCIInputImageKey)
+
+    guard let filtered = filter.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CIColorCubeWithColorSpace")
+    }
+
+    let foreground = filtered.applyingFilter(
+      "CIColorMatrix",
+      parameters: [
+        "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+        "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+        "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+        "inputAVector": CIVector(x: 0, y: 0, z: 0, w: CGFloat(feature.amount)),
+        "inputBiasVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+      ]
+    )
+
+    guard let output = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: foreground,
+        kCIInputBackgroundImageKey: image,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    return output.cropped(to: image.extent)
+  }
+
+  func apply(_ feature: HighlightShadowTintFeature, to image: CIImage) throws -> CIImage {
+    let shadow = CIImage(color: feature.shadowColor.ciColor)
+      .cropped(to: image.extent)
+    guard let shadowOutput = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: shadow,
+        kCIInputBackgroundImageKey: image,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    let highlight = CIImage(color: feature.highlightColor.ciColor)
+      .cropped(to: image.extent)
+    guard let highlightOutput = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: highlight,
+        kCIInputBackgroundImageKey: shadowOutput,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    return highlightOutput.cropped(to: image.extent)
+  }
+
+  func apply(
+    _ localAdjustment: LocalAdjustmentFeature,
+    to base: CIImage
+  ) throws -> (image: CIImage, mask: CIImage) {
+    guard localAdjustment.isEnabled else {
+      return (base, CIImage.parametricTransparent(extent: base.extent))
+    }
+
+    let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+    guard enabledEffects.isEmpty == false else {
+      throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+    }
+
+    let adjusted = try enabledEffects.reduce(base) { image, effect in
+      try apply(effect, to: image)
+    }
+    let mask = try render(localAdjustment.maskTree, extent: base.extent)
+
+    switch localAdjustment.blendMode {
+    case .alpha:
+      let composited = adjusted.applyingFilter(
+        "CIBlendWithAlphaMask",
+        parameters: [
+          kCIInputBackgroundImageKey: base,
+          kCIInputMaskImageKey: mask,
+        ]
+      )
+      .cropped(to: base.extent)
+      return (composited, mask)
+    }
+  }
+
+  func apply(
+    _ localAdjustment: FeatureLocalAdjustment,
+    to base: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> (image: CIImage, mask: CIImage) {
+    guard localAdjustment.isEnabled else {
+      return (base, CIImage.parametricTransparent(extent: base.extent))
+    }
+
+    let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+    guard enabledEffects.isEmpty == false else {
+      throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+    }
+
+    let adjusted = try enabledEffects.reduce(base) { image, effect in
+      try featureRegistry.applyImageEffect(effect, to: image, context: context)
+    }
+    let mask = try featureRegistry.renderMask(localAdjustment.mask, extent: base.extent, context: context)
+
+    switch localAdjustment.blendMode {
+    case .alpha:
+      let composited = adjusted.applyingFilter(
+        "CIBlendWithAlphaMask",
+        parameters: [
+          kCIInputBackgroundImageKey: base,
+          kCIInputMaskImageKey: mask,
+        ]
+      )
+      .cropped(to: base.extent)
+      return (composited, mask)
+    }
+  }
+
+  func render(_ maskTree: MaskTree, extent: CGRect) throws -> CIImage {
+    try render(maskTree.root, extent: extent)
+      .cropped(to: extent)
+  }
+
+  func render(_ node: MaskNode, extent: CGRect) throws -> CIImage {
+    switch node {
+    case let .brush(mask):
+      return try render(mask, extent: extent)
+
+    case let .invert(input):
+      let inputImage = try render(input, extent: extent)
+      return inputImage.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: -1),
+          "inputBiasVector": CIVector(x: 1, y: 1, z: 1, w: 1),
+        ]
+      )
+      .cropped(to: extent)
+
+    case let .feather(feather):
+      let inputImage = try render(feather.input, extent: extent)
+      guard feather.isEnabled, feather.radius > 0.0001 else {
+        return inputImage
+      }
+      return inputImage
+        .clamped(to: extent)
+        .applyingFilter(
+          "CIGaussianBlur",
+          parameters: [kCIInputRadiusKey: feather.radius]
+        )
+        .cropped(to: extent)
+
+    case let .union(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      return try nodes.reduce(CIImage.parametricTransparent(extent: extent)) { accumulated, node in
+        let next = try render(node, extent: extent)
+        return try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMax,
+          extent: extent
+        )
+      }
+
+    case let .intersect(nodes):
+      guard let first = nodes.first else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      var accumulated = try render(first, extent: extent)
+      for node in nodes.dropFirst() {
+        let next = try render(node, extent: extent)
+        accumulated = try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMultiply,
+          extent: extent
+        )
+      }
+      return accumulated.cropped(to: extent)
+
+    case let .subtract(subtract):
+      let base = try render(subtract.base, extent: extent)
+      guard subtract.isEnabled else {
+        return base
+      }
+      let removing = try render(subtract.removing, extent: extent)
+      return try kernelRegistry.subtractMask(
+        base: base,
+        removing: removing,
+        extent: extent
+      )
+    }
+  }
+
+  func render(_ mask: BrushMask, extent: CGRect) throws -> CIImage {
+    guard mask.isEnabled else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    var accumulated = CIImage.parametricTransparent(extent: extent)
+
+    for stroke in mask.strokes {
+      let radius = max(stroke.brush.diameter / 2, 0)
+      for stamp in stroke.stamps {
+        let stampImage = try kernelRegistry.makeBrushStamp(
+          extent: extent,
+          center: stamp,
+          radius: radius,
+          hardness: stroke.brush.hardness,
+          opacity: stroke.brush.opacity
+        )
+        accumulated = try blendMask(
+          foreground: stampImage,
+          background: accumulated,
+          kernel: .componentMax,
+          extent: extent
+        )
+      }
+    }
+
+    return accumulated.cropped(to: extent)
+  }
+
+  func blendMask(
+    foreground: CIImage,
+    background: CIImage,
+    kernel: CIBlendKernel,
+    extent: CGRect
+  ) throws -> CIImage {
+    guard let output = kernel.apply(
+      foreground: foreground,
+      background: background
+    ) else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CIBlendKernel")
+    }
+    return output.cropped(to: extent)
+  }
+}
+
+private extension FeatureGraphCompiler {
+
+  func validate(_ document: EditingDocument) throws {
+    var ids = Set<FeatureID>()
+
+    func insert(_ id: FeatureID) throws {
+      guard ids.insert(id).inserted else {
+        throw FeatureGraphCompilerError.duplicateID(id)
+      }
+    }
+
+    for feature in document.mainTree.features {
+      try insert(feature.id)
+
+      switch feature {
+      case let .domain(.crop(crop)):
+        guard crop.cropRect.isParametricValidExtent else {
+          throw FeatureGraphCompilerError.invalidCropRect(crop.id, crop.cropRect)
+        }
+
+      case .effect:
+        break
+
+      case let .localAdjustment(localAdjustment):
+        let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+        guard enabledEffects.isEmpty == false else {
+          throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+        }
+
+        for effect in localAdjustment.effectPipeline.effects {
+          try validate(effect, insert: insert)
+        }
+        try validate(localAdjustment.maskTree.root, insert: insert)
+      }
+    }
+  }
+
+  func validate(_ document: FeatureDocument) throws {
+    var ids = Set<FeatureID>()
+
+    func insert(_ id: FeatureID) throws {
+      guard ids.insert(id).inserted else {
+        throw FeatureGraphCompilerError.duplicateID(id)
+      }
+    }
+
+    for feature in document.mainTree.features {
+      switch feature {
+      case let .domain(node):
+        try validateDomainFeature(node, insert: insert)
+
+      case let .effect(node):
+        try validateImageEffect(node, insert: insert)
+
+      case let .localAdjustment(localAdjustment):
+        try insert(localAdjustment.id)
+
+        let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+        guard enabledEffects.isEmpty == false else {
+          throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+        }
+
+        for effect in localAdjustment.effectPipeline.effects {
+          try validateImageEffect(effect, insert: insert)
+        }
+        try validateMask(localAdjustment.mask, insert: insert)
+      }
+    }
+  }
+
+  func validateDomainFeature(
+    _ node: FeatureNode,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    try insert(node.id)
+    try featureRegistry.domainDefinition(for: node).validate(node)
+  }
+
+  func validateImageEffect(
+    _ node: FeatureNode,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    try insert(node.id)
+    let definition = try featureRegistry.imageEffectDefinition(for: node)
+    try definition.validate(node)
+    for child in try definition.childImageEffects(in: node) {
+      try validateImageEffect(child, insert: insert)
+    }
+  }
+
+  func validateMask(
+    _ node: FeatureNode,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    try insert(node.id)
+    let definition = try featureRegistry.maskDefinition(for: node)
+    try definition.validate(node)
+    for child in try definition.childMasks(in: node) {
+      try validateMask(child, insert: insert)
+    }
+  }
+
+  func validate(
+    _ effect: ImageEffectFeature,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    try insert(effect.id)
+
+    switch effect {
+    case let .preset(preset):
+      for effect in preset.effects {
+        try validate(effect, insert: insert)
+      }
+
+    case let .colorCube(colorCube):
+      let expectedByteCount = colorCubeByteCount(dimension: colorCube.dimension)
+      guard colorCube.cubeData.count == expectedByteCount else {
+        throw FeatureGraphCompilerError.invalidColorCubeData(
+          colorCube.id,
+          expectedByteCount: expectedByteCount,
+          actualByteCount: colorCube.cubeData.count
+        )
+      }
+
+    case .brightness,
+      .contrast,
+      .saturation,
+      .exposure,
+      .highlights,
+      .shadows,
+      .highlightShadowTint,
+      .temperature,
+      .sharpen,
+      .gaussianBlur,
+      .unsharpMask,
+      .vignette,
+      .fade:
+      break
+    }
+  }
+
+  func validate(
+    _ node: MaskNode,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    switch node {
+    case let .brush(mask):
+      try insert(mask.id)
+
+    case let .invert(input):
+      try validate(input, insert: insert)
+
+    case let .feather(feather):
+      try insert(feather.id)
+      try validate(feather.input, insert: insert)
+
+    case let .union(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      for node in nodes {
+        try validate(node, insert: insert)
+      }
+
+    case let .intersect(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      for node in nodes {
+        try validate(node, insert: insert)
+      }
+
+    case let .subtract(subtract):
+      try insert(subtract.id)
+      try validate(subtract.base, insert: insert)
+      try validate(subtract.removing, insert: insert)
+    }
+  }
+}
+
+private func resolve(_ radius: GaussianBlurRadius, extent: CGRect) -> Double {
+  switch radius {
+  case let .absolute(value):
+    value
+  case let .editingStackFilterValue(value):
+    ParametricRadiusCalculator.radius(
+      value: value,
+      max: ParametricFilterConstants.gaussianBlurSliderMax,
+      imageExtent: extent
+    )
+  }
+}
+
+private func colorCubeByteCount(dimension: Int) -> Int {
+  dimension * dimension * dimension * 4 * MemoryLayout<Float>.size
+}
+
+private extension ParametricRGBAColor {
+
+  var ciColor: CIColor {
+    CIColor(
+      red: CGFloat(red),
+      green: CGFloat(green),
+      blue: CGFloat(blue),
+      alpha: CGFloat(alpha)
+    )
+  }
+}
+
+private extension CGRect {
+
+  var isParametricValidExtent: Bool {
+    origin.x.isFinite
+      && origin.y.isFinite
+      && size.width.isFinite
+      && size.height.isFinite
+      && size.width > 0
+      && size.height > 0
+  }
+}

--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -334,19 +334,7 @@ private extension FeatureGraphCompiler {
       .cropped(to: image.extent)
 
     case let .vignette(feature):
-      let radius = ParametricRadiusCalculator.radius(
-        value: feature.value,
-        max: ParametricFilterConstants.vignetteSliderMax,
-        imageExtent: image.extent
-      )
-      return image.applyingFilter(
-        "CIVignette",
-        parameters: [
-          kCIInputRadiusKey: radius,
-          kCIInputIntensityKey: feature.value,
-        ]
-      )
-      .cropped(to: image.extent)
+      return ParametricVignetteRenderer.apply(value: feature.value, to: image)
 
     case let .fade(feature):
       let foreground = CIImage(

--- a/Sources/BrightroomParametric/FeatureNodeBridge.swift
+++ b/Sources/BrightroomParametric/FeatureNodeBridge.swift
@@ -1,0 +1,385 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+public extension FeatureDocument {
+
+  /// Creates a registry-backed document from the current enum-backed prototype.
+  init(editingDocument document: EditingDocument) throws {
+    self.init(
+      mainTree: FeatureMainTree(
+        features: try document.mainTree.features.map(FeatureTreeNode.init(mainFeature:))
+      )
+    )
+  }
+}
+
+public extension FeatureTreeNode {
+
+  /// Creates a registry-backed main-tree node from the current enum-backed prototype.
+  init(mainFeature feature: MainFeature) throws {
+    switch feature {
+    case let .domain(domain):
+      self = .domain(try FeatureNode(domainFeature: domain))
+
+    case let .effect(effect):
+      self = .effect(try FeatureNode(imageEffect: effect))
+
+    case let .localAdjustment(localAdjustment):
+      self = .localAdjustment(try FeatureLocalAdjustment(localAdjustment: localAdjustment))
+    }
+  }
+}
+
+public extension FeatureLocalAdjustment {
+
+  /// Creates a registry-backed local adjustment from the current enum-backed prototype.
+  init(localAdjustment: LocalAdjustmentFeature) throws {
+    self.init(
+      id: localAdjustment.id,
+      isEnabled: localAdjustment.isEnabled,
+      mask: try FeatureNode(maskNode: localAdjustment.maskTree.root),
+      effectPipeline: try FeatureEffectPipeline(effectPipeline: localAdjustment.effectPipeline),
+      blendMode: localAdjustment.blendMode
+    )
+  }
+}
+
+public extension FeatureEffectPipeline {
+
+  /// Creates a registry-backed effect pipeline from the current enum-backed prototype.
+  init(effectPipeline: EffectPipeline) throws {
+    self.init(
+      effects: try effectPipeline.effects.map(FeatureNode.init(imageEffect:))
+    )
+  }
+}
+
+public extension FeatureNode {
+
+  /// Creates a registry-backed node from a domain feature.
+  init(domainFeature feature: DomainFeature) throws {
+    switch feature {
+    case let .crop(feature):
+      try self.init(crop: feature)
+    }
+  }
+
+  /// Creates a registry-backed node from an image effect.
+  init(imageEffect effect: ImageEffectFeature) throws {
+    switch effect {
+    case let .preset(feature):
+      try self.init(preset: feature)
+    case let .colorCube(feature):
+      try self.init(colorCube: feature)
+    case let .brightness(feature):
+      try self.init(brightness: feature)
+    case let .contrast(feature):
+      try self.init(contrast: feature)
+    case let .saturation(feature):
+      try self.init(saturation: feature)
+    case let .exposure(feature):
+      try self.init(exposure: feature)
+    case let .highlights(feature):
+      try self.init(highlights: feature)
+    case let .shadows(feature):
+      try self.init(shadows: feature)
+    case let .highlightShadowTint(feature):
+      try self.init(highlightShadowTint: feature)
+    case let .temperature(feature):
+      try self.init(temperature: feature)
+    case let .sharpen(feature):
+      try self.init(sharpen: feature)
+    case let .gaussianBlur(feature):
+      try self.init(gaussianBlur: feature)
+    case let .unsharpMask(feature):
+      try self.init(unsharpMask: feature)
+    case let .vignette(feature):
+      try self.init(vignette: feature)
+    case let .fade(feature):
+      try self.init(fade: feature)
+    }
+  }
+
+  /// Creates a registry-backed node from a mask node.
+  init(maskNode node: MaskNode) throws {
+    switch node {
+    case let .brush(mask):
+      try self.init(brushMask: mask)
+    case let .invert(input):
+      try self.init(invertMaskInput: input)
+    case let .feather(feather):
+      try self.init(featherMask: feather)
+    case let .union(nodes):
+      try self.init(unionMaskNodes: nodes)
+    case let .intersect(nodes):
+      try self.init(intersectMaskNodes: nodes)
+    case let .subtract(subtract):
+      try self.init(subtractMask: subtract)
+    }
+  }
+
+  /// Creates a registry-backed crop node.
+  init(crop feature: CropFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Crop.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(cropRect: feature.cropRect)
+    )
+  }
+
+  /// Creates a registry-backed preset node.
+  init(preset feature: PresetFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Preset.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(
+        name: feature.name,
+        identifier: feature.identifier,
+        effects: try feature.effects.map(FeatureNode.init(imageEffect:))
+      )
+    )
+  }
+
+  /// Creates a registry-backed color-cube node.
+  init(colorCube feature: ColorCubeFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.ColorCube.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(
+        name: feature.name,
+        identifier: feature.identifier,
+        amount: feature.amount,
+        dimension: feature.dimension,
+        cubeData: feature.cubeData
+      )
+    )
+  }
+
+  /// Creates a registry-backed brightness node.
+  init(brightness feature: BrightnessFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Brightness.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed contrast node.
+  init(contrast feature: ContrastFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Contrast.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed saturation node.
+  init(saturation feature: SaturationFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Saturation.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed exposure node.
+  init(exposure feature: ExposureFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Exposure.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed highlights node.
+  init(highlights feature: HighlightsFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Highlights.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed shadows node.
+  init(shadows feature: ShadowsFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Shadows.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed highlight/shadow tint node.
+  init(highlightShadowTint feature: HighlightShadowTintFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.HighlightShadowTint.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(
+        highlightColor: feature.highlightColor,
+        shadowColor: feature.shadowColor
+      )
+    )
+  }
+
+  /// Creates a registry-backed temperature node.
+  init(temperature feature: TemperatureFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Temperature.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed sharpen node.
+  init(sharpen feature: SharpenFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Sharpen.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(
+        sharpness: feature.sharpness,
+        radius: feature.radius
+      )
+    )
+  }
+
+  /// Creates a registry-backed Gaussian blur node.
+  init(gaussianBlur feature: GaussianBlurFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.GaussianBlur.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(radius: feature.radius)
+    )
+  }
+
+  /// Creates a registry-backed unsharp mask node.
+  init(unsharpMask feature: UnsharpMaskFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.UnsharpMask.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(
+        intensity: feature.intensity,
+        radius: feature.radius
+      )
+    )
+  }
+
+  /// Creates a registry-backed vignette node.
+  init(vignette feature: VignetteFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Vignette.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(value: feature.value)
+    )
+  }
+
+  /// Creates a registry-backed fade node.
+  init(fade feature: FadeFeature) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.Fade.self,
+      id: feature.id,
+      isEnabled: feature.isEnabled,
+      payload: .init(intensity: feature.intensity)
+    )
+  }
+
+  /// Creates a registry-backed brush mask node.
+  init(brushMask mask: BrushMask) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.BrushMask.self,
+      id: mask.id,
+      isEnabled: mask.isEnabled,
+      payload: .init(strokes: mask.strokes)
+    )
+  }
+
+  /// Creates a registry-backed invert mask node.
+  init(invertMaskInput input: MaskNode) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.InvertMask.self,
+      id: .init(),
+      isEnabled: true,
+      payload: .init(input: try FeatureNode(maskNode: input))
+    )
+  }
+
+  /// Creates a registry-backed feather mask node.
+  init(featherMask feather: MaskFeather) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.FeatherMask.self,
+      id: feather.id,
+      isEnabled: feather.isEnabled,
+      payload: .init(
+        input: try FeatureNode(maskNode: feather.input),
+        radius: feather.radius
+      )
+    )
+  }
+
+  /// Creates a registry-backed union mask node.
+  init(unionMaskNodes nodes: [MaskNode]) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.UnionMask.self,
+      id: .init(),
+      isEnabled: true,
+      payload: .init(nodes: try nodes.map(FeatureNode.init(maskNode:)))
+    )
+  }
+
+  /// Creates a registry-backed intersection mask node.
+  init(intersectMaskNodes nodes: [MaskNode]) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.IntersectMask.self,
+      id: .init(),
+      isEnabled: true,
+      payload: .init(nodes: try nodes.map(FeatureNode.init(maskNode:)))
+    )
+  }
+
+  /// Creates a registry-backed subtract mask node.
+  init(subtractMask subtract: MaskSubtract) throws {
+    try self.init(
+      BrightroomFeatureDefinitions.SubtractMask.self,
+      id: subtract.id,
+      isEnabled: subtract.isEnabled,
+      payload: .init(
+        base: try FeatureNode(maskNode: subtract.base),
+        removing: try FeatureNode(maskNode: subtract.removing)
+      )
+    )
+  }
+}

--- a/Sources/BrightroomParametric/FeatureNodeDocument.swift
+++ b/Sources/BrightroomParametric/FeatureNodeDocument.swift
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// A registry-backed parametric image editing document.
+///
+/// Unlike `EditingDocument`, this document stores all domain, effect, and mask
+/// operations as `FeatureNode` values. Brightroom-provided features and
+/// app-provided features therefore share the same serialized representation.
+public struct FeatureDocument: Codable, Equatable, Sendable {
+
+  /// The ordered main feature tree evaluated from source image to output image.
+  public var mainTree: FeatureMainTree
+
+  /// Creates a registry-backed editing document.
+  public init(mainTree: FeatureMainTree = .init()) {
+    self.mainTree = mainTree
+  }
+}
+
+/// The main editing sequence for a registry-backed document.
+public struct FeatureMainTree: Codable, Equatable, Sendable {
+
+  /// The nodes evaluated in source-to-output order.
+  public var features: [FeatureTreeNode]
+
+  /// Creates a main tree with the provided ordered nodes.
+  public init(features: [FeatureTreeNode] = []) {
+    self.features = features
+  }
+}
+
+/// A node that can appear in the registry-backed document's main tree.
+public enum FeatureTreeNode: Codable, Equatable, Sendable {
+
+  /// A feature node resolved as a domain-changing operation.
+  case domain(FeatureNode)
+
+  /// A feature node resolved as an extent-preserving image effect.
+  case effect(FeatureNode)
+
+  /// A local branch that composites an effect pipeline through a mask node.
+  case localAdjustment(FeatureLocalAdjustment)
+}
+
+extension FeatureTreeNode: Feature {
+
+  public var id: FeatureID {
+    switch self {
+    case let .domain(node):
+      node.id
+    case let .effect(node):
+      node.id
+    case let .localAdjustment(localAdjustment):
+      localAdjustment.id
+    }
+  }
+
+  public var isEnabled: Bool {
+    switch self {
+    case let .domain(node):
+      node.isEnabled
+    case let .effect(node):
+      node.isEnabled
+    case let .localAdjustment(localAdjustment):
+      localAdjustment.isEnabled
+    }
+  }
+}
+
+/// An ordered chain of registry-backed extent-preserving effects.
+public struct FeatureEffectPipeline: Codable, Equatable, Sendable {
+
+  /// The effect nodes applied from first to last.
+  public var effects: [FeatureNode]
+
+  /// Creates an effect pipeline.
+  public init(effects: [FeatureNode] = []) {
+    self.effects = effects
+  }
+}
+
+/// A registry-backed local adjustment branch.
+public struct FeatureLocalAdjustment: Feature {
+
+  /// The stable identity of this local adjustment.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this local adjustment participates in rendering.
+  public var isEnabled: Bool
+
+  /// The root mask node that produces alpha for compositing.
+  public var mask: FeatureNode
+
+  /// The extent-preserving effects applied inside the local branch.
+  public var effectPipeline: FeatureEffectPipeline
+
+  /// The blend rule used to composite the adjusted branch over the base image.
+  public var blendMode: LocalAdjustmentBlendMode
+
+  /// Creates a registry-backed local adjustment branch.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    mask: FeatureNode,
+    effectPipeline: FeatureEffectPipeline,
+    blendMode: LocalAdjustmentBlendMode = .alpha
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.mask = mask
+    self.effectPipeline = effectPipeline
+    self.blendMode = blendMode
+  }
+}

--- a/Sources/BrightroomParametric/FeatureRegistry.swift
+++ b/Sources/BrightroomParametric/FeatureRegistry.swift
@@ -1,0 +1,573 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// A stable identifier for a feature definition.
+///
+/// Brightroom-provided features and app-provided features share the same type ID
+/// namespace. The document model therefore does not need a built-in/custom
+/// distinction; it only stores the ID needed to resolve behavior at render time.
+public struct FeatureTypeID: RawRepresentable, Codable, Equatable, Hashable, Sendable, ExpressibleByStringLiteral {
+
+  /// The serialized feature type identifier.
+  public var rawValue: String
+
+  /// Creates a feature type identifier.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a feature type identifier from a string literal.
+  public init(stringLiteral value: String) {
+    self.rawValue = value
+  }
+}
+
+/// The placement and output contract of a feature definition.
+public enum FeatureCapability: String, Codable, Equatable, Sendable {
+
+  /// A main-tree operation that may change image extent or coordinate domain.
+  case domain
+
+  /// An extent-preserving image operation.
+  case imageEffect
+
+  /// A mask-tree operation that produces alpha.
+  case mask
+}
+
+/// A serializable feature invocation.
+///
+/// `FeatureNode` is the common document shape for all operations. The payload is
+/// kept as JSON so unknown feature types can round-trip through a document even
+/// when the current registry cannot render them.
+public struct FeatureNode: Codable, Equatable, Sendable {
+
+  /// The registered feature definition to use when evaluating this node.
+  public var typeID: FeatureTypeID
+
+  /// The schema version used by `payload`.
+  public var schemaVersion: Int
+
+  /// The stable identity of this feature invocation.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this feature participates in rendering.
+  public var isEnabled: Bool
+
+  /// The feature-specific serialized parameters.
+  public var payload: JSONValue
+
+  /// Creates a feature node from already-erased payload data.
+  public init(
+    typeID: FeatureTypeID,
+    schemaVersion: Int,
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    payload: JSONValue
+  ) {
+    self.typeID = typeID
+    self.schemaVersion = schemaVersion
+    self.id = id
+    self.isEnabled = isEnabled
+    self.payload = payload
+  }
+
+  /// Creates a feature node for a typed feature definition.
+  public init<Definition: ParametricFeatureDefinition>(
+    _ definition: Definition.Type,
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    payload: Definition.Payload
+  ) throws {
+    self.init(
+      typeID: Definition.typeID,
+      schemaVersion: Definition.currentSchemaVersion,
+      id: id,
+      isEnabled: isEnabled,
+      payload: try JSONValue(payload)
+    )
+  }
+
+  /// Decodes this node's payload as the supplied feature definition's payload.
+  public func decodePayload<Definition: ParametricFeatureDefinition>(
+    as definition: Definition.Type
+  ) throws -> Definition.Payload {
+    try payload.decode(Definition.Payload.self)
+  }
+}
+
+/// A JSON value used for type-erased feature payload storage.
+public enum JSONValue: Codable, Equatable, Sendable {
+
+  /// A JSON null value.
+  case null
+
+  /// A JSON Boolean value.
+  case bool(Bool)
+
+  /// A JSON number value.
+  case number(Double)
+
+  /// A JSON string value.
+  case string(String)
+
+  /// A JSON array value.
+  case array([JSONValue])
+
+  /// A JSON object value.
+  case object([String: JSONValue])
+
+  /// Encodes a typed value into a JSON payload.
+  public init<Value: Encodable>(_ value: Value) throws {
+    let data = try JSONEncoder().encode(value)
+    let object = try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    self = try JSONValue(object)
+  }
+
+  /// Decodes this JSON payload into a typed value.
+  public func decode<Value: Decodable>(_ type: Value.Type) throws -> Value {
+    let object = jsonObject
+    let data = try JSONSerialization.data(withJSONObject: object, options: [.fragmentsAllowed])
+    return try JSONDecoder().decode(Value.self, from: data)
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if container.decodeNil() {
+      self = .null
+    } else if let value = try? container.decode(Bool.self) {
+      self = .bool(value)
+    } else if let value = try? container.decode(Double.self) {
+      self = .number(value)
+    } else if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode([JSONValue].self) {
+      self = .array(value)
+    } else {
+      self = .object(try container.decode([String: JSONValue].self))
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+
+    switch self {
+    case .null:
+      try container.encodeNil()
+    case let .bool(value):
+      try container.encode(value)
+    case let .number(value):
+      try container.encode(value)
+    case let .string(value):
+      try container.encode(value)
+    case let .array(value):
+      try container.encode(value)
+    case let .object(value):
+      try container.encode(value)
+    }
+  }
+}
+
+/// Errors thrown while erasing or restoring feature payloads.
+public enum FeaturePayloadCodingError: Error, Equatable, Sendable {
+
+  /// The supplied object cannot be represented by `JSONValue`.
+  case unsupportedJSONObject(String)
+}
+
+/// Common metadata for a feature definition.
+public protocol ParametricFeatureDefinition: Sendable {
+
+  /// The typed payload stored in a `FeatureNode`.
+  associatedtype Payload: Codable & Equatable & Sendable
+
+  /// The stable type identifier used by serialized documents.
+  static var typeID: FeatureTypeID { get }
+
+  /// The current payload schema version emitted by new nodes.
+  static var currentSchemaVersion: Int { get }
+
+  /// Validates a decoded payload before it is rendered.
+  static func validate(payload: Payload, node: FeatureNode) throws
+}
+
+public extension ParametricFeatureDefinition {
+
+  static func validate(payload: Payload, node: FeatureNode) throws {}
+}
+
+/// A feature definition that may change image domain.
+public protocol DomainFeatureDefinition: ParametricFeatureDefinition {
+
+  /// Applies the domain operation to the current image.
+  static func apply(
+    payload: Payload,
+    node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage
+}
+
+/// A feature definition that preserves image extent.
+public protocol ImageEffectFeatureDefinition: ParametricFeatureDefinition {
+
+  /// Applies the image effect to the current image.
+  static func apply(
+    payload: Payload,
+    node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage
+
+  /// Returns nested effect nodes owned by this feature.
+  static func childImageEffects(payload: Payload) -> [FeatureNode]
+}
+
+public extension ImageEffectFeatureDefinition {
+
+  static func childImageEffects(payload: Payload) -> [FeatureNode] { [] }
+}
+
+/// A feature definition that renders an alpha mask.
+public protocol MaskFeatureDefinition: ParametricFeatureDefinition {
+
+  /// Renders this mask in the current image domain.
+  static func renderMask(
+    payload: Payload,
+    node: FeatureNode,
+    extent: CGRect,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage
+
+  /// Returns nested mask nodes owned by this feature.
+  static func childMasks(payload: Payload) -> [FeatureNode]
+}
+
+public extension MaskFeatureDefinition {
+
+  static func childMasks(payload: Payload) -> [FeatureNode] { [] }
+}
+
+/// Runtime dependencies used while evaluating feature definitions.
+public struct FeatureEvaluationContext: Sendable {
+
+  /// The registry that resolves feature type IDs.
+  public var featureRegistry: FeatureRegistry
+
+  /// The registry that provides Metal-backed Core Image kernels.
+  public var kernelRegistry: ParametricKernelRegistry
+
+  /// Creates an evaluation context.
+  public init(
+    featureRegistry: FeatureRegistry,
+    kernelRegistry: ParametricKernelRegistry
+  ) {
+    self.featureRegistry = featureRegistry
+    self.kernelRegistry = kernelRegistry
+  }
+}
+
+/// A registry that resolves feature nodes into renderable behavior.
+public struct FeatureRegistry: Sendable {
+
+  private var domainDefinitions: [FeatureTypeID: AnyDomainFeatureDefinition] = [:]
+  private var imageEffectDefinitions: [FeatureTypeID: AnyImageEffectFeatureDefinition] = [:]
+  private var maskDefinitions: [FeatureTypeID: AnyMaskFeatureDefinition] = [:]
+
+  /// Creates an empty feature registry.
+  public init() {}
+
+  /// Registers a domain feature definition.
+  public mutating func registerDomainFeature<Definition: DomainFeatureDefinition>(
+    _ definition: Definition.Type
+  ) {
+    domainDefinitions[Definition.typeID] = AnyDomainFeatureDefinition(definition)
+  }
+
+  /// Registers an image effect feature definition.
+  public mutating func registerImageEffect<Definition: ImageEffectFeatureDefinition>(
+    _ definition: Definition.Type
+  ) {
+    imageEffectDefinitions[Definition.typeID] = AnyImageEffectFeatureDefinition(definition)
+  }
+
+  /// Registers a mask feature definition.
+  public mutating func registerMask<Definition: MaskFeatureDefinition>(
+    _ definition: Definition.Type
+  ) {
+    maskDefinitions[Definition.typeID] = AnyMaskFeatureDefinition(definition)
+  }
+
+  /// Applies a registered domain feature.
+  public func applyDomainFeature(
+    _ node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    guard node.isEnabled else {
+      return image
+    }
+    return try domainDefinition(for: node).apply(node, to: image, context: context)
+  }
+
+  /// Applies a registered image effect.
+  public func applyImageEffect(
+    _ node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    guard node.isEnabled else {
+      return image
+    }
+    return try imageEffectDefinition(for: node).apply(node, to: image, context: context)
+  }
+
+  /// Renders a registered mask feature.
+  public func renderMask(
+    _ node: FeatureNode,
+    extent: CGRect,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    try maskDefinition(for: node).renderMask(node, extent: extent, context: context)
+  }
+
+  /// Resolves a domain definition.
+  public func domainDefinition(for node: FeatureNode) throws -> AnyDomainFeatureDefinition {
+    guard let definition = domainDefinitions[node.typeID] else {
+      throw FeatureRegistryError.unregisteredFeature(node.typeID, .domain)
+    }
+    return definition
+  }
+
+  /// Resolves an image-effect definition.
+  public func imageEffectDefinition(for node: FeatureNode) throws -> AnyImageEffectFeatureDefinition {
+    guard let definition = imageEffectDefinitions[node.typeID] else {
+      throw FeatureRegistryError.unregisteredFeature(node.typeID, .imageEffect)
+    }
+    return definition
+  }
+
+  /// Resolves a mask definition.
+  public func maskDefinition(for node: FeatureNode) throws -> AnyMaskFeatureDefinition {
+    guard let definition = maskDefinitions[node.typeID] else {
+      throw FeatureRegistryError.unregisteredFeature(node.typeID, .mask)
+    }
+    return definition
+  }
+}
+
+/// Errors thrown by feature registry resolution.
+public enum FeatureRegistryError: Error, Equatable, Sendable {
+
+  /// No definition for the type ID has been registered for the requested capability.
+  case unregisteredFeature(FeatureTypeID, FeatureCapability)
+}
+
+/// Type-erased domain feature definition.
+public struct AnyDomainFeatureDefinition: Sendable {
+
+  /// The registered feature type ID.
+  public let typeID: FeatureTypeID
+
+  /// The current payload schema version.
+  public let currentSchemaVersion: Int
+
+  private let _validate: @Sendable (FeatureNode) throws -> Void
+  private let _apply: @Sendable (FeatureNode, CIImage, FeatureEvaluationContext) throws -> CIImage
+
+  init<Definition: DomainFeatureDefinition>(_ definition: Definition.Type) {
+    self.typeID = Definition.typeID
+    self.currentSchemaVersion = Definition.currentSchemaVersion
+    self._validate = { node in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+    }
+    self._apply = { node, image, context in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+      return try Definition.apply(payload: payload, node: node, to: image, context: context)
+    }
+  }
+
+  /// Validates a node payload for this definition.
+  public func validate(_ node: FeatureNode) throws {
+    try _validate(node)
+  }
+
+  /// Applies the feature to the current image.
+  public func apply(
+    _ node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    try _apply(node, image, context)
+  }
+}
+
+/// Type-erased image effect feature definition.
+public struct AnyImageEffectFeatureDefinition: Sendable {
+
+  /// The registered feature type ID.
+  public let typeID: FeatureTypeID
+
+  /// The current payload schema version.
+  public let currentSchemaVersion: Int
+
+  private let _validate: @Sendable (FeatureNode) throws -> Void
+  private let _apply: @Sendable (FeatureNode, CIImage, FeatureEvaluationContext) throws -> CIImage
+  private let _childImageEffects: @Sendable (FeatureNode) throws -> [FeatureNode]
+
+  init<Definition: ImageEffectFeatureDefinition>(_ definition: Definition.Type) {
+    self.typeID = Definition.typeID
+    self.currentSchemaVersion = Definition.currentSchemaVersion
+    self._validate = { node in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+    }
+    self._apply = { node, image, context in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+      return try Definition.apply(payload: payload, node: node, to: image, context: context)
+    }
+    self._childImageEffects = { node in
+      let payload = try node.decodePayload(as: Definition.self)
+      return Definition.childImageEffects(payload: payload)
+    }
+  }
+
+  /// Validates a node payload for this definition.
+  public func validate(_ node: FeatureNode) throws {
+    try _validate(node)
+  }
+
+  /// Applies the feature to the current image.
+  public func apply(
+    _ node: FeatureNode,
+    to image: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    try _apply(node, image, context)
+  }
+
+  /// Returns nested image-effect nodes owned by this definition.
+  public func childImageEffects(in node: FeatureNode) throws -> [FeatureNode] {
+    try _childImageEffects(node)
+  }
+}
+
+/// Type-erased mask feature definition.
+public struct AnyMaskFeatureDefinition: Sendable {
+
+  /// The registered feature type ID.
+  public let typeID: FeatureTypeID
+
+  /// The current payload schema version.
+  public let currentSchemaVersion: Int
+
+  private let _validate: @Sendable (FeatureNode) throws -> Void
+  private let _renderMask: @Sendable (FeatureNode, CGRect, FeatureEvaluationContext) throws -> CIImage
+  private let _childMasks: @Sendable (FeatureNode) throws -> [FeatureNode]
+
+  init<Definition: MaskFeatureDefinition>(_ definition: Definition.Type) {
+    self.typeID = Definition.typeID
+    self.currentSchemaVersion = Definition.currentSchemaVersion
+    self._validate = { node in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+    }
+    self._renderMask = { node, extent, context in
+      let payload = try node.decodePayload(as: Definition.self)
+      try Definition.validate(payload: payload, node: node)
+      return try Definition.renderMask(payload: payload, node: node, extent: extent, context: context)
+    }
+    self._childMasks = { node in
+      let payload = try node.decodePayload(as: Definition.self)
+      return Definition.childMasks(payload: payload)
+    }
+  }
+
+  /// Validates a node payload for this definition.
+  public func validate(_ node: FeatureNode) throws {
+    try _validate(node)
+  }
+
+  /// Renders the feature mask.
+  public func renderMask(
+    _ node: FeatureNode,
+    extent: CGRect,
+    context: FeatureEvaluationContext
+  ) throws -> CIImage {
+    try _renderMask(node, extent, context)
+  }
+
+  /// Returns nested mask nodes owned by this definition.
+  public func childMasks(in node: FeatureNode) throws -> [FeatureNode] {
+    try _childMasks(node)
+  }
+}
+
+private extension JSONValue {
+
+  init(_ object: Any) throws {
+    switch object {
+    case _ as NSNull:
+      self = .null
+    case let value as NSNumber:
+      if CFGetTypeID(value) == CFBooleanGetTypeID() {
+        self = .bool(value.boolValue)
+      } else {
+        self = .number(value.doubleValue)
+      }
+    case let value as Bool:
+      self = .bool(value)
+    case let value as String:
+      self = .string(value)
+    case let value as [Any]:
+      self = .array(try value.map(JSONValue.init))
+    case let value as [String: Any]:
+      self = .object(try value.mapValues(JSONValue.init))
+    default:
+      throw FeaturePayloadCodingError.unsupportedJSONObject(String(describing: type(of: object)))
+    }
+  }
+
+  var jsonObject: Any {
+    switch self {
+    case .null:
+      NSNull()
+    case let .bool(value):
+      value
+    case let .number(value):
+      value
+    case let .string(value):
+      value
+    case let .array(value):
+      value.map(\.jsonObject)
+    case let .object(value):
+      value.mapValues(\.jsonObject)
+    }
+  }
+}

--- a/Sources/BrightroomParametric/ParametricFeatureModel.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureModel.swift
@@ -1,0 +1,984 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import Foundation
+
+/// A stable identifier for a parametric editing feature or mask node.
+///
+/// Feature identifiers are stored in documents so debug views, UI selections,
+/// and future references can survive Codable round trips.
+public struct FeatureID: Codable, Equatable, Hashable, Sendable {
+
+  /// The serialized identifier value.
+  public var rawValue: String
+
+  /// Creates an identifier with the provided serialized value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a new unique identifier.
+  public init() {
+    self.rawValue = UUID().uuidString
+  }
+}
+
+/// A serializable parametric operation that can appear in an editing document.
+///
+/// Concrete feature enums use this protocol to expose common identity and
+/// enabled-state behavior without storing protocol existentials in documents.
+public protocol Feature: Codable, Equatable, Sendable {
+
+  /// The stable identity of this feature.
+  var id: FeatureID { get }
+
+  /// A Boolean value indicating whether the feature contributes to rendering.
+  var isEnabled: Bool { get }
+}
+
+/// A parametric image editing document.
+///
+/// The document intentionally stores edit parameters only. The source image is
+/// supplied to the compiler so the same document can be evaluated for preview,
+/// export, or debugging without baking pixels into the model.
+public struct EditingDocument: Codable, Equatable, Sendable {
+
+  /// The ordered main feature tree evaluated from source image to output image.
+  public var mainTree: MainTree
+
+  /// Creates a document with the provided main tree.
+  public init(mainTree: MainTree = .init()) {
+    self.mainTree = mainTree
+  }
+}
+
+/// The main editing sequence for a document.
+///
+/// Main-tree features are evaluated in array order. Domain-changing features
+/// such as crop are allowed here, while local adjustment subtrees are restricted
+/// to extent-preserving operations.
+public struct MainTree: Codable, Equatable, Sendable {
+
+  /// The features evaluated in source-to-output order.
+  public var features: [MainFeature]
+
+  /// Creates a main tree with the provided ordered features.
+  public init(features: [MainFeature] = []) {
+    self.features = features
+  }
+}
+
+/// A feature that can appear in the document's main tree.
+public enum MainFeature: Codable, Equatable, Sendable {
+
+  /// A feature that may change image extent or coordinate domain.
+  case domain(DomainFeature)
+
+  /// A global, extent-preserving image effect.
+  case effect(ImageEffectFeature)
+
+  /// A local branch that composites an effect pipeline through a mask tree.
+  case localAdjustment(LocalAdjustmentFeature)
+}
+
+extension MainFeature: Feature {
+
+  public var id: FeatureID {
+    switch self {
+    case let .domain(feature):
+      feature.id
+    case let .effect(feature):
+      feature.id
+    case let .localAdjustment(feature):
+      feature.id
+    }
+  }
+
+  public var isEnabled: Bool {
+    switch self {
+    case let .domain(feature):
+      feature.isEnabled
+    case let .effect(feature):
+      feature.isEnabled
+    case let .localAdjustment(feature):
+      feature.isEnabled
+    }
+  }
+}
+
+/// A main-tree feature that may change the current image domain.
+///
+/// Domain features are deliberately excluded from local adjustment subtrees.
+/// This makes crop and future geometry correction semantics explicit.
+public enum DomainFeature: Codable, Equatable, Sendable {
+
+  /// Crops the current domain and resets the resulting image to zero origin.
+  case crop(CropFeature)
+}
+
+extension DomainFeature: Feature {
+
+  public var id: FeatureID {
+    switch self {
+    case let .crop(feature):
+      feature.id
+    }
+  }
+
+  public var isEnabled: Bool {
+    switch self {
+    case let .crop(feature):
+      feature.isEnabled
+    }
+  }
+}
+
+/// A crop in the current main-tree domain.
+///
+/// The crop rectangle is interpreted relative to the image produced by the
+/// previous main-tree feature. A second crop therefore crops the already-cropped
+/// output of the first crop.
+public struct CropFeature: Feature {
+
+  /// The stable identity of this crop.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this crop participates in rendering.
+  public var isEnabled: Bool
+
+  /// The rectangle to keep, expressed in the current domain.
+  public var cropRect: CGRect
+
+  /// Creates a current-domain crop feature.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    cropRect: CGRect
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.cropRect = cropRect
+  }
+}
+
+/// An extent-preserving image effect.
+///
+/// Image effects can appear directly in the main tree or inside a local
+/// adjustment effect pipeline.
+public enum ImageEffectFeature: Codable, Equatable, Sendable {
+
+  /// Applies a named group of image effects.
+  case preset(PresetFeature)
+
+  /// Applies a color-cube lookup table.
+  case colorCube(ColorCubeFeature)
+
+  /// Adjusts luminance using Core Image color controls.
+  case brightness(BrightnessFeature)
+
+  /// Adjusts contrast using Core Image color controls.
+  case contrast(ContrastFeature)
+
+  /// Adjusts saturation using Core Image color controls.
+  case saturation(SaturationFeature)
+
+  /// Adjusts exposure value.
+  case exposure(ExposureFeature)
+
+  /// Recovers highlight values using Core Image highlight/shadow adjustment.
+  case highlights(HighlightsFeature)
+
+  /// Opens shadow values using Core Image highlight/shadow adjustment.
+  case shadows(ShadowsFeature)
+
+  /// Blends separate tint colors over highlight and shadow regions.
+  case highlightShadowTint(HighlightShadowTintFeature)
+
+  /// Adjusts color temperature.
+  case temperature(TemperatureFeature)
+
+  /// Sharpens luminance using Core Image sharpen luminance.
+  case sharpen(SharpenFeature)
+
+  /// Applies a Gaussian blur while preserving the input extent.
+  case gaussianBlur(GaussianBlurFeature)
+
+  /// Applies an unsharp mask.
+  case unsharpMask(UnsharpMaskFeature)
+
+  /// Applies a vignette.
+  case vignette(VignetteFeature)
+
+  /// Blends white over the input image.
+  case fade(FadeFeature)
+}
+
+extension ImageEffectFeature: Feature {
+
+  public var id: FeatureID {
+    switch self {
+    case let .preset(feature):
+      feature.id
+    case let .colorCube(feature):
+      feature.id
+    case let .brightness(feature):
+      feature.id
+    case let .contrast(feature):
+      feature.id
+    case let .saturation(feature):
+      feature.id
+    case let .exposure(feature):
+      feature.id
+    case let .highlights(feature):
+      feature.id
+    case let .shadows(feature):
+      feature.id
+    case let .highlightShadowTint(feature):
+      feature.id
+    case let .temperature(feature):
+      feature.id
+    case let .sharpen(feature):
+      feature.id
+    case let .gaussianBlur(feature):
+      feature.id
+    case let .unsharpMask(feature):
+      feature.id
+    case let .vignette(feature):
+      feature.id
+    case let .fade(feature):
+      feature.id
+    }
+  }
+
+  public var isEnabled: Bool {
+    switch self {
+    case let .preset(feature):
+      feature.isEnabled
+    case let .colorCube(feature):
+      feature.isEnabled
+    case let .brightness(feature):
+      feature.isEnabled
+    case let .contrast(feature):
+      feature.isEnabled
+    case let .saturation(feature):
+      feature.isEnabled
+    case let .exposure(feature):
+      feature.isEnabled
+    case let .highlights(feature):
+      feature.isEnabled
+    case let .shadows(feature):
+      feature.isEnabled
+    case let .highlightShadowTint(feature):
+      feature.isEnabled
+    case let .temperature(feature):
+      feature.isEnabled
+    case let .sharpen(feature):
+      feature.isEnabled
+    case let .gaussianBlur(feature):
+      feature.isEnabled
+    case let .unsharpMask(feature):
+      feature.isEnabled
+    case let .vignette(feature):
+      feature.isEnabled
+    case let .fade(feature):
+      feature.isEnabled
+    }
+  }
+}
+
+/// A named group of extent-preserving effects.
+///
+/// This is the parametric equivalent of a filter preset. It stores concrete
+/// supported effects rather than arbitrary `AnyFilter` values so the document
+/// remains Codable and inspectable.
+public struct PresetFeature: Feature {
+
+  /// The stable identity of this preset feature.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this preset participates in rendering.
+  public var isEnabled: Bool
+
+  /// The display name associated with the preset.
+  public var name: String
+
+  /// The stable preset identifier.
+  public var identifier: String
+
+  /// The effects evaluated inside the preset, in order.
+  public var effects: [ImageEffectFeature]
+
+  /// Creates a preset feature.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    name: String,
+    identifier: String,
+    effects: [ImageEffectFeature]
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.name = name
+    self.identifier = identifier
+    self.effects = effects
+  }
+}
+
+/// A color-cube lookup-table effect.
+///
+/// The feature stores cube data directly so rendering can stay in the Core Image
+/// graph without asking an `ImageSource` or bundle resource to materialize.
+public struct ColorCubeFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The display name associated with the lookup table.
+  public var name: String
+
+  /// The stable lookup-table identifier.
+  public var identifier: String
+
+  /// The opacity used when compositing the color-cube result over its input.
+  public var amount: Double
+
+  /// The color-cube dimension.
+  public var dimension: Int
+
+  /// RGBA float cube data in `CIColorCubeWithColorSpace` layout.
+  public var cubeData: Data
+
+  /// Creates a color-cube effect.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    name: String,
+    identifier: String,
+    amount: Double = 1,
+    dimension: Int,
+    cubeData: Data
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.name = name
+    self.identifier = identifier
+    self.amount = amount
+    self.dimension = dimension
+    self.cubeData = cubeData
+  }
+}
+
+/// A brightness adjustment.
+public struct BrightnessFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The brightness value passed to `CIColorControls`.
+  public var value: Double
+
+  /// Creates a brightness adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A contrast adjustment.
+public struct ContrastFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The contrast offset passed to `CIColorControls` as `1 + value`.
+  public var value: Double
+
+  /// Creates a contrast adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A saturation adjustment.
+public struct SaturationFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The saturation offset passed to `CIColorControls` as `1 + value`.
+  public var value: Double
+
+  /// Creates a saturation adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// An exposure adjustment.
+public struct ExposureFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The exposure value passed to `CIExposureAdjust`.
+  public var value: Double
+
+  /// Creates an exposure adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A highlight recovery adjustment.
+public struct HighlightsFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The highlight recovery value. It is applied as `1 - value`.
+  public var value: Double
+
+  /// Creates a highlight adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A shadow lift adjustment.
+public struct ShadowsFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The shadow amount passed to `CIHighlightShadowAdjust`.
+  public var value: Double
+
+  /// Creates a shadow adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// An RGBA color value stored inside a parametric feature document.
+public struct ParametricRGBAColor: Codable, Equatable, Sendable {
+
+  /// The red component in the Core Image working range.
+  public var red: Double
+
+  /// The green component in the Core Image working range.
+  public var green: Double
+
+  /// The blue component in the Core Image working range.
+  public var blue: Double
+
+  /// The alpha component in the Core Image working range.
+  public var alpha: Double
+
+  /// Creates an RGBA color value.
+  public init(
+    red: Double,
+    green: Double,
+    blue: Double,
+    alpha: Double
+  ) {
+    self.red = red
+    self.green = green
+    self.blue = blue
+    self.alpha = alpha
+  }
+}
+
+/// A highlight/shadow tint effect.
+public struct HighlightShadowTintFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The color composited over highlight regions.
+  public var highlightColor: ParametricRGBAColor
+
+  /// The color composited over shadow regions.
+  public var shadowColor: ParametricRGBAColor
+
+  /// Creates a highlight/shadow tint adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    highlightColor: ParametricRGBAColor,
+    shadowColor: ParametricRGBAColor
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.highlightColor = highlightColor
+    self.shadowColor = shadowColor
+  }
+}
+
+/// A color temperature adjustment.
+public struct TemperatureFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The temperature offset from Brightroom's neutral value.
+  public var value: Double
+
+  /// Creates a temperature adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A luminance sharpen adjustment.
+public struct SharpenFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The sharpness value passed to `CISharpenLuminance`.
+  public var sharpness: Double
+
+  /// The Brightroom filter radius value, resolved against the current extent.
+  public var radius: Double
+
+  /// Creates a sharpen adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    sharpness: Double,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.sharpness = sharpness
+    self.radius = radius
+  }
+}
+
+/// A Gaussian blur radius value.
+public enum GaussianBlurRadius: Codable, Equatable, Sendable {
+
+  /// A Core Image blur radius in image-domain points.
+  case absolute(Double)
+
+  /// A `FilterGaussianBlur.value` slider value, resolved against image extent.
+  case editingStackFilterValue(Double)
+}
+
+/// A Gaussian blur that preserves the input extent.
+public struct GaussianBlurFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The blur radius descriptor.
+  public var radius: GaussianBlurRadius
+
+  /// Creates a Gaussian blur.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.radius = .absolute(radius)
+  }
+
+  /// Creates a Gaussian blur from `FilterGaussianBlur.value`.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.radius = .editingStackFilterValue(value)
+  }
+}
+
+/// An unsharp mask adjustment.
+public struct UnsharpMaskFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The intensity passed to `CIUnsharpMask`.
+  public var intensity: Double
+
+  /// The Brightroom filter radius value, resolved against the current extent.
+  public var radius: Double
+
+  /// Creates an unsharp mask adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    intensity: Double,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.intensity = intensity
+    self.radius = radius
+  }
+}
+
+/// A vignette adjustment.
+public struct VignetteFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The Brightroom vignette value used for both intensity and radius scaling.
+  public var value: Double
+
+  /// Creates a vignette adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A fade adjustment that overlays white.
+public struct FadeFeature: Feature {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The opacity of the white overlay.
+  public var intensity: Double
+
+  /// Creates a fade adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    intensity: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.intensity = intensity
+  }
+}
+
+/// An ordered chain of extent-preserving effects.
+public struct EffectPipeline: Codable, Equatable, Sendable {
+
+  /// The effects applied from first to last.
+  public var effects: [ImageEffectFeature]
+
+  /// Creates an effect pipeline.
+  public init(effects: [ImageEffectFeature] = []) {
+    self.effects = effects
+  }
+}
+
+/// A local adjustment branch.
+///
+/// The branch evaluates an effect pipeline from the current main image, evaluates
+/// a mask tree in the same current domain, and composites the adjusted image
+/// back over the base image without changing extent.
+public struct LocalAdjustmentFeature: Feature {
+
+  /// The stable identity of this local adjustment.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this local adjustment participates in rendering.
+  public var isEnabled: Bool
+
+  /// The mask tree that produces the alpha used for compositing.
+  public var maskTree: MaskTree
+
+  /// The extent-preserving effects applied inside the local branch.
+  public var effectPipeline: EffectPipeline
+
+  /// The blend rule used to composite the adjusted branch over the base image.
+  public var blendMode: LocalAdjustmentBlendMode
+
+  /// Creates a local adjustment branch.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    maskTree: MaskTree,
+    effectPipeline: EffectPipeline,
+    blendMode: LocalAdjustmentBlendMode = .alpha
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.maskTree = maskTree
+    self.effectPipeline = effectPipeline
+    self.blendMode = blendMode
+  }
+}
+
+/// A blend rule for local adjustment output.
+public enum LocalAdjustmentBlendMode: String, Codable, Equatable, Sendable {
+
+  /// Uses the mask alpha to blend adjusted output over the base image.
+  case alpha
+}
+
+/// A mask graph that produces alpha in the current feature domain.
+public struct MaskTree: Codable, Equatable, Sendable {
+
+  /// The root mask node.
+  public var root: MaskNode
+
+  /// Creates a mask tree.
+  public init(root: MaskNode) {
+    self.root = root
+  }
+}
+
+/// A node in an alpha-only mask tree.
+public indirect enum MaskNode: Codable, Equatable, Sendable {
+
+  /// Produces alpha from brush strokes.
+  case brush(BrushMask)
+
+  /// Inverts the input alpha.
+  case invert(MaskNode)
+
+  /// Blurs the input alpha while preserving extent.
+  case feather(MaskFeather)
+
+  /// Combines child masks using alpha union.
+  case union([MaskNode])
+
+  /// Combines child masks using alpha intersection.
+  case intersect([MaskNode])
+
+  /// Removes one mask from another.
+  case subtract(MaskSubtract)
+}
+
+/// A brush-authored mask.
+public struct BrushMask: Feature {
+
+  /// The stable identity of this mask leaf.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this mask leaf contributes alpha.
+  public var isEnabled: Bool
+
+  /// The brush strokes authored in the current feature domain.
+  public var strokes: [BrushMaskStroke]
+
+  /// Creates a brush-authored mask.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    strokes: [BrushMaskStroke] = []
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.strokes = strokes
+  }
+}
+
+/// A continuous brush stroke represented by sampled stamp centers.
+public struct BrushMaskStroke: Codable, Equatable, Sendable {
+
+  /// The stamp centers in current feature-domain coordinates.
+  public var stamps: [CGPoint]
+
+  /// The brush used to render each stamp.
+  public var brush: BrushMaskBrush
+
+  /// Creates a brush stroke.
+  public init(
+    stamps: [CGPoint],
+    brush: BrushMaskBrush
+  ) {
+    self.stamps = stamps
+    self.brush = brush
+  }
+}
+
+/// Brush parameters for a mask stroke.
+public struct BrushMaskBrush: Codable, Equatable, Sendable {
+
+  /// The brush diameter in current feature-domain units.
+  public var diameter: Double
+
+  /// The hard inner alpha region, from `0` for soft to `1` for hard.
+  public var hardness: Double
+
+  /// The stamp opacity, from `0` to `1`.
+  public var opacity: Double
+
+  /// Creates brush parameters.
+  public init(
+    diameter: Double,
+    hardness: Double,
+    opacity: Double
+  ) {
+    self.diameter = diameter
+    self.hardness = hardness
+    self.opacity = opacity
+  }
+}
+
+/// A mask feather operation.
+public struct MaskFeather: Codable, Equatable, Sendable {
+
+  /// The stable identity of this operation.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this operation participates in rendering.
+  public var isEnabled: Bool
+
+  /// The input mask node to feather.
+  public var input: MaskNode
+
+  /// The blur radius used to feather alpha.
+  public var radius: Double
+
+  /// Creates a feather operation.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    input: MaskNode,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.input = input
+    self.radius = radius
+  }
+}
+
+/// A mask subtraction operation.
+public struct MaskSubtract: Codable, Equatable, Sendable {
+
+  /// The stable identity of this operation.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this operation participates in rendering.
+  public var isEnabled: Bool
+
+  /// The mask to subtract from.
+  public var base: MaskNode
+
+  /// The mask removed from the base alpha.
+  public var removing: MaskNode
+
+  /// Creates a mask subtraction operation.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    base: MaskNode,
+    removing: MaskNode
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.base = base
+    self.removing = removing
+  }
+}

--- a/Sources/BrightroomParametric/ParametricFilterSupport.swift
+++ b/Sources/BrightroomParametric/ParametricFilterSupport.swift
@@ -55,6 +55,38 @@ enum ParametricRadiusCalculator {
   }
 }
 
+/// Applies a vignette centered in the image's current domain.
+///
+/// `CIVignette` accepts a scalar radius and does not expose the effect center,
+/// which makes repeated crop operations hard to reason about. The parametric
+/// renderer uses `CIVignetteEffect` so the vignette is explicitly evaluated
+/// against the current feature output extent.
+enum ParametricVignetteRenderer {
+
+  /// Applies a vignette to the supplied image while preserving its extent.
+  static func apply(
+    value: Double,
+    to image: CIImage
+  ) -> CIImage {
+    guard abs(value) > 0.0001 else {
+      return image
+    }
+
+    let extent = image.extent
+    let radius = max(extent.width, extent.height) * 0.5
+    return image.applyingFilter(
+      "CIVignetteEffect",
+      parameters: [
+        kCIInputCenterKey: CIVector(x: extent.midX, y: extent.midY),
+        kCIInputRadiusKey: radius,
+        kCIInputIntensityKey: value,
+        "inputFalloff": 0.5,
+      ]
+    )
+    .cropped(to: extent)
+  }
+}
+
 /// Geometry helpers kept inside the Parametric layer so the renderer can be
 /// compiled without BrightroomEngine's UIKit-backed support files.
 enum ParametricImageGeometry {

--- a/Sources/BrightroomParametric/ParametricFilterSupport.swift
+++ b/Sources/BrightroomParametric/ParametricFilterSupport.swift
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// Shared constants that mirror Brightroom's legacy filter slider ranges.
+///
+/// The parametric renderer keeps these values local so the rendering graph can
+/// be compiled by a macOS app without importing the UIKit-backed legacy filter
+/// types.
+enum ParametricFilterConstants {
+
+  /// The maximum legacy slider value for Gaussian blur.
+  static let gaussianBlurSliderMax = 100.0
+
+  /// The maximum legacy slider value for unsharp-mask radius.
+  static let unsharpMaskRadiusSliderMax = 1.0
+
+  /// The maximum legacy slider value for vignette.
+  static let vignetteSliderMax = 2.0
+}
+
+/// Converts Brightroom-style normalized radius values into image-domain radii.
+enum ParametricRadiusCalculator {
+
+  /// Resolves a slider value against the diagonal length of the current image.
+  static func radius(
+    value: Double,
+    max: Double,
+    imageExtent: CGRect
+  ) -> Double {
+    let base = Double(sqrt(pow(imageExtent.width, 2) + pow(imageExtent.height, 2)))
+    let coefficient = base / 20
+    return coefficient * value / max
+  }
+}
+
+/// Geometry helpers kept inside the Parametric layer so the renderer can be
+/// compiled without BrightroomEngine's UIKit-backed support files.
+enum ParametricImageGeometry {
+
+  /// Translates the image so its extent starts at zero while preserving pixels.
+  static func removingExtentOffset(_ image: CIImage) -> CIImage {
+    image.transformed(
+      by: .init(
+        translationX: -image.extent.origin.x,
+        y: -image.extent.origin.y
+      )
+    )
+  }
+}
+
+/// Creates Core Image color-cube filters from serialized cube data.
+enum ParametricColorCubeHelper {
+
+  /// Creates a `CIColorCubeWithColorSpace` filter for a stored RGBA float cube.
+  static func makeColorCubeFilter(
+    cubeData: Data,
+    dimension: Int,
+    cacheKey: String?
+  ) -> CIFilter {
+    if let cacheKey,
+       let cached = parametricColorCubeFilterCache.object(forKey: cacheKey as NSString)
+    {
+      return cached.copy() as! CIFilter
+    }
+
+    let expectedByteCount = dimension * dimension * dimension * 4 * MemoryLayout<Float>.size
+    precondition(
+      cubeData.count == expectedByteCount,
+      "Cube data byte count must be \(expectedByteCount), but got \(cubeData.count)."
+    )
+
+    let filter = CIFilter(
+      name: "CIColorCubeWithColorSpace",
+      parameters: [
+        "inputCubeDimension": dimension,
+        "inputCubeData": cubeData,
+        "inputColorSpace": CGColorSpaceCreateDeviceRGB(),
+      ]
+    )!
+
+    if let cacheKey {
+      parametricColorCubeFilterCache.setObject(filter, forKey: cacheKey as NSString)
+    }
+
+    return filter
+  }
+}
+
+nonisolated(unsafe) private let parametricColorCubeFilterCache = NSCache<NSString, CIFilter>()

--- a/Sources/BrightroomParametric/ParametricImageRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricImageRenderer.swift
@@ -1,0 +1,89 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Renders parametric feature documents for still images.
+///
+/// `ParametricImageRenderer` is the public rendering facade for image inputs.
+/// It delegates graph construction to `FeatureGraphCompiler` and returns lazy
+/// Core Image recipes; callers decide when to materialize the result with a
+/// `CIContext`.
+public struct ParametricImageRenderer: Sendable {
+
+  /// The compiler used to evaluate feature graphs.
+  public var compiler: FeatureGraphCompiler
+
+  /// Creates an image renderer.
+  public init(compiler: FeatureGraphCompiler = .init()) {
+    self.compiler = compiler
+  }
+
+  /// Evaluates an enum-backed editing document from a source image.
+  ///
+  /// This path exists for the first parametric prototype and migration tests.
+  /// New saved documents should prefer the registry-backed `FeatureDocument`.
+  public func makeOutput(
+    from sourceImage: CIImage,
+    document: EditingDocument
+  ) throws -> FeatureGraphOutput {
+    try compiler.makeOutput(
+      from: sourceImage,
+      document: document
+    )
+  }
+
+  /// Evaluates a registry-backed feature document from a source image.
+  public func makeOutput(
+    from sourceImage: CIImage,
+    document: FeatureDocument
+  ) throws -> FeatureGraphOutput {
+    try compiler.makeOutput(
+      from: sourceImage,
+      document: document
+    )
+  }
+
+  /// Returns only the final image recipe for an enum-backed document.
+  public func makeImage(
+    from sourceImage: CIImage,
+    document: EditingDocument
+  ) throws -> CIImage {
+    try makeOutput(
+      from: sourceImage,
+      document: document
+    )
+    .image
+  }
+
+  /// Returns only the final image recipe for a registry-backed document.
+  public func makeImage(
+    from sourceImage: CIImage,
+    document: FeatureDocument
+  ) throws -> CIImage {
+    try makeOutput(
+      from: sourceImage,
+      document: document
+    )
+    .image
+  }
+}

--- a/Sources/BrightroomParametric/ParametricKernelRegistry.swift
+++ b/Sources/BrightroomParametric/ParametricKernelRegistry.swift
@@ -1,0 +1,169 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Provides cached kernels used by the parametric Core Image compiler.
+///
+/// Documents store semantic feature data only. This registry is renderer
+/// infrastructure and all custom operations are represented as Metal-backed
+/// Core Image kernels. The backing source can evolve from inlined Metal source
+/// to compiled metallib resources without changing document Codable shape.
+public struct ParametricKernelRegistry: Sendable {
+
+  /// Creates a registry for Metal-backed parametric kernels.
+  public init() {}
+
+  func makeBrushStamp(
+    extent: CGRect,
+    center: CGPoint,
+    radius: Double,
+    hardness: Double,
+    opacity: Double
+  ) throws -> CIImage {
+    guard radius > 0, opacity > 0 else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    let kernel = try ParametricMetalKernelStore.colorKernel(named: "brushStamp")
+    guard let image = kernel.apply(
+      extent: extent,
+      arguments: [
+        CIVector(x: center.x, y: center.y),
+        radius,
+        hardness,
+        opacity,
+      ]
+    ) else {
+      throw ParametricKernelRegistryError.failedToApplyKernel("brushStamp")
+    }
+    return image.cropped(to: extent)
+  }
+
+  func subtractMask(
+    base: CIImage,
+    removing: CIImage,
+    extent: CGRect
+  ) throws -> CIImage {
+    let kernel = try ParametricMetalKernelStore.colorKernel(named: "maskSubtract")
+    guard let image = kernel.apply(
+      extent: extent,
+      arguments: [removing, base]
+    ) else {
+      throw ParametricKernelRegistryError.failedToApplyKernel("maskSubtract")
+    }
+    return image.cropped(to: extent)
+  }
+}
+
+/// Errors thrown while preparing or applying parametric custom kernels.
+public enum ParametricKernelRegistryError: Error, Equatable, Sendable {
+
+  /// A named kernel was not present in the loaded Metal source.
+  case missingKernel(String)
+
+  /// Core Image returned nil while applying a named kernel.
+  case failedToApplyKernel(String)
+
+  /// Core Image failed to compile the Metal source.
+  case failedToCompileMetalSource(String)
+}
+
+private enum ParametricMetalKernelStore {
+
+  static func colorKernel(named name: String) throws -> CIColorKernel {
+    switch loadedKernels {
+    case let .success(kernels):
+      guard let kernel = kernels[name] else {
+        throw ParametricKernelRegistryError.missingKernel(name)
+      }
+      return kernel
+    case let .failure(error):
+      throw error
+    }
+  }
+
+  private static let loadedKernels: Result<[String: CIColorKernel], ParametricKernelRegistryError> = {
+    do {
+      let kernels = try CIKernel.kernels(withMetalString: metalSource)
+      var result: [String: CIColorKernel] = [:]
+      for kernel in kernels {
+        if let colorKernel = kernel as? CIColorKernel {
+          result[kernel.name] = colorKernel
+        }
+      }
+      return .success(result)
+    } catch {
+      return .failure(.failedToCompileMetalSource(String(describing: error)))
+    }
+  }()
+
+  private static let metalSource = """
+  #include <CoreImage/CoreImage.h>
+  using namespace metal;
+
+  extern "C" { namespace coreimage {
+    [[ stitchable ]] float4 brushStamp(
+      float2 center,
+      float radius,
+      float hardness,
+      float opacity,
+      destination dest
+    ) {
+      if (radius <= 0.0 || opacity <= 0.0) {
+        return float4(0.0);
+      }
+
+      float distanceFromCenter = length(dest.coord() - center);
+      if (distanceFromCenter > radius) {
+        return float4(0.0);
+      }
+
+      float normalizedDistance = distanceFromCenter / radius;
+      float alpha = 1.0;
+      if (hardness < 0.999) {
+        float start = clamp(hardness, 0.0, 0.998);
+        alpha = 1.0 - smoothstep(start, 1.0, normalizedDistance);
+      }
+
+      alpha *= clamp(opacity, 0.0, 1.0);
+      return float4(alpha, alpha, alpha, alpha);
+    }
+
+    [[ stitchable ]] float4 maskSubtract(sample_t removing, sample_t base) {
+      float alpha = max(base.a - removing.a, 0.0);
+      return float4(alpha, alpha, alpha, alpha);
+    }
+  }}
+  """
+}
+
+extension CIImage {
+
+  static func parametricTransparent(extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0)).cropped(to: extent)
+  }
+
+  static func parametricOpaqueWhite(extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: 1, green: 1, blue: 1, alpha: 1)).cropped(to: extent)
+  }
+}

--- a/Sources/BrightroomParametric/ParametricVideoRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricVideoRenderer.swift
@@ -1,0 +1,226 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import AVFoundation
+import CoreImage
+import Foundation
+
+/// Renders parametric feature documents for video assets.
+///
+/// `ParametricVideoRenderer` keeps video processing in the Core Image domain. It
+/// does not decode, encode, or export movies by itself; callers pass the
+/// returned `AVMutableVideoComposition` to `AVPlayerItem` or
+/// `AVAssetExportSession`.
+public struct ParametricVideoRenderer: Sendable {
+
+  /// How the video composition should choose its render canvas.
+  public enum RenderSizeMode: Equatable, Sendable {
+
+    /// Preserve AVFoundation's source render size.
+    case source
+
+    /// Resolve the render size by applying the document to a synthetic frame
+    /// with the source render size.
+    case featureOutput
+
+    /// Use an explicitly supplied render size.
+    case custom(CGSize)
+  }
+
+  /// The image renderer used to evaluate the feature graph for each frame.
+  public var imageRenderer: ParametricImageRenderer
+
+  /// Creates a video renderer.
+  public init(imageRenderer: ParametricImageRenderer = .init()) {
+    self.imageRenderer = imageRenderer
+  }
+
+  /// Creates a video renderer using a specific feature graph compiler.
+  public init(compiler: FeatureGraphCompiler) {
+    self.imageRenderer = ParametricImageRenderer(compiler: compiler)
+  }
+
+  /// Applies a feature document to a single video frame.
+  ///
+  /// - Parameters:
+  ///   - sourceImage: The frame image supplied by AVFoundation.
+  ///   - document: The feature document to evaluate.
+  ///   - renderExtent: The optional output canvas. When specified, the feature
+  ///     output is placed at the canvas origin and cropped/expanded to that
+  ///     extent using a transparent Core Image background.
+  /// - Returns: A Core Image recipe for the filtered frame.
+  public func makeFrameImage(
+    from sourceImage: CIImage,
+    document: FeatureDocument,
+    renderExtent: CGRect? = nil
+  ) throws -> CIImage {
+    let output = try imageRenderer.makeImage(
+      from: sourceImage,
+      document: document
+    )
+
+    guard let renderExtent else {
+      return output
+    }
+
+    return output.parametricPlaced(in: renderExtent)
+  }
+
+  /// Resolves the render size for a video composition.
+  ///
+  /// `featureOutput` performs a dry run with a transparent frame so domain
+  /// features such as crop can decide the final canvas size without decoding a
+  /// real video frame.
+  public func resolveRenderSize(
+    sourceRenderSize: CGSize,
+    document: FeatureDocument,
+    mode: RenderSizeMode
+  ) throws -> CGSize {
+    guard sourceRenderSize.isParametricVideoValidRenderSize else {
+      throw ParametricVideoRendererError.invalidSourceRenderSize(sourceRenderSize)
+    }
+
+    switch mode {
+    case .source:
+      return sourceRenderSize
+
+    case let .custom(renderSize):
+      guard renderSize.isParametricVideoValidRenderSize else {
+        throw ParametricVideoRendererError.invalidRenderSize(renderSize)
+      }
+      return renderSize
+
+    case .featureOutput:
+      let sourceExtent = CGRect(origin: .zero, size: sourceRenderSize)
+      let dryRunInput = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+        .cropped(to: sourceExtent)
+      let output = try imageRenderer.makeOutput(
+        from: dryRunInput,
+        document: document
+      )
+      .image
+      let renderSize = output.extent.size
+      guard renderSize.isParametricVideoValidRenderSize else {
+        throw ParametricVideoRendererError.invalidRenderSize(renderSize)
+      }
+      return renderSize
+    }
+  }
+
+  /// Creates a Core Image backed video composition that applies the document to
+  /// every frame.
+  ///
+  /// The returned composition can be assigned to `AVPlayerItem.videoComposition`
+  /// or `AVAssetExportSession.videoComposition`.
+  public func makeVideoComposition(
+    for asset: AVAsset,
+    document: FeatureDocument,
+    renderSizeMode: RenderSizeMode = .featureOutput,
+    ciContext: CIContext? = nil
+  ) throws -> AVMutableVideoComposition {
+    let sizingComposition = AVMutableVideoComposition(asset: asset) { request in
+      request.finish(with: request.sourceImage, context: nil)
+    }
+    let sourceRenderSize = ParametricVideoRenderer.sourceRenderSize(
+      for: asset,
+      sizingComposition: sizingComposition
+    )
+    let renderSize = try resolveRenderSize(
+      sourceRenderSize: sourceRenderSize,
+      document: document,
+      mode: renderSizeMode
+    )
+    let renderExtent = CGRect(origin: .zero, size: renderSize)
+    let imageRenderer = imageRenderer
+
+    let composition = AVMutableVideoComposition(asset: asset) { request in
+      do {
+        let output = try ParametricVideoRenderer(imageRenderer: imageRenderer).makeFrameImage(
+          from: request.sourceImage,
+          document: document,
+          renderExtent: renderExtent
+        )
+        request.finish(with: output, context: ciContext)
+      } catch {
+        request.finish(with: error)
+      }
+    }
+    composition.renderSize = renderSize
+    guard composition.renderSize.isParametricVideoValidRenderSize else {
+      throw ParametricVideoRendererError.invalidRenderSize(composition.renderSize)
+    }
+    return composition
+  }
+
+  private static func sourceRenderSize(
+    for asset: AVAsset,
+    sizingComposition: AVMutableVideoComposition
+  ) -> CGSize {
+    if sizingComposition.renderSize.isParametricVideoValidRenderSize {
+      return sizingComposition.renderSize
+    }
+
+    if let composition = asset as? AVComposition,
+       composition.naturalSize.isParametricVideoValidRenderSize
+    {
+      return composition.naturalSize
+    }
+
+    return sizingComposition.renderSize
+  }
+}
+
+/// Errors thrown while preparing parametric video rendering.
+public enum ParametricVideoRendererError: Error, Equatable, Sendable {
+
+  /// AVFoundation could not provide a usable source render size.
+  case invalidSourceRenderSize(CGSize)
+
+  /// The requested or resolved output render size is invalid.
+  case invalidRenderSize(CGSize)
+}
+
+private extension CIImage {
+
+  func parametricPlaced(in renderExtent: CGRect) -> CIImage {
+    let placed = transformed(
+      by: CGAffineTransform(
+        translationX: renderExtent.minX - extent.minX,
+        y: renderExtent.minY - extent.minY
+      )
+    )
+    let background = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+      .cropped(to: renderExtent)
+    return placed
+      .composited(over: background)
+      .cropped(to: renderExtent)
+  }
+}
+
+private extension CGSize {
+
+  var isParametricVideoValidRenderSize: Bool {
+    width.isFinite
+      && height.isFinite
+      && width > 0
+      && height > 0
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new `BrightroomParametric` SwiftPM product/target for platform-neutral parametric editing features.
- Move Feature documents, registry-backed definitions, graph compilation, image rendering, video rendering, and Metal-backed mask kernels into the new module.
- Keep the `EditingStack` bridge inside `BrightroomEngine` so legacy `EditingStack.Edit.Filters` can convert into parametric feature pipelines without making the new module depend on Engine/UI.
- Add SwiftUI image/video playgrounds plus a lightweight macOS `ParametricMacDemo` target for interactive checks.

## Notes

`Package.swift` now declares macOS support so the new `BrightroomParametric` product can build for macOS. This PR does not make the UIKit-backed `BrightroomEngine` or `BrightroomUI` surfaces a full macOS port.

## Validation

- `plutil -lint Dev/Brightroom.xcodeproj/project.pbxproj`
- `xcodebuild -project Dev/Brightroom.xcodeproj -scheme ParametricMacDemo -destination 'platform=macOS' -derivedDataPath build/CodexDerivedData build`
- `xcodebuild -project Dev/Brightroom.xcodeproj -scheme BrightroomEngineTests -destination 'platform=iOS Simulator,id=05718949-3329-4852-9F7A-FA1649441821' -destination-timeout 60 -derivedDataPath build/CodexDerivedData -only-testing:BrightroomEngineTests/ParametricFeatureTreeTests test`
- `xcodebuild -project Dev/Brightroom.xcodeproj -scheme SwiftUIDemo -destination 'platform=iOS Simulator,id=05718949-3329-4852-9F7A-FA1649441821' -destination-timeout 60 -derivedDataPath build/CodexDerivedData build`