### PR TITLE
Fix CropView auto-commit during held-still pinch

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
@@ -925,6 +925,13 @@ final class CropView: UIView {
         self.debounce.on { [weak self] in
           guard let self else { return }
           guard self.featureFocus.isCropEditing else { return }
+          // A held-still pinch (fingers down, no movement) stops emitting
+          // scrollViewDidZoom events, so the trailing debounce would otherwise
+          // fire mid-gesture and snap the scroll view back to the not-yet-
+          // recorded proposedCrop via updateCropLayout()'s customZoom. Defer the
+          // settle layout until the pinch actually ends, mirroring the
+          // isTracking guard used by onDidScroll for drags.
+          guard self.cropSurface.isInteractiveZoomGestureActive == false else { return }
 
           self.updateCropLayout()
         }


### PR DESCRIPTION
## Problem

In Crop mode, holding a pinch still (fingers down, no movement) would snap the scroll view back to the recorded crop after ~0.8s, making it look like the crop was committed mid-gesture.

## Cause

`cropSurface.onDidZoom` schedules `updateCropLayout()` on a trailing `debounce` (interval 0.8s). `updateCropLayout()` → `updateScrollContainerView()` → `customZoom(to: crop.zoomExtent())` resets the scroll view to `state.proposedCrop`, which is **not** updated mid-pinch (`record()` only runs on settle).

While the user moves their fingers, continuous `scrollViewDidZoom` events keep resetting the 0.8s debounce. The moment the user **holds still with fingers down**, events stop firing and the debounce fires mid-gesture, snapping the view.

The sibling `onDidScroll` debounce already guards against this for drags with an `isTracking == false` check, but `onDidZoom` had no equivalent guard — and both closures share the same `debounce` instance, so whether the snap happens depends on which event was scheduled last.

## Fix

Guard the `onDidZoom` settle layout with `cropSurface.isInteractiveZoomGestureActive == false` (pinch recognizer not in `.began`/`.changed`), deferring the reflow until the pinch actually ends.

The crop **recording** path (`record()` via the `scrollViewSettleDebounce` → `didSettleScrollViewAdjustment`) already checks `isContentOffsetResting` (`isZooming == false`, etc.), so commit semantics are unchanged — this only stops the premature layout snap.

## Verification

- `BrightroomUI` builds (iPhone 17 Pro, iOS 26.5).
- Confirmed in SwiftUIDemo PhotosCrop: pinching and holding still no longer auto-snaps the crop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)