### PR TITLE
Wide-gamut (Display-P3) editing canvas + export gamut parity

### DIFF
--- a/Dev/Sources/SwiftUIDemo/ContentView.swift
+++ b/Dev/Sources/SwiftUIDemo/ContentView.swift
@@ -27,6 +27,9 @@ struct ContentView: View {
   @State private var photosCropSuperSmallStack = Mocks.makeEditingStack(
     image: Asset.superSmall.image
   )
+  @State private var photosCropInstaLogoStack = Mocks.makeEditingStack(
+    image: Asset.instaLogo.image
+  )
   @State private var photosCropRemoteStack = EditingStack(
     imageProvider: .init(
       editableRemoteURL: URL(
@@ -148,6 +151,12 @@ struct ContentView: View {
               Button("Super small") {
                 fullScreenView = .init(showsDismissButton: false) {
                   DemoPhotosCropView(stack: photosCropSuperSmallStack)
+                }
+              }
+
+              Button("Insta Logo") {
+                fullScreenView = .init(showsDismissButton: false) {
+                  DemoPhotosCropView(stack: photosCropInstaLogoStack)
                 }
               }
 

--- a/Dev/Tests/BrightroomEngineTests/EditingCanvasColorContractTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EditingCanvasColorContractTests.swift
@@ -1,0 +1,127 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import CoreGraphics
+import XCTest
+
+@testable import BrightroomUI
+
+/// Display-independent guard for the editing-canvas wide-gamut color contract.
+///
+/// The simulator (and CI) cannot DISPLAY wide gamut or EDR, so the on-screen
+/// fidelity can only be verified on a real P3 device. What CAN be tested
+/// anywhere is the COLOR MATH: a Display-P3 primary pushed through a CIContext
+/// configured like the canvas must survive, where the old sRGB/8-bit contract
+/// clamped it. This test renders the same P3-red through the new contract and
+/// the old contract, both encoded into a common Display-P3 buffer, and asserts
+/// the new path stays saturated while the old path desaturates — so a
+/// regression back to sRGB clamping fails here, not silently in the field.
+final class EditingCanvasColorContractTests: XCTestCase {
+
+  private let displayP3 = CGColorSpace(name: CGColorSpace.displayP3)!
+  private let sRGB = CGColorSpace(name: CGColorSpace.sRGB)!
+
+  /// The four boundary contracts must keep COLOR content wide-gamut. (The mask
+  /// contract is intentionally sRGB — a [0,1] selection field, not color.)
+  func test_colorContracts_areWideGamut() {
+    XCTAssertTrue(
+      EditingCanvasImageProcessing.workingColorSpace.isWideGamutRGB,
+      "working space must be wide-gamut so P3 chroma survives filtering"
+    )
+    XCTAssertTrue(
+      EditingCanvasImageProcessing.intermediateColorSpace.isWideGamutRGB,
+      "intermediate texture space must be wide-gamut and match the working space"
+    )
+    XCTAssertTrue(
+      EditingCanvasImageProcessing.drawableColorSpace.isWideGamutRGB,
+      "drawable space must be wide-gamut (Display-P3)"
+    )
+    // The intermediate round-trip is lossless only if write-space == read-space
+    // == working-space. Assert they are the same color space.
+    XCTAssertEqual(
+      EditingCanvasImageProcessing.workingColorSpace.name,
+      EditingCanvasImageProcessing.intermediateColorSpace.name,
+      "intermediate space must equal the working space for a lossless round-trip"
+    )
+  }
+
+  /// The canvas contract preserves an out-of-sRGB-gamut Display-P3 red, while the
+  /// previous sRGB-working/8-bit contract clamps it (visible as desaturation once
+  /// both are expressed in the same Display-P3 space).
+  func test_canvasContract_preservesDisplayP3Red_whereSRGBContractClamps() throws {
+    // A pure Display-P3 red — its chroma lies OUTSIDE the sRGB gamut.
+    let p3Red = CIImage(
+      color: CIColor(red: 1, green: 0, blue: 0, colorSpace: displayP3)!
+    )
+    .cropped(to: CGRect(x: 0, y: 0, width: 1, height: 1))
+
+    // New canvas contract: extended-linear Display-P3 working space + half-float.
+    let canvasContext = CIContext(options: [
+      .workingColorSpace: EditingCanvasImageProcessing.workingColorSpace,
+      .workingFormat: EditingCanvasImageProcessing.workingFormat,
+    ])
+    // Old contract: sRGB working space + 8-bit (what the canvas used before).
+    let legacyContext = CIContext(options: [
+      .workingColorSpace: sRGB,
+      .workingFormat: CIFormat.RGBA8,
+    ])
+
+    // Encode BOTH results into Display-P3 so they are directly comparable.
+    let canvasPixel = renderPixel(p3Red, context: canvasContext, outputColorSpace: displayP3)
+    let legacyPixel = renderPixel(p3Red, context: legacyContext, outputColorSpace: displayP3)
+
+    // New contract keeps P3 red ~pure: red maxed, green/blue near zero.
+    XCTAssertGreaterThan(canvasPixel.r, 250, "canvas contract should keep P3 red at full red")
+    XCTAssertLessThan(canvasPixel.g, 12, "canvas contract should not bleed green into P3 red")
+    XCTAssertLessThan(canvasPixel.b, 12, "canvas contract should not bleed blue into P3 red")
+
+    // Old contract clamps P3 red into the sRGB gamut; expressed back in P3 the
+    // sRGB red primary is visibly desaturated (green/blue rise).
+    XCTAssertGreaterThan(
+      legacyPixel.g, 20,
+      "sanity: the legacy sRGB contract should desaturate P3 red (else the test proves nothing)"
+    )
+
+    // The fix must preserve strictly more saturation than the old contract.
+    XCTAssertLessThan(
+      Int(canvasPixel.g), Int(legacyPixel.g),
+      "canvas contract must preserve more P3 saturation than the legacy sRGB contract"
+    )
+  }
+
+  private func renderPixel(
+    _ image: CIImage,
+    context: CIContext,
+    outputColorSpace: CGColorSpace
+  ) -> (r: UInt8, g: UInt8, b: UInt8, a: UInt8) {
+    var pixel = [UInt8](repeating: 0, count: 4)
+    context.render(
+      image,
+      toBitmap: &pixel,
+      rowBytes: 4,
+      bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+      format: .RGBA8,
+      colorSpace: outputColorSpace
+    )
+    return (pixel[0], pixel[1], pixel[2], pixel[3])
+  }
+}

--- a/Sources/BrightroomParametric/ParametricExportRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricExportRenderer.swift
@@ -286,8 +286,16 @@ public struct ParametricExportRenderer {
     device: RenderingDevice = .automatic
   ) throws -> Rendered {
 
+    let colorSpace = options.workingColorSpace ?? source.colorSpace
+
+    // Always process through a half-float WORKING buffer so wide-gamut and
+    // out-of-range (>1 / <0) values survive the multi-filter chain — an 8-bit
+    // working format would clamp/band them mid-chain. This is the processing
+    // precision only; it is independent of the OUTPUT format below, which stays
+    // `options.workingFormat` (the caller's delivery format — 8-bit Display-P3
+    // is fine for SDR; bumping the output to float is a per-call delivery choice).
     let ciContext = Self.makeCIContext(
-      workingFormat: options.workingFormat,
+      workingFormat: .RGBAh,
       device: device,
       imageExtent: source.extent
     )
@@ -300,8 +308,6 @@ public struct ParametricExportRenderer {
     // `Resolution.resize` is a Core Image scale on the recipe, so the downscale
     // is part of the same (tiled) evaluation for both outputs.
     let image = Self.scaled(outputCIImage, for: options.resolution)
-
-    let colorSpace = options.workingColorSpace ?? source.colorSpace
 
     switch options.output {
     case .memory:
@@ -391,6 +397,16 @@ public struct ParametricExportRenderer {
   // of the Swift 6 global-mutable-state check rather than re-isolating.
   private nonisolated(unsafe) static var ciContextCache: [CIContextCacheKey: CIContext] = [:]
 
+  /// Extended-linear, wide-gamut (Display-P3 primaries) CIContext WORKING space.
+  /// Paired with the half-float working format, this extended space lets
+  /// out-of-sRGB / out-of-range values survive the filter chain, so edited
+  /// wide-gamut sources (Display-P3, Adobe RGB, ...) export faithfully instead
+  /// of being gamut-clipped into the default sRGB-primary working space. It
+  /// matches the editing canvas working space so canvas and export agree.
+  /// (Distinct from `Options.workingColorSpace`, which is the OUTPUT tag.)
+  private static let processingColorSpace =
+    CGColorSpace(name: CGColorSpace.extendedLinearDisplayP3) ?? CGColorSpaceCreateDeviceRGB()
+
   /// CIContext creation costs tens to hundreds of milliseconds; CIContext is
   /// thread-safe, so contexts are shared across renders keyed by the options
   /// that affect their output.
@@ -413,6 +429,7 @@ public struct ParametricExportRenderer {
     let context = CIContext(
       options: [
         .workingFormat: workingFormat,
+        .workingColorSpace: processingColorSpace,
         .highQualityDownsample: true,
         .useSoftwareRenderer: useSoftwareRenderer,
         .cacheIntermediates: false

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskMetalRasterizer.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskMetalRasterizer.swift
@@ -189,7 +189,7 @@ struct BrushMaskMetalRasterizer {
     guard
       let textureImage = CIImage(
         mtlTexture: texture,
-        options: [.colorSpace: EditingCanvasImageProcessing.colorSpace]
+        options: [.colorSpace: EditingCanvasImageProcessing.maskColorSpace]
       )
     else {
       return nil

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
@@ -32,7 +32,59 @@ extension CGRect {
 }
 
 enum EditingCanvasImageProcessing {
-  static let colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+
+  // MARK: - Color contract
+  //
+  // The editing canvas crosses the Metal<->Core Image boundary many times
+  // (source bake, prepared base/adjusted, mask, drawable). Each crossing has a
+  // DISTINCT color-space role; collapsing them into one constant is what made
+  // the canvas clamp Display-P3 to sRGB. The four contracts below keep wide
+  // gamut intact while avoiding double color management:
+  //
+  //   working      == intermediate   (extended-linear Display-P3)
+  //     -> every intermediate texture is WRITTEN and READ BACK in this same
+  //        space, so each hop round-trips losslessly through a float texture.
+  //   drawable     == CAMetalLayer.colorspace (Display-P3, SDR)
+  //     -> the single linear->display conversion happens only at the final
+  //        drawable write; the layer interprets the same space (no re-convert).
+  //   mask                             (sRGB — a [0,1] selection field, not color)
+  //     -> pinned independently so changing the color contract never perturbs
+  //        the brush feather fed to CIBlendWithAlphaMask.
+
+  /// Core Image working (math) space. Extended-linear so wide-gamut and
+  /// out-of-sRGB chroma survive filtering instead of being gamut-clamped.
+  static let workingColorSpace =
+    CGColorSpace(name: CGColorSpace.extendedLinearDisplayP3) ?? CGColorSpaceCreateDeviceRGB()
+
+  /// Encoding for every intermediate COLOR texture, used by BOTH the
+  /// `ciContext.render(...)` that writes it and the `CIImage(mtlTexture:)` that
+  /// reads it back. MUST equal `workingColorSpace` for a lossless round-trip.
+  static let intermediateColorSpace =
+    CGColorSpace(name: CGColorSpace.extendedLinearDisplayP3) ?? CGColorSpaceCreateDeviceRGB()
+
+  /// Encoding of the final drawable write. MUST equal the CAMetalLayer's
+  /// colorspace (Display-P3, SDR); a mismatch double-manages color.
+  static let drawableColorSpace =
+    CGColorSpace(name: CGColorSpace.displayP3) ?? CGColorSpaceCreateDeviceRGB()
+
+  /// The brush mask is a [0,1] selection field, not color content. Kept on a
+  /// fixed space independent of the color contract so the feather is
+  /// deterministic and unaffected by wide-gamut changes (behavior-preserving).
+  static let maskColorSpace =
+    CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
+
+  /// Core Image working precision — half-float so the working buffer carries
+  /// extended-range / wide-gamut values without 8-bit clamping or banding.
+  static let workingFormat: CIFormat = .RGBAh
+
+  /// Pixel format for intermediate COLOR textures (source / base / adjusted).
+  /// Float so the extended-linear-Display-P3 round-trip stays lossless (and is
+  /// EDR-ready). The mask texture stays `.rgba8Unorm` — a [0,1] field needs no float.
+  static let colorTextureFormat: MTLPixelFormat = .rgba16Float
+
+  /// Drawable pixel format — 10-bit unorm shows Display-P3 SDR without 8-bit
+  /// banding at half the bandwidth of a float drawable (EDR would need rgba16Float).
+  static let drawablePixelFormat: MTLPixelFormat = .bgr10a2Unorm
 
   static func clippedToSourceAlpha(_ image: CIImage, source: CIImage) -> CIImage {
     let extent = image.extent

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
@@ -323,7 +323,14 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     [unowned self] in
     CIContext(
       mtlCommandQueue: self.commandQueue,
-      options: [.name: "EditingCanvas"]
+      options: [
+        .name: "EditingCanvas",
+        // Wide-gamut, high-precision working space so Display-P3 / out-of-sRGB
+        // chroma survives filtering instead of being clamped (see the color
+        // contract in EditingCanvasImageProcessing).
+        .workingColorSpace: EditingCanvasImageProcessing.workingColorSpace,
+        .workingFormat: EditingCanvasImageProcessing.workingFormat,
+      ]
     )
   }()
 
@@ -345,7 +352,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     isOpaque = false
     layer.isOpaque = false
     framebufferOnly = false
-    colorPixelFormat = .bgra8Unorm
+    colorPixelFormat = EditingCanvasImageProcessing.drawablePixelFormat
     clearColor = MTLClearColor(red: 0, green: 0, blue: 0, alpha: 0)
     enableSetNeedsDisplay = true
     isPaused = true
@@ -365,8 +372,20 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     if let metalLayer = layer as? CAMetalLayer {
       metalLayer.maximumDrawableCount = 3
     }
+    applyColorSpaceContract()
 
     reset()
+  }
+
+  /// Pins the drawable's color contract so the Display-P3 pixels Core Image
+  /// encodes into the drawable are interpreted as Display-P3 by the compositor —
+  /// one conversion, no double color management. MTKView (re)creates its
+  /// CAMetalLayer/drawable from `colorPixelFormat`, so the layer colorspace is
+  /// (re)asserted here and again from `didMoveToWindow`. This is SDR Display-P3
+  /// (no EDR); it matches the export's Display-P3 tag.
+  private func applyColorSpaceContract() {
+    guard let metalLayer = layer as? CAMetalLayer else { return }
+    metalLayer.colorspace = EditingCanvasImageProcessing.drawableColorSpace
   }
 
   @available(*, unavailable)
@@ -380,6 +399,9 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
   override func didMoveToWindow() {
     super.didMoveToWindow()
+    // Re-assert: MTKView can rebuild its drawable/layer when entering a window,
+    // which would drop the colorspace and silently reinterpret the drawable.
+    applyColorSpaceContract()
     updatePreferredFrameRate()
   }
 
@@ -950,7 +972,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
       to: drawable.texture,
       commandBuffer: commandBuffer,
       bounds: renderBounds,
-      colorSpace: EditingCanvasImageProcessing.colorSpace
+      colorSpace: EditingCanvasImageProcessing.drawableColorSpace
     )
     commandBuffer.commit()
     commandBuffer.waitUntilScheduled()
@@ -1072,7 +1094,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
     guard
       let sourceTexture = makeRenderTexture(
-        pixelFormat: .bgra8Unorm,
+        pixelFormat: EditingCanvasImageProcessing.colorTextureFormat,
         width: pixelWidth,
         height: pixelHeight
       ),
@@ -1092,7 +1114,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
     guard let sourceImage = CIImage(
       mtlTexture: sourceTexture,
-      options: [.colorSpace: EditingCanvasImageProcessing.colorSpace]
+      options: [.colorSpace: EditingCanvasImageProcessing.intermediateColorSpace]
     ) else {
       return nil
     }
@@ -1143,7 +1165,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
       to: drawable.texture,
       commandBuffer: commandBuffer,
       bounds: renderBounds,
-      colorSpace: EditingCanvasImageProcessing.colorSpace
+      colorSpace: EditingCanvasImageProcessing.drawableColorSpace
     )
     commandBuffer.commit()
     commandBuffer.waitUntilScheduled()
@@ -1197,7 +1219,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     guard
       let maskImage = CIImage(
         mtlTexture: textures.maskTexture,
-        options: [.colorSpace: EditingCanvasImageProcessing.colorSpace]
+        options: [.colorSpace: EditingCanvasImageProcessing.maskColorSpace]
       )?.cropped(to: renderBounds)
     else {
       clearCurrentDrawable()
@@ -1255,12 +1277,12 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
     guard
       let baseTexture = makeRenderTexture(
-        pixelFormat: .bgra8Unorm,
+        pixelFormat: EditingCanvasImageProcessing.colorTextureFormat,
         width: pixelWidth,
         height: pixelHeight
       ),
       let adjustedTexture = makeRenderTexture(
-        pixelFormat: .bgra8Unorm,
+        pixelFormat: EditingCanvasImageProcessing.colorTextureFormat,
         width: pixelWidth,
         height: pixelHeight
       ),
@@ -1280,11 +1302,11 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     guard
       let baseImage = CIImage(
         mtlTexture: baseTexture,
-        options: [.colorSpace: EditingCanvasImageProcessing.colorSpace]
+        options: [.colorSpace: EditingCanvasImageProcessing.intermediateColorSpace]
       )?.cropped(to: renderBounds),
       let adjustedImage = CIImage(
         mtlTexture: adjustedTexture,
-        options: [.colorSpace: EditingCanvasImageProcessing.colorSpace]
+        options: [.colorSpace: EditingCanvasImageProcessing.intermediateColorSpace]
       )?.cropped(to: renderBounds)
     else {
       return nil
@@ -1346,7 +1368,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
       to: texture,
       commandBuffer: commandBuffer,
       bounds: renderBounds,
-      colorSpace: EditingCanvasImageProcessing.colorSpace
+      colorSpace: EditingCanvasImageProcessing.intermediateColorSpace
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes the editing canvas clamping **Display-P3 to sRGB** (export was already correct — this was a **preview-only WYSIWYG defect**, not data loss), and makes the canvas wide-gamut end to end.

**Root cause:** the canvas ran a closed sRGB/8-bit loop. One color constant tagged every Metal↔Core Image hop as sRGB, and all color textures + the drawable were `.bgra8Unorm`, so the very first source bake hard-clipped out-of-sRGB-gamut P3 chroma; every downstream stage re-clipped.

## Changes

**Four-boundary color contract** (`EditingCanvasImageProcessing`), replacing the single `colorSpace`:
- `workingColorSpace` == `intermediateColorSpace` = `extendedLinearDisplayP3` — the **same** space writes AND reads back every intermediate texture, so each hop round-trips losslessly through a float texture.
- `drawableColorSpace` = `displayP3`, kept identical to `CAMetalLayer.colorspace` → a single linear→display conversion, no double color management.
- `maskColorSpace` = `sRGB` (unchanged) — the mask is a [0,1] selection field, so the brush feather fed to `CIBlendWithAlphaMask` is behavior-preserving.

**Canvas** (`EditingCanvasMTKView`):
- CIContext: `workingColorSpace` = extendedLinearDisplayP3, `workingFormat` = `.RGBAh`.
- Color intermediates (source/base/adjusted) → `.rgba16Float`; drawable → `.bgr10a2Unorm` (10-bit P3 SDR).
- Layer colorspace set in `init` and re-asserted in `didMoveToWindow` (MTKView rebuilds its drawable from `colorPixelFormat`). Both canvas surfaces share the init, so CropView's instance is fixed too.

**Export** (`ParametricExportRenderer`): always process through an **extended-linear Display-P3 working space + half-float (`.RGBAh`) working buffer**, so out-of-sRGB / out-of-range chroma survives the multi-filter chain. The previous setup (CI's default sRGB-primary working space, 8-bit) clipped edited wide-gamut sources mid-chain. This is the processing precision only; the **output** stays `options.workingFormat` (8-bit, source-space-tagged, for SDR delivery). The export working space now matches the canvas, so canvas and export agree.

Measured — an Adobe RGB green `(0,1,0)` (outside both sRGB and P3) edited (blur) then exported back to Adobe RGB:

| working space / format | exported (R,G,B) |
|---|---|
| default sRGB-primary, 8-bit (old) | `(144, 255, 60)` — badly contaminated |
| default sRGB-primary, RGBAh | `(4, 255, 60)` |
| **extended-linear Display-P3, RGBAh (this PR)** | **`(0, 255, 0)` — faithful** |

On the editing canvas, out-of-P3 source colors (Adobe RGB greens/cyans) are clamped to the P3 gamut boundary at the final drawable write — correct and unavoidable, since a P3 panel cannot display colors outside its gamut; the internal pipeline preserves them up to that point.

**Test + demo:** `EditingCanvasColorContractTests` renders P3 red through the new vs old contract — both encoded to Display-P3 — and asserts the new path stays saturated while the old desaturates (runs on the simulator: it tests color **math**, not the panel, which can't show wide gamut). Added an "Insta Logo" PhotosCrop demo entry using the existing Display-P3 `Asset.instaLogo` sample.

## Verification
- BrightroomUI + SwiftUIDemo build clean; **137 engine tests pass** (135 prior + 2 new).
- **On real P3 hardware:** P3 now renders correctly in the editing canvas and matches export (confirmed via the PhotosCrop "Insta Logo" sample).

## Not included (follow-up)
- **EDR/HDR:** float drawable + `wantsExtendedDynamicRangeContent` + per-frame `currentEDRHeadroom` tone-mapping, plus HDR gain-map ingest. The float intermediates + extended-linear working space introduced here make that mostly a layer-config + one view-node addition.

## Note
- The `.bgr10a2Unorm` drawable has only 2-bit alpha; verified on-device that transparent-edge quality is fine. Flipping the single `drawablePixelFormat` constant to `.rgba16Float` (full alpha, also the EDR format) is the escape hatch if it ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
