### PR TITLE
[codex] Fix Simulator PhotosCrop black canvas

### DIFF
--- a/Dev/Tests/BrightroomEngineTests/EditingCanvasColorContractTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EditingCanvasColorContractTests.swift
@@ -22,6 +22,7 @@
 import CoreGraphics
 import CoreImage
 import Foundation
+import Metal
 import Testing
 
 @testable import BrightroomUI
@@ -63,6 +64,17 @@ struct EditingCanvasColorContractTests {
         == EditingCanvasImageProcessing.intermediateColorSpace.name,
       "intermediate space must equal the working space for a lossless round-trip"
     )
+  }
+
+  /// The Simulator compositor is not a reliable target for the 10-bit drawable
+  /// used on device. Keep the display fallback explicit while preserving the
+  /// wide-gamut math contract tested below.
+  @Test func `Drawable pixel format is simulator safe`() {
+    #if targetEnvironment(simulator)
+    #expect(EditingCanvasImageProcessing.drawablePixelFormat == .bgra8Unorm)
+    #else
+    #expect(EditingCanvasImageProcessing.drawablePixelFormat == .bgr10a2Unorm)
+    #endif
   }
 
   /// The canvas contract preserves an out-of-sRGB-gamut Display-P3 red, while the

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
@@ -82,9 +82,18 @@ enum EditingCanvasImageProcessing {
   /// EDR-ready). The mask texture stays `.rgba8Unorm` — a [0,1] field needs no float.
   static let colorTextureFormat: MTLPixelFormat = .rgba16Float
 
-  /// Drawable pixel format — 10-bit unorm shows Display-P3 SDR without 8-bit
-  /// banding at half the bandwidth of a float drawable (EDR would need rgba16Float).
+  /// Pixel format for the final drawable written by the editing canvas.
+  ///
+  /// Device builds use a 10-bit unorm drawable for Display-P3 SDR with less
+  /// banding than an 8-bit surface. Simulator builds intentionally fall back to
+  /// `.bgra8Unorm`: recent Simulator runtimes can create the view with
+  /// `.bgr10a2Unorm` but present a black drawable, while the color math is still
+  /// covered by the wide-gamut working and intermediate contracts above.
+  #if targetEnvironment(simulator)
+  static let drawablePixelFormat: MTLPixelFormat = .bgra8Unorm
+  #else
   static let drawablePixelFormat: MTLPixelFormat = .bgr10a2Unorm
+  #endif
 
   static func clippedToSourceAlpha(_ image: CIImage, source: CIImage) -> CIImage {
     let extent = image.extent


### PR DESCRIPTION
## Summary

Fixes PhotosCrop rendering as a black canvas on iOS Simulator while keeping the 10-bit Display-P3 drawable path on real devices.

## Root Cause

The editing canvas drawable pixel format was changed to `.bgr10a2Unorm` for the wide-gamut Display-P3 canvas path. That works on device, but recent iOS Simulator runtimes can create the MTKView and still present the drawable as black.

## Changes

- Use `.bgra8Unorm` for the editing canvas drawable on Simulator builds.
- Keep `.bgr10a2Unorm` for device builds.
- Add a regression test that locks the intended platform-specific drawable format while preserving the existing wide-gamut color math tests.

## Verification

- Reproduced the black PhotosCrop canvas in SwiftUIDemo on iPhone 17 Pro, iOS 26.5 Simulator before the fix.
- Verified the same PhotosCrop Horizontal screen renders the image after the fix.
- Ran `BrightroomEngineTests/EditingCanvasColorContractTests`: 3 passed.
- Built and launched `SwiftUIDemo` successfully on the same Simulator.