### PR TITLE
Remove load-time MTLTexture conversion; warm Core Image instead

### DIFF
--- a/Sources/BrightroomEngine/Core/EditingStack.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.swift
@@ -20,7 +20,6 @@
 // THE SOFTWARE.
 
 import CoreImage
-import MetalKit
 import SwiftUI
 import UIKit
 import Combine
@@ -50,8 +49,6 @@ open class EditingStack: Hashable {
   )
 
   public struct Options {
-
-    public var usesMTLTextureForEditingImage: Bool = true
 
     public init() {}
   }
@@ -214,8 +211,6 @@ open class EditingStack: Hashable {
 
   public let options: Options
 
-  private let mtlDevice = MTLCreateSystemDefaultDevice()
-
   public let imageProvider: ImageProvider
 
   private let filterPresets: [FilterPreset]
@@ -352,15 +347,11 @@ open class EditingStack: Hashable {
 
       /// resized
       let _editingSourceCIImage: CIImage = editingSourceCGImage._makeCIImage(
-        orientation: metadata.orientation,
-        device: self.mtlDevice,
-        usesMTLTexture: self.options.usesMTLTextureForEditingImage
+        orientation: metadata.orientation
       )
 
       let _thumbnailImage: CIImage = thumbnailCGImage._makeCIImage(
-        orientation: metadata.orientation,
-        device: self.mtlDevice,
-        usesMTLTexture: self.options.usesMTLTextureForEditingImage
+        orientation: metadata.orientation
       )
 
       self.adjustCropExtent(
@@ -377,7 +368,7 @@ open class EditingStack: Hashable {
 
           let initialEdit = Edit(crop: crop)
 
-          self.loadedState = .init(
+          let loaded = Loaded(
             imageSource: imageSource,
             metadata: metadata,
             initialEditing: initialEdit,
@@ -391,10 +382,24 @@ open class EditingStack: Hashable {
             )
           )
 
-          self.imageProviderSubscription = nil
+          /**
+           Warm Core Image's GPU pipeline off the main thread *before* publishing
+           `loadedState` (which reveals the editing canvas). The source is no longer
+           pre-uploaded as an MTLTexture at load time, so without this the first
+           `draw(in:)` would pay the GPU upload + one-time pipeline compilation on
+           the main thread and visibly stall.
+           */
+          self.backgroundQueue.async { [weak self] in
+            guard let self else { return }
 
-          DispatchQueue.main.async {
-            onPreparationCompleted()
+            EditingImageWarmUp.warmUp(loaded.editingSourceImage)
+
+            self.loadedState = loaded
+            self.imageProviderSubscription = nil
+
+            DispatchQueue.main.async {
+              onPreparationCompleted()
+            }
           }
         }
       )
@@ -430,9 +435,7 @@ open class EditingStack: Hashable {
       return try orientedImage
         .croppedWithColorspace(to: renderCrop)
         ._makeCIImage(
-          orientation: .up,
-          device: mtlDevice,
-          usesMTLTexture: options.usesMTLTextureForEditingImage
+          orientation: .up
         )
     } catch {
       return .init(color: .gray)

--- a/Sources/BrightroomEngine/Engine/CoreGraphics+.swift
+++ b/Sources/BrightroomEngine/Engine/CoreGraphics+.swift
@@ -277,171 +277,21 @@ extension CGImage {
 
 }
 
-import Metal
-import MetalKit
 import CoreImage
 
 extension CGImage {
 
+  /// Creates a `CIImage` from this `CGImage`, applying the given orientation.
+  ///
+  /// The image's color space is carried over intrinsically by `CIImage(cgImage:)`,
+  /// and Core Image uploads pixels to the GPU lazily on first render through a
+  /// Metal-backed `CIContext`. There is no need to pre-decode into an `MTLTexture`
+  /// here: the editing canvas re-renders the source into its own viewport texture
+  /// every frame, so the backing of this image is irrelevant to display.
   func _makeCIImage(
-    orientation: CGImagePropertyOrientation,
-    device: MTLDevice?,
-    usesMTLTexture: Bool
+    orientation: CGImagePropertyOrientation
   ) -> CIImage {
-
-    let cgImage = self
-
-    let colorSpace = cgImage.colorSpace ?? CGColorSpaceCreateDeviceRGB()
-
-    func createFromCGImage() -> CIImage {
-      return CIImage(
-        cgImage: cgImage
-      )
-      .oriented(orientation)
-    }
-
-    func createFromMTLTexture(device: MTLDevice) throws -> CIImage {
-      let thumbnailTexture = try makeMTLTexture(
-        from: cgImage,
-        device: device
-      )
-
-      let ciImage = try CIImage(
-        mtlTexture: thumbnailTexture,
-        options: [.colorSpace: colorSpace]
-      )
-        .map {
-          $0.transformed(by: .init(scaleX: 1, y: -1))
-        }.map {
-          $0.transformed(by: .init(translationX: 0, y: $0.extent.height))
-        }
-        .map {
-          $0.oriented(orientation)
-        }
-        .unwrap()
-
-      EngineLog.debug(.stack, "Load MTLTexture")
-
-      return ciImage
-    }
-
-    if usesMTLTexture {
-      assert(device != nil)
-    }
-
-    if usesMTLTexture, let device = device {
-
-      do {
-        // TODO: As possible, creates CIImage from MTLTexture
-        // 16bits image can't be MTLTexture with MTKTextureLoader.
-        // https://stackoverflow.com/questions/54710592/cant-load-large-jpeg-into-a-mtltexture-with-mtktextureloader
-        return try createFromMTLTexture(device: device)
-      } catch {
-        EngineLog.debug(
-          .stack,
-          "Unable to create MTLTexutre, fallback to CIImage from CGImage.\n\(cgImage)"
-        )
-
-        return createFromCGImage()
-      }
-    } else {
-
-      if usesMTLTexture, device == nil {
-        EngineLog.error(
-          .stack,
-          "MTLDevice not found, fallback to using CGImage to create CIImage."
-        )
-      }
-
-      return createFromCGImage()
-    }
-
+    return CIImage(cgImage: self).oriented(orientation)
   }
-
-}
-
-
-private enum MTLImageCreationError: Error {
-  case imageTooBig
-}
-
-extension MTLDevice {
-  fileprivate func supportsImage(size: CGSize) -> Bool {
-#if DEBUG
-    switch MTLGPUFamily.apple1 {
-    case .apple1,
-        .apple2,
-        .apple3,
-        .apple4,
-        .apple5,
-        .apple6,
-        .apple7,
-        .apple8,
-        .apple9,
-        .common1,
-        .common2,
-        .common3,
-        .mac1,
-        .mac2,
-        .macCatalyst1,
-        .macCatalyst2,
-        .metal3:
-      break
-    @unknown default:  //If a warning is triggered here, please check https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf for a possibly new value in the Maximum 2D texture width and height table.
-      break
-    }
-#endif
-    let maxSideSize: CGFloat = self.supportsFamily(.apple3) ? 16384 : 8192
-    return size.width <= maxSideSize && size.height <= maxSideSize
-  }
-}
-
-/// TODO: As possible, creates CIImage from MTLTexture
-/// 16bits image can't be MTLTexture with MTKTextureLoader.
-/// https://stackoverflow.com/questions/54710592/cant-load-large-jpeg-into-a-mtltexture-with-mtktextureloader
-private func makeMTLTexture(from cgImage: CGImage, device: MTLDevice) throws -> MTLTexture {
-  guard device.supportsImage(size: cgImage.size) else {
-    throw MTLImageCreationError.imageTooBig
-  }
-
-#if true
-  let loader = MTKTextureLoader(device: device)
-  let texture = try loader.newTexture(cgImage: cgImage, options: [:])
-  return texture
-#else
-
-  // Here does not work well.
-
-  let textureDescriptor = MTLTextureDescriptor()
-
-  textureDescriptor.pixelFormat = .rgba16Uint
-  textureDescriptor.width = cgImage.width
-  textureDescriptor.height = cgImage.height
-
-  let texture = try device.makeTexture(descriptor: textureDescriptor).unwrap(
-    orThrow: "Failed to create MTLTexture"
-  )
-
-  let context = try CGContext.makeContext(for: cgImage)
-    .perform { context in
-      let flip = CGAffineTransform(a: 1, b: 0, c: 0, d: -1, tx: 0, ty: CGFloat(cgImage.height))
-      context.concatenate(flip)
-      context.draw(
-        cgImage,
-        in: CGRect(x: 0, y: 0, width: CGFloat(cgImage.width), height: CGFloat(cgImage.height))
-      )
-    }
-
-  let data = try context.data.unwrap()
-
-  texture.replace(
-    region: MTLRegionMake2D(0, 0, cgImage.width, cgImage.height),
-    mipmapLevel: 0,
-    withBytes: data,
-    bytesPerRow: 8 * cgImage.width
-  )
-
-  return texture
-#endif
 
 }

--- a/Sources/BrightroomEngine/Engine/EditingImageWarmUp.swift
+++ b/Sources/BrightroomEngine/Engine/EditingImageWarmUp.swift
@@ -1,0 +1,57 @@
+import CoreImage
+import Metal
+
+/// Primes Core Image's GPU pipeline for a freshly-loaded editing image.
+///
+/// Loading no longer pre-uploads the source into an `MTLTexture` (Core Image now
+/// uploads the `CIImage(cgImage:)` lazily on first render). Without warming, that
+/// upload — together with the one-time Metal pipeline-state compilation Core Image
+/// performs the first time it renders on a device — would land on the main thread
+/// during the editing canvas's first `draw(in:)`, causing a visible hitch.
+///
+/// Rendering the source once on a background queue here moves that cost off the
+/// first frame: the Core Image kernel/pipeline compilation is cached device-wide
+/// (so the canvas's own `CIContext` reuses it), and the source bitmap is already
+/// decoded, leaving only a cheap CPU→GPU blit for the first real frame.
+enum EditingImageWarmUp {
+
+  /// A dedicated, process-wide context used only for warm-up renders. Creating it
+  /// lazily means the first `warmUp(_:)` call also absorbs the context/library
+  /// compilation cost on the background queue rather than on the first frame.
+  private static let context: CIContext? = {
+    guard let device = MTLCreateSystemDefaultDevice() else {
+      return nil
+    }
+    return CIContext(
+      mtlDevice: device,
+      options: [.name: "Brightroom.WarmUp", .cacheIntermediates: false]
+    )
+  }()
+
+  /// Forces a synchronous GPU render of `image`, sampling it in full so the source
+  /// texture is uploaded and the render pipeline is compiled. The output is
+  /// discarded. Safe to call from a background queue; the readback is bounded to a
+  /// small size to keep the cost negligible.
+  static func warmUp(_ image: CIImage) {
+    guard let context else {
+      return
+    }
+
+    let extent = image.extent
+    guard extent.isInfinite == false, extent.isEmpty == false else {
+      return
+    }
+
+    // Downscale so the whole source is sampled (forcing a full upload and the
+    // sampling pipeline) while keeping the read-back tiny.
+    let maxSide = max(extent.width, extent.height)
+    let scale = maxSide > 256 ? 256 / maxSide : 1
+    let scaled = image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+
+    autoreleasepool {
+      _ = context.createCGImage(scaled, from: scaled.extent)
+    }
+
+    EngineLog.debug(.stack, "Warmed up Core Image pipeline for editing image")
+  }
+}


### PR DESCRIPTION
## Summary
- Remove the load-time path that eagerly decoded the editing source into an `MTLTexture` via `MTKTextureLoader`; collapse `CGImage._makeCIImage` down to `CIImage(cgImage:).oriented()`.
- Delete `EditingStack.Options.usesMTLTextureForEditingImage` and its plumbing (`makeMTLTexture` / `supportsImage` / `MTLImageCreationError`, the now-unused `mtlDevice`, and the `MetalKit` import).
- Add `EditingImageWarmUp`: render the source once on a background queue before publishing `loadedState`, warming Core Image's pipeline.

## Why
In the v5 canvas, `EditingCanvasMTKView` re-renders the source `CIImage` into its own viewport texture every frame (`viewportSourceImage`). The source's backing — `MTLTexture` vs `CGImage` — is therefore irrelevant to display, so the load-time texture conversion is unnecessary. It only carried downsides:

- `MTKTextureLoader` quantizes to **8-bit**, defeating the P3/EDR pixel format `MetalImageView` configures.
- **16-bit images were never supported** and silently fell back to the `CGImage` path, so behavior was already split in two.
- `CIImage(mtlTexture:)` required a **y-flip** that has been a recurring source of orientation bugs (e.g. flipped export masks).

This direction also matches the Core Image guidance in WWDC 2026 Session 305 ("Enhance RAW image processing with Core Image"): use a per-view Metal-backed `CIContext` rendering into an `MTKView`, and do not pre-convert the source into a texture yourself.

## Preload (warm-up)
Dropping the texture path moves the GPU upload — previously done off-thread by `MTKTextureLoader` during load — plus Core Image's one-time pipeline-state compilation onto the first main-thread `draw(in:)`, which visibly stalls the first frame. `EditingImageWarmUp` addresses this:

- Renders the source downscaled to 256px through a dedicated process-wide `CIContext(mtlDevice:)` (downscaling forces the whole source to be sampled → full upload + pipeline compilation), with a tiny read-back.
- Runs on a background queue in `handleImageLoaded` **before** `loadedState` is assigned. Since `isLoading == (loadedState == nil)`, the loading spinner stays up until warm-up finishes, so the canvas only draws once the pipeline is hot.
- Never blocks the main thread. No new public API.

## Test plan
- [x] `xcodebuild -scheme BrightroomUI` build succeeds
- [x] `BrightroomEngineTests` pass with 0 failures (incl. orientation/render suites: `RendererOrientationTests`, `LocalAdjustmentMaskOrientationTests`, `RendererDeviceEquivalenceTests`)
- [ ] On-device verification of the first-load hitch (not yet done)

## Notes
- `Options.usesMTLTextureForEditingImage` was public, so its removal is technically a breaking change. v5 already carries larger breaking changes (e.g. PixelEditor removal), so this is in scope.
- The warm-up gates presentation: the spinner is slightly longer in exchange for a hitch-free first frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)