### PR TITLE
Show per-filter preview swatches in PhotosCrop Filters strip

### DIFF
--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import CoreImage
 import SwiftUI
 import UIKit
 
@@ -99,6 +100,7 @@ struct PhotosCropContentView: View {
             aspectRatioSelection: aspectRatioSelection,
             blurMaskingState: blurMaskingState,
             filterPresets: options.filterPresets,
+            filterPreviewBaseImage: loadedState?.thumbnailImage,
             currentEffects: loadedState?.currentEdit.effects,
             adjustmentParameter: adjustmentParameter,
             localizedStrings: localizedStrings,
@@ -457,6 +459,7 @@ private struct PhotosCropControlHost: View {
   let aspectRatioSelection: PhotosCropAspectRatioSelection
   let blurMaskingState: PhotosCropBlurMaskingState
   let filterPresets: [PresetFeature]
+  let filterPreviewBaseImage: CIImage?
   let currentEffects: EffectPipeline?
   let adjustmentParameter: PhotosCropAdjustmentParameter
   let localizedStrings: SwiftUIPhotosCropView.LocalizedStrings
@@ -499,6 +502,7 @@ private struct PhotosCropControlHost: View {
       case .filters:
         PhotosCropFilterControl(
           presets: filterPresets,
+          baseImage: filterPreviewBaseImage,
           selectedPresetIdentifier: currentEffects?.first(of: PresetFeature.self)?.identifier,
           localizedStrings: localizedStrings,
           isLoaded: isLoaded,
@@ -1066,44 +1070,159 @@ enum PhotosCropEffectOrder {
   }
 }
 
-/// Filter preset chips evaluated inside the global-effects feature node.
+/// Filter preset swatches evaluated inside the global-effects feature node.
+///
+/// Each chip previews the current image with that preset applied. The strip is
+/// lazy: a chip renders its own swatch only as it first scrolls into view and
+/// holds it in `@State`, which a `LazyHStack` retains for the chip's lifetime —
+/// so scrolling never re-renders, only re-entering Filters mode does.
 private struct PhotosCropFilterControl: View {
 
+  /// On-screen edge length of a swatch.
+  static let thumbnailPointSize: CGFloat = 56
+
+  /// Scroll identity for the Original chip (preset chips use their identifier).
+  private static let originalScrollID = "brightroom.filters.original"
+
   let presets: [PresetFeature]
+  let baseImage: CIImage?
   let selectedPresetIdentifier: String?
   let localizedStrings: SwiftUIPhotosCropView.LocalizedStrings
   let isLoaded: Bool
   let onSelectPreset: (PresetFeature?) -> Void
 
+  /// The chip centered by `.scrollPosition` (also written back as the user
+  /// scrolls). Driven to the selected chip whenever the selection changes.
+  @State private var scrolledFilterID: String?
+
   var body: some View {
     ScrollView(.horizontal, showsIndicators: false) {
-      HStack(spacing: 12) {
-        PhotosCropAspectRatioButton(
+      LazyHStack(spacing: 12) {
+        PhotosCropFilterChip(
           title: localizedStrings.button_filter_original,
-          isSelected: selectedPresetIdentifier == nil
-        ) {
-          onSelectPreset(nil)
-        }
+          preset: nil,
+          baseImage: baseImage,
+          pointSize: Self.thumbnailPointSize,
+          isSelected: selectedPresetIdentifier == nil,
+          action: { onSelectPreset(nil) }
+        )
+        .id(Self.originalScrollID)
         .accessibilityIdentifier("photos.crop.filters.original")
 
         ForEach(presets, id: \.identifier) { preset in
-          PhotosCropAspectRatioButton(
+          PhotosCropFilterChip(
             title: preset.name,
-            isSelected: selectedPresetIdentifier == preset.identifier
-          ) {
-            onSelectPreset(preset)
-          }
+            preset: preset,
+            baseImage: baseImage,
+            pointSize: Self.thumbnailPointSize,
+            isSelected: selectedPresetIdentifier == preset.identifier,
+            action: { onSelectPreset(preset) }
+          )
+          .id(preset.identifier)
           .accessibilityIdentifier("photos.crop.filters.\(preset.identifier)")
         }
       }
+      .scrollTargetLayout()
       .padding(.horizontal, 24)
       .frame(maxHeight: .infinity)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .scrollPosition(id: $scrolledFilterID, anchor: .center)
     .opacity(isLoaded ? 1 : 0.5)
     .disabled(!isLoaded)
     .environment(\.colorScheme, .dark)
     .accessibilityIdentifier("photos.crop.filters")
+    // Center the selected swatch on selection. ScrollView clamps at the ends, so
+    // Original / the last filter just rest at the edge (Photos-like).
+    .onChange(of: selectedPresetIdentifier) { _, newValue in
+      withAnimation(.snappy) {
+        scrolledFilterID = newValue ?? Self.originalScrollID
+      }
+    }
+  }
+}
+
+/// A single filter swatch: a square preview thumbnail above the preset name.
+///
+/// The chip renders its own swatch when it appears (`.task`) into its `@State`,
+/// computed once for the chip's lifetime. `preset == nil` is the no-filter
+/// ("Original") swatch.
+private struct PhotosCropFilterChip: View {
+
+  let title: String
+  let preset: PresetFeature?
+  let baseImage: CIImage?
+  let pointSize: CGFloat
+  let isSelected: Bool
+  let action: () -> Void
+
+  @Environment(\.displayScale) private var displayScale
+  @State private var image: UIImage?
+
+  var body: some View {
+    Button(action: action) {
+      VStack(spacing: 6) {
+        ZStack {
+          if let image {
+            Image(uiImage: image)
+              .resizable()
+              .scaledToFill()
+          } else {
+            Color.white.opacity(0.08)
+          }
+        }
+        .frame(width: pointSize, height: pointSize)
+        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+          // The dark drop shadow keeps the white ring legible on bright swatches
+          // (Original / Mono / Noir on light photos), where a plain white border
+          // would have no contrast against the image.
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .strokeBorder(Color.white, lineWidth: 2.5)
+            .shadow(color: Color.black.opacity(isSelected ? 0.55 : 0), radius: 2)
+            .opacity(isSelected ? 1 : 0)
+        }
+        .animation(.easeInOut(duration: 0.2), value: image != nil)
+
+        Text(title)
+          .font(.system(size: 11))
+          .foregroundStyle(isSelected ? Color.white : Color.white.opacity(0.5))
+          .lineLimit(1)
+      }
+    }
+    .buttonStyle(.plain)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(title)
+    .accessibilityValue(isSelected ? "selected" : "not selected")
+    .task(id: renderKey) {
+      guard let baseImage else {
+        image = nil
+        return
+      }
+      let rendered = await PhotosCropFilterThumbnailRenderer.render(
+        base: baseImage,
+        preset: preset,
+        pointSize: pointSize,
+        scale: displayScale
+      )
+      guard !Task.isCancelled else { return }
+      image = rendered
+    }
+  }
+
+  /// Re-render only when the source thumbnail, the preset, or the scale changes.
+  private var renderKey: RenderKey {
+    RenderKey(
+      baseImageID: baseImage.map(ObjectIdentifier.init),
+      presetIdentifier: preset?.identifier,
+      scale: displayScale
+    )
+  }
+
+  private struct RenderKey: Equatable {
+    let baseImageID: ObjectIdentifier?
+    let presetIdentifier: String?
+    let scale: CGFloat
   }
 }
 

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropFilterThumbnail.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropFilterThumbnail.swift
@@ -1,0 +1,169 @@
+//
+// Copyright (c) 2026 Muukii <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Metal
+import UIKit
+
+import BrightroomEngine
+import BrightroomParametric
+
+/// Renders a single filter-preview swatch for PhotosCrop's Filters strip.
+///
+/// A swatch is the session thumbnail — the uncropped, already-oriented ~180px
+/// preview the EditingStack decoded at load — center-cropped to a square and run
+/// through one preset's effects. Swatches preview the filter only, not the user's
+/// manual adjustments or the current crop, matching the Photos/Instagram strip.
+///
+/// Each chip renders its own swatch when the strip appears and holds it in its
+/// SwiftUI `@State`, so the render happens once for that chip's lifetime.
+enum PhotosCropFilterThumbnailRenderer {
+
+  /// Wide-gamut, GPU-backed context dedicated to swatch rendering. Mirrors the
+  /// editing canvas's working space/precision so a swatch and the live canvas
+  /// resolve the same colors. `CIContext` is thread-safe.
+  private static let context: CIContext = {
+    let options: [CIContextOption: Any] = [
+      .name: "Brightroom.FilterThumbnail",
+      .workingColorSpace: EditingCanvasImageProcessing.workingColorSpace,
+      .workingFormat: EditingCanvasImageProcessing.workingFormat,
+      .cacheIntermediates: false,
+    ]
+    if let device = MTLCreateSystemDefaultDevice() {
+      return CIContext(mtlDevice: device, options: options)
+    }
+    return CIContext(options: options)
+  }()
+
+  /// Renders a single square swatch — a `nil` preset yields the unfiltered base.
+  ///
+  /// `@concurrent` runs the body on the concurrent executor, so a chip's
+  /// MainActor `.task` offloads the Core Image work off the main thread just by
+  /// awaiting it — no queue hop, no box. `CIImage`, `PresetFeature` and `UIImage`
+  /// are all `Sendable`, so the values cross the isolation boundary directly.
+  ///
+  /// - Parameters:
+  ///   - pointSize: the swatch's on-screen point size (a square edge).
+  ///   - scale: the display scale; the swatch is rendered at `pointSize * scale`
+  ///     pixels, never larger than the source thumbnail.
+  @concurrent
+  static func render(
+    base: CIImage,
+    preset: PresetFeature?,
+    pointSize: CGFloat,
+    scale: CGFloat
+  ) async -> UIImage? {
+    guard let prepared = normalizedSquare(base: base, pointSize: pointSize, scale: scale) else {
+      return nil
+    }
+    return makeImage(from: prepared, preset: preset, scale: scale)
+  }
+
+  // MARK: -
+
+  /// A base thumbnail center-cropped to a square, moved to a zero origin, and
+  /// scaled to the render pixel size paired with the rect to read back.
+  private struct Prepared {
+    let image: CIImage
+    let outputRect: CGRect
+    /// The FULL (uncropped) thumbnail at the swatch's render scale. Diagonal-
+    /// based radii (blur/sharpen/unsharp) must resolve against the source, not
+    /// the square crop, so a blur stays the source-relative fraction the canvas
+    /// shows instead of weakening with the crop's tighter diagonal.
+    let radiusReferenceExtent: CGRect
+  }
+
+  private static func normalizedSquare(
+    base: CIImage,
+    pointSize: CGFloat,
+    scale: CGFloat
+  ) -> Prepared? {
+    let extent = base.extent
+    guard extent.isInfinite == false, extent.isEmpty == false else {
+      return nil
+    }
+
+    // Center square crop in the base's own coordinate space.
+    let side = min(extent.width, extent.height)
+    let square = base.cropped(
+      to: CGRect(
+        x: extent.midX - side / 2,
+        y: extent.midY - side / 2,
+        width: side,
+        height: side
+      )
+    )
+
+    // Downscale to the requested pixel size; never upscale past the source —
+    // 8-bit swatches gain nothing from it.
+    let targetPixels = floor(min((pointSize * scale).rounded(), side))
+    guard targetPixels >= 1 else {
+      return nil
+    }
+    let renderScale = targetPixels / side
+    let normalized =
+      square
+      .transformed(by: CGAffineTransform(translationX: -square.extent.minX, y: -square.extent.minY))
+      .transformed(by: CGAffineTransform(scaleX: renderScale, y: renderScale))
+
+    return Prepared(
+      image: normalized,
+      outputRect: CGRect(x: 0, y: 0, width: targetPixels, height: targetPixels),
+      radiusReferenceExtent: CGRect(
+        origin: .zero,
+        size: CGSize(width: extent.width * renderScale, height: extent.height * renderScale)
+      )
+    )
+  }
+
+  private static func makeImage(
+    from prepared: Prepared,
+    preset: PresetFeature?,
+    scale: CGFloat
+  ) -> UIImage? {
+    let source: CIImage
+    if let preset {
+      do {
+        source = try preset.apply(
+          to: prepared.image,
+          context: .init(radiusReferenceExtent: prepared.radiusReferenceExtent)
+        )
+      } catch {
+        source = prepared.image
+      }
+    } else {
+      source = prepared.image
+    }
+
+    guard
+      let cgImage = context.createCGImage(
+        source,
+        from: prepared.outputRect,
+        format: .RGBA8,
+        colorSpace: EditingCanvasImageProcessing.drawableColorSpace
+      )
+    else {
+      return nil
+    }
+
+    return UIImage(cgImage: cgImage, scale: scale, orientation: .up)
+  }
+}


### PR DESCRIPTION
## What

Each filter in the PhotosCrop **Filters** strip now renders a live thumbnail of the photo with that filter applied (Photos/Instagram-style), replacing the text-only pills — including an "Original" swatch.

## How

- **New `PhotosCropFilterThumbnail.swift`** — a `@concurrent` single-swatch renderer on a dedicated wide-gamut `CIContext` whose working/output color spaces match the editing canvas (`extendedLinearDisplayP3` → `displayP3`), so a swatch and the live canvas resolve the same colors. It center-square-crops the session thumbnail, never upscales past the source, and threads a source-relative `radiusReferenceExtent` so host-supplied blur/sharpen presets preview at the correct strength.
- **Per-cell lazy rendering** — each `PhotosCropFilterChip` renders its own swatch in a `.task` into its `@State`. A `LazyHStack` defers off-screen first renders and retains created chips, so scrolling never re-renders. No shared cache or stringly-typed dictionary.
- **Selected chip auto-centers** via `.scrollPosition(id:anchor:)` on selection change (clamps at the ends, so Original / the last filter rest at the edge).
- **Selection ring** uses a dark shadow halo so it stays legible on bright swatches (Original / Mono / Noir on light photos).
- Swatches preview the **filter only** — not the user's manual Adjust edits, blur mask, or current crop — matching the Photos/Instagram strip.

## Notes

- Uses the iOS 17 `scrollPosition(id:anchor:)` modifier (not deprecated). The iOS 18 `ScrollPosition` struct would need `if #available` since the deployment floor is iOS 17.

## Verification

- BrightroomUI builds clean in Swift 6 language mode.
- Verified on the iOS Simulator: all swatches render distinctly (Mono/Noir desaturated, Warm/Cool shifted, Fade washed, Vivid/Dramatic as expected), off-screen chips render lazily when scrolled into view, the selection ring is visible on bright swatches, and selecting a chip scrolls it to center.

🤖 Generated with [Claude Code](https://claude.com/claude-code)