### PR TITLE
Fix blur-mask see-through and stamp seams; bound export mask graph depth

### DIFF
--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -275,28 +275,66 @@ private extension FeatureGraphCompiler {
       return CIImage.parametricTransparent(extent: extent)
     }
 
-    var accumulated = CIImage.parametricTransparent(extent: extent)
-
+    // Each stamp compiles to one CIImage layer. `componentMax` is associative
+    // and commutative, so the stamps reduce in any grouping; folding them in a
+    // balanced tree keeps the Core Image graph depth at O(log n) instead of
+    // O(n). A dense brush (small spacing) emits hundreds–thousands of stamps
+    // per stroke, and a linear fold built a chain that deep — slow to compile
+    // and at risk of stack overflow during render. The tree keeps the same
+    // node count and the same result.
+    var stampImages: [CIImage] = []
     for stroke in mask.strokes {
       let radius = max(stroke.brush.diameter / 2, 0)
       for stamp in stroke.stamps {
-        let stampImage = try kernelRegistry.makeBrushStamp(
-          extent: extent,
-          center: stamp,
-          radius: radius,
-          hardness: stroke.brush.hardness,
-          opacity: stroke.brush.opacity
-        )
-        accumulated = try blendMask(
-          foreground: stampImage,
-          background: accumulated,
-          kernel: .componentMax,
-          extent: extent
+        stampImages.append(
+          try kernelRegistry.makeBrushStamp(
+            extent: extent,
+            center: stamp,
+            radius: radius,
+            hardness: stroke.brush.hardness,
+            opacity: stroke.brush.opacity
+          )
         )
       }
     }
 
-    return accumulated.cropped(to: extent)
+    return try reduceComponentMax(stampImages, extent: extent)
+  }
+
+  /// Reduces mask layers with `componentMax` in a balanced tree so the Core
+  /// Image graph depth stays O(log n). `componentMax` is associative and
+  /// commutative and `componentMax(transparent, x) == x`, so the pairwise
+  /// grouping produces the same alpha field as a linear fold over a transparent
+  /// base.
+  private func reduceComponentMax(_ images: [CIImage], extent: CGRect) throws -> CIImage {
+    guard images.isEmpty == false else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    var level = images
+    while level.count > 1 {
+      var next: [CIImage] = []
+      next.reserveCapacity((level.count + 1) / 2)
+      var index = 0
+      while index < level.count {
+        if index + 1 < level.count {
+          next.append(
+            try blendMask(
+              foreground: level[index + 1],
+              background: level[index],
+              kernel: .componentMax,
+              extent: extent
+            )
+          )
+        } else {
+          next.append(level[index])
+        }
+        index += 2
+      }
+      level = next
+    }
+
+    return level[0].cropped(to: extent)
   }
 
   func blendMask(

--- a/Sources/BrightroomUI/Shared/Components/Crop/CropViewMaskingDefaults.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropViewMaskingDefaults.swift
@@ -29,8 +29,8 @@ public struct CropViewMaskingBrush: Equatable {
   public init(
     diameter: Diameter,
     hardness: Double = 0.72,
-    opacity: Double = 0.9,
-    spacing: Double = 0.18
+    opacity: Double = 1.0,
+    spacing: Double = 0.05
   ) {
     self.diameter = diameter
     self.hardness = hardness

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasPublicTypes.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasPublicTypes.swift
@@ -126,8 +126,8 @@ public struct EditingCanvasBrush: Equatable {
   public init(
     size: Double = 56,
     hardness: Double = 0.72,
-    opacity: Double = 0.9,
-    spacing: Double = 0.18
+    opacity: Double = 1.0,
+    spacing: Double = 0.05
   ) {
     self.size = size
     self.hardness = hardness

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasStroke.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasStroke.swift
@@ -47,7 +47,10 @@ struct EditingCanvasStrokeRecord {
         size: stroke.brush.diameter,
         hardness: stroke.brush.hardness,
         opacity: stroke.brush.opacity,
-        spacing: 0.18
+        // `BrushMaskStroke` does not persist spacing; committed strokes render
+        // from their stored stamps, so this is a placeholder kept in sync with
+        // the authoring default (CropViewMaskingBrush / EditingCanvasBrush).
+        spacing: 0.05
       )
     )
   }


### PR DESCRIPTION
## What

Fixes two visible defects in blur-mask painting (PhotosCrop), plus a related export-path safety change.

### 1. See-through — the unblurred image bled through the blur
The brush default `opacity` was **0.9**, and the mask accumulates with **max** (live = Metal `.max` blend; export = `CIBlendKernel.componentMax`). So opacity acts as a *hard ceiling* — overlapping/repeated strokes can never exceed the single-stamp peak. `CIBlendWithAlphaMask` then composited `blur·0.9 + original·0.1`, leaving ~10% of the sharp original visible even at the stroke core.

**Fix:** default `opacity` 0.9 → **1.0** (`hardness` 0.72 still feathers the edge).

The color-space / premultiplied-alpha theories were investigated and **ruled out**: the mask, base, and adjusted images are all sRGB (`EditingCanvasImageProcessing.colorSpace`), and `CIBlendWithAlphaMask` blends using only the alpha channel, which is color-space independent.

### 2. Visible stamp seams along a stroke
Default `spacing` 0.18 placed stamps `0.36·radius` apart — wider than the hardness‑0.72 falloff ring of `(1−0.72)·radius = 0.28·radius` — so the feathered edge scalloped between stamps.

**Fix:** default `spacing` 0.18 → **0.05** (`~0.10·radius`, about ⅓ of the ring). Preview and export share the **same stored stamp list** (commit performs no decimation; export rasterizes stored stamps 1:1), so this densifies both — as requested.

### 3. Export safety — bound the mask Core Image graph depth
`FeatureGraphCompiler.render(_:BrushMask)` folded each stamp into the mask with `componentMax` **linearly**, making the CI graph depth O(n stamps). Denser stamps would risk slow compiles / stack overflow on long strokes.

**Fix:** reduce stamps in a **balanced tree** (`reduceComponentMax`, O(log n) depth). `componentMax` is associative and commutative and `componentMax(transparent, x) == x`, so the result is identical.

## Why
Direct response to the report: blur mask compositing looked wrong (original faintly showing through) and stamp joints were visible. Both trace to brush defaults; the export reducer change keeps the denser default safe.

## Reviewer notes
- Behavior change is limited to **new** strokes' defaults; existing committed strokes render from their stored stamps unchanged.
- `EditingCanvasStrokeRecord.init(brushMaskStroke:)` spacing is a display-only placeholder (`BrushMaskStroke` doesn't persist spacing); updated to match the authoring default.
- Base branch is **v5** (this branch sits on the v5 line, not `main`).

## Verification
- `BrightroomUI` builds (iOS Simulator).
- Tests pass: `BrushMaskRasterizerParityTests`, `CommittedMaskParametricParityTests`, `LargeMaskedExportTests`, `LocalAdjustmentRenderingTests` (the balanced-tree reduction preserves mask parity).
- `opacity 1.0` / `spacing 0.05` are values best confirmed visually; `spacing` can be lowered further if seams persist (export cost is now O(log n)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)