### PR TITLE
Fix Crop→Blur viewport desync after a crop zoom change

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
@@ -1603,7 +1603,20 @@ extension CropView {
     // while the scroll view's model values are already clamped to the minimum
     // zoom. Derive both the sampled output rect and the canvas placement from
     // layer conversion so the mask canvas follows that visible bounce.
-    let usesPresentationLayers = toolSurface.isInteractiveZoomGestureActive == false
+    //
+    // Presentation-layer reads are ONLY valid while the viewport display link is
+    // actively re-sampling that in-flight bounce. When the tool viewport is
+    // applied as a one-shot with the link idle — e.g. entering Blur from Crop,
+    // where `updateToolScrollGeometry` just reconfigured the freshly-un-hidden
+    // scroll view synchronously in this same runloop turn — the presentation
+    // layers still hold the previous session's geometry until the next Core
+    // Animation commit. Sampling them then renders the crop output small and
+    // pinned to the top-left, and with no display link to re-sample, that stale
+    // frame sticks until the next mode switch (the "switch back and forth fixes
+    // it" symptom). Fall back to the model layers, which the synchronous
+    // reconfigure already made authoritative, whenever the link is idle.
+    let usesPresentationLayers = toolSurface.viewportRendering.isRunning
+      && toolSurface.isInteractiveZoomGestureActive == false
     let canvasFrame = Self.currentLayerRect(
       bounds,
       from: self,


### PR DESCRIPTION
## Summary

Fixes a regression where, after changing the zoom in **Crop** mode and switching to **Blur** (tool/mask) mode, the crop output rendered **small and pinned to the top-left**. Toggling the Crop/Blur tabs again corrected it; zooming the other way produced the inverse misplacement.

## Root cause

`makeToolCropDisplayViewport` derives the Metal canvas placement from **presentation-layer** conversions (`currentLayerRect(... usesPresentationLayers:)`), gated only on `toolSurface.isInteractiveZoomGestureActive == false`. This was introduced in #309 to make the mask canvas follow the post-release zoom bounce.

The Crop→Blur switch applies the tool viewport **once, synchronously**, in the same runloop turn that `updateToolScrollGeometry` just reconfigured the freshly-un-hidden tool scroll view (non-animated `setZoomScale`, `centerContentInViewport`, etc.):

`setFeatureFocus` → `applySurfaceMode(syncsToolViewportFromCrop: true)` → `updateToolScrollGeometry` (model set synchronously) → `updateToolCropDisplayViewport()` (one-shot, no display link).

At that instant no pinch is active, so `usesPresentationLayers == true`, but Core Animation has not yet committed the new geometry to the presentation layers — they still hold the **previous** Blur session's geometry. The one-shot samples that stale transform → small + top-left placement, and because no display link runs afterward, the stale frame sticks until the next mode switch (the "switch back and forth fixes it" symptom).

`#308` (GPU-resident source / per-generation content bake), originally suspected, is **not** involved: it never touches `CropView.swift`, and `EditingCanvasContentBake` maps the bake back to the original `extent`, so it changes layer *content*, never viewport *placement*.

## Fix

Presentation-layer reads are only meaningful while the viewport display link is actively re-sampling an in-flight bounce. Gate them on whether that link is running:

```swift
let usesPresentationLayers = toolSurface.viewportRendering.isRunning
  && toolSurface.isInteractiveZoomGestureActive == false
```

This flips **only** the link-idle one-shot paths (i.e. the mode switch) back to the model layers, which the synchronous reconfigure already made authoritative. Every display-link-driven path (interactive pinch, post-release bounce, deceleration) is unchanged, so #309's bounce tracking still works.

## Scope / notes

- Scoped to the **tool** path only. `makeCropDisplayViewport` has the same presentation-read pattern, but the crop path is not a reported repro and its animator-driven rotation computes the viewport inside a `UIViewPropertyAnimator` block (where presentation reads are intended), so it is intentionally left untouched.
- The tool path's animator case early-returns (the tool surface is hidden in Crop mode), so the gate is safe there.

## Test plan

- [x] `xcodebuild -scheme BrightroomUI -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` builds.
- [x] Verified on device: Crop zoom change → switch to Blur now displays the crop output correctly (no small/top-left misplacement, no need to toggle tabs).
- [ ] Editing canvas renders black on the Simulator, so visual confirmation is device-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)