### PR TITLE
Remove redundant EditingCanvasMode.preview compatibility alias

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasPublicTypes.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasPublicTypes.swift
@@ -83,15 +83,9 @@ public enum EditingCanvasMode: Equatable {
   /// use the renderer when the final composed result is required.
   case renderedEditPreview
 
-  /// Compatibility spelling for `renderedEditPreview`.
-  ///
-  /// Prefer `viewportBase` for realtime preview and `renderedEditPreview` only
-  /// when a materialized global-filter preview is explicitly required.
-  case preview
-
   var localEffect: EffectPipeline {
     switch self {
-    case .viewportBase, .renderedEditPreview, .preview:
+    case .viewportBase, .renderedEditPreview:
       return .init()
     case let .localAdjustment(effect):
       return effect
@@ -100,7 +94,7 @@ public enum EditingCanvasMode: Equatable {
 
   var activeLocalEffect: EffectPipeline? {
     switch self {
-    case .viewportBase, .renderedEditPreview, .preview:
+    case .viewportBase, .renderedEditPreview:
       return nil
     case let .localAdjustment(effect):
       return effect
@@ -109,7 +103,7 @@ public enum EditingCanvasMode: Equatable {
 
   var defaultInteractionMode: EditingCanvasInteractionMode {
     switch self {
-    case .viewportBase, .renderedEditPreview, .preview:
+    case .viewportBase, .renderedEditPreview:
       return .view
     case .localAdjustment:
       return .draw

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasRenderImageFactory.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasRenderImageFactory.swift
@@ -79,7 +79,7 @@ enum EditingCanvasRenderImageFactory {
       // result.
       usesPreparedBaseImage = true
 
-    case .renderedEditPreview, .preview:
+    case .renderedEditPreview:
       let previewImage = loadedState.currentEdit.effects
         .applyIgnoringFailure(to: scaledPreviewSourceImage)
         .cropped(to: canvasRect)
@@ -168,7 +168,7 @@ enum EditingCanvasRenderImageFactory {
         .cropped(to: canvasRect)
       renderEffect = localEffect
 
-    case .renderedEditPreview, .preview:
+    case .renderedEditPreview:
       let filteredSourceImage = EditingCanvasImageProcessing.clippedToSourceAlpha(
         loadedState.currentEdit.effects
           .applyIgnoringFailure(to: sourceImage)


### PR DESCRIPTION
## Summary

`EditingCanvasMode.preview` was a dead compatibility alias of `.renderedEditPreview`. This removes it and collapses its `switch` arms into `.renderedEditPreview`.

## Why

An audit of all four `EditingCanvasMode` cases found that `.preview`:

- Was documented in-source as a *"Compatibility spelling for `renderedEditPreview`"* and was introduced in the **same** commit as `.renderedEditPreview` (it is not an older, migrated-away-from name).
- Is **never constructed anywhere** — production, demo, or tests. `git grep` for any producer (`= .preview`, `return .preview`, `mode: .preview`, `EditingCanvasMode.preview`) returns nothing.
- Appears **only** as a passive `switch` co-arm, always paired with `.renderedEditPreview` and handled identically, in every `switch` over the enum:
  - `EditingCanvasPublicTypes.swift` — `localEffect`, `activeLocalEffect`, `defaultInteractionMode`
  - `EditingCanvasRenderImageFactory.swift` — `makeRenderImages`, `makeCropOutputRenderImages`

So the case carried no distinct behavior and could never be reached.

## Behavioral impact

None. No first-party code path ever produced `.preview`, and it was rendered byte-for-byte identically to `.renderedEditPreview`. The other three cases (`.viewportBase`, `.localAdjustment`, `.renderedEditPreview`) are unchanged and remain in use.

## API note

This removes a `public` enum case, so it is technically source-breaking for any external caller that explicitly referenced `EditingCanvasMode.preview`. There are no such references inside this repository.

## Verification

- `git grep` confirms zero remaining `.preview` references in `Sources/` and `Dev/`.
- `xcodebuild -scheme BrightroomUI -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (Swift 6 mode).

## Follow-up (not in this PR)

`.renderedEditPreview` itself is only selected by `CropView.CanvasRenderPlan` when 2+ local-adjustment layers are simultaneously active — a state the built-in PhotosCrop UI cannot currently produce. It (and `CanvasRenderPlan`, already marked `// TODO: Consider to remove this`) is a candidate for removal/replacement once the live canvas composites multiple local-adjustment layers; left out of this PR to keep the change a pure, behavior-preserving cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)