### PR TITLE
[codex] Limit crop zoom for mask editing

### DIFF
--- a/Dev/Tests/BrightroomEngineTests/CropEditingZoomScaleTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/CropEditingZoomScaleTests.swift
@@ -1,0 +1,56 @@
+import Testing
+import Foundation
+import CoreGraphics
+
+@testable import BrightroomParametric
+@testable import BrightroomUI
+
+/// Guards the crop authoring zoom policy shared with blur-mask editing.
+///
+/// The final crop output becomes the masking tool's canvas. These tests keep
+/// crop zoom from producing a canvas so small that viewport-sized brushes become
+/// sub-pixel image-space strokes.
+struct CropEditingZoomScaleTests {
+
+  @Test func `Maximum zoom keeps crop output at the minimum maskable side`() {
+    let imageSize = CGSize(width: 4000, height: 3000)
+    let crop = CropEditingState(
+      cropFeature: CropFeature.test(imageSize: imageSize),
+      imageSize: imageSize
+    )
+    let guideSize = CGSize(width: 400, height: 300)
+
+    let scales = crop.calculateZoomScale(visibleSize: guideSize)
+    let cropOutputSizeAtMaximumZoom = CGSize(
+      width: guideSize.width / scales.max / crop.imageToPlatterScale(),
+      height: guideSize.height / scales.max / crop.imageToPlatterScale()
+    )
+
+    #expect(scales.max.isFinite)
+    #expect(abs(scales.max - 9.375) < 0.0001)
+    #expect(
+      abs(min(cropOutputSizeAtMaximumZoom.width, cropOutputSizeAtMaximumZoom.height)
+        - CropEditingState.minimumAuthoredCropOutputSideLength) < 0.0001
+    )
+  }
+
+  @Test func `Maximum zoom does not require a crop output larger than the image`() {
+    let imageSize = CGSize(width: 80, height: 60)
+    let crop = CropEditingState(
+      cropFeature: CropFeature.test(imageSize: imageSize),
+      imageSize: imageSize
+    )
+    let guideSize = CGSize(width: 400, height: 300)
+
+    let scales = crop.calculateZoomScale(visibleSize: guideSize)
+    let cropOutputSizeAtMaximumZoom = CGSize(
+      width: guideSize.width / scales.max / crop.imageToPlatterScale(),
+      height: guideSize.height / scales.max / crop.imageToPlatterScale()
+    )
+
+    #expect(scales.max.isFinite)
+    #expect(abs(scales.max - scales.min) < 0.0001)
+    #expect(abs(cropOutputSizeAtMaximumZoom.width - imageSize.width) < 0.0001)
+    #expect(abs(cropOutputSizeAtMaximumZoom.height - imageSize.height) < 0.0001)
+  }
+}

--- a/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
@@ -2724,7 +2724,11 @@ extension UIScrollView {
 
       let minXScale = boundSize.width / targetContentSize.width
       let minYScale = boundSize.height / targetContentSize.height
-      let targetScale = min(minXScale, minYScale)
+      let unclampedTargetScale = min(minXScale, minYScale)
+      let targetScale = min(
+        max(unclampedTargetScale, minimumZoomScale),
+        maximumZoomScale
+      )
       setZoomScale(targetScale, animated: false)
 
       var targetContentOffset =

--- a/Sources/BrightroomUI/Shared/Utils/CropEditingState+.swift
+++ b/Sources/BrightroomUI/Shared/Utils/CropEditingState+.swift
@@ -20,6 +20,14 @@ import BrightroomEngine
 /// mapping.
 extension CropEditingState {
 
+  /// The smallest crop-output side the crop surface may author, in image pixels.
+  ///
+  /// The masking tool treats the final crop output as its editable canvas. Letting
+  /// crop zoom create a smaller output forces the tool surface into very large
+  /// zoom scales and resolves viewport-sized brushes into sub-pixel image-space
+  /// strokes, which is not a meaningful blur-mask editing domain.
+  static let minimumAuthoredCropOutputSideLength: CGFloat = 128
+
   func scrollViewContentSize() -> CGSize {
     PixelAspectRatio(imageSize).size(byWidth: 1000)
   }
@@ -36,6 +44,11 @@ extension CropEditingState {
     imageToPlatterScale()
   }
 
+  /// Returns the crop scroll view's zoom range for a visible crop guide size.
+  ///
+  /// `max` is finite by design: the crop output becomes the masking tool's
+  /// canvas, so crop authoring must stop before that output becomes too small to
+  /// paint with a viewport-sized brush reliably.
   func calculateZoomScale(visibleSize: CGSize) -> (min: CGFloat, max: CGFloat) {
 
     let contentSize = scrollViewContentSize()
@@ -47,7 +60,18 @@ extension CropEditingState {
      */
     let minScale = max(minXScale, minYScale)
 
-    return (min: minScale, max: .greatestFiniteMagnitude)
+    let platterScale = imageToPlatterScale()
+    let effectiveMinimumOutputSide = min(
+      Self.minimumAuthoredCropOutputSideLength,
+      max(min(imageSize.width, imageSize.height), 1)
+    )
+    let minimumPlatterSide = effectiveMinimumOutputSide * platterScale
+    let maxScale = min(
+      visibleSize.width / max(minimumPlatterSide, 0.0001),
+      visibleSize.height / max(minimumPlatterSide, 0.0001)
+    )
+
+    return (min: minScale, max: max(minScale, maxScale))
   }
 
   func platterRect(fromImageRect rect: CGRect) -> CGRect {


### PR DESCRIPTION
## Summary

- Add a finite maximum crop zoom based on a minimum authored crop-output side length.
- Clamp programmatic crop zoom to the scroll view's configured zoom range before calculating content offset.
- Add focused tests for the crop zoom policy on large and small images.

## Root Cause

Crop editing allowed an unbounded zoom scale, so users could author a final crop output that was only a few pixels wide or tall. Blur masking uses that final crop output as the tool canvas; once the crop output became extremely small, the tool surface entered huge zoom-scale space and viewport-sized brushes resolved into sub-pixel image-space strokes.

## Validation

- `BrightroomEngineTests/CropEditingZoomScaleTests` via XcodeBuildMCP: 2 tests passed
- `git diff --check`