### PR TITLE
[codex] Add PhotosCrop Gaussian blur adjustment

### DIFF
--- a/Dev/Tests/BrightroomEngineTests/PhotosCropAdjustmentParameterTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/PhotosCropAdjustmentParameterTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import BrightroomParametric
+@testable import BrightroomUI
+
+struct PhotosCropAdjustmentParameterTests {
+
+  @Test func `blur adjustment writes value-form gaussian blur`() {
+    var effects = EffectPipeline()
+
+    PhotosCropAdjustmentParameter.blur.apply(sliderValue: 40, to: &effects)
+
+    let blur = effects.first(of: GaussianBlurFeature.self)
+    #expect(blur?.radius == .editingStackFilterValue(40))
+    #expect(PhotosCropAdjustmentParameter.blur.sliderValue(in: effects) == 40)
+  }
+
+  @Test func `blur adjustment removes gaussian blur at neutral value`() {
+    var effects = EffectPipeline(effects: [
+      GaussianBlurFeature(value: 40)
+    ])
+
+    PhotosCropAdjustmentParameter.blur.apply(sliderValue: 0, to: &effects)
+
+    #expect(effects.first(of: GaussianBlurFeature.self) == nil)
+  }
+
+  @Test func `blur adjustment keeps photos crop effect order`() {
+    var effects = EffectPipeline(effects: [
+      VignetteFeature(value: 1)
+    ])
+
+    PhotosCropAdjustmentParameter.blur.apply(sliderValue: 40, to: &effects)
+
+    #expect(effects.effects.count == 2)
+    #expect(effects.effects[0] is GaussianBlurFeature)
+    #expect(effects.effects[1] is VignetteFeature)
+  }
+}

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -888,6 +888,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
   case temperature
   case highlights
   case shadows
+  case blur
   case vignette
 
   var id: Self { self }
@@ -901,6 +902,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
     case .temperature: return "Warmth"
     case .highlights: return "Highlights"
     case .shadows: return "Shadows"
+    case .blur: return "Blur"
     case .vignette: return "Vignette"
     }
   }
@@ -914,6 +916,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
     case .temperature: return "thermometer.medium"
     case .highlights: return "circle.tophalf.filled"
     case .shadows: return "circle.bottomhalf.filled"
+    case .blur: return "drop.fill"
     case .vignette: return "circle.dashed.inset.filled"
     }
   }
@@ -925,7 +928,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
   /// Zero-based parameters only strengthen in one direction.
   private var isZeroBased: Bool {
     switch self {
-    case .highlights, .vignette:
+    case .highlights, .blur, .vignette:
       return true
     case .exposure, .brightness, .contrast, .saturation, .temperature, .shadows:
       return false
@@ -949,6 +952,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
     case .temperature: return 3000
     case .highlights: return 1
     case .shadows: return 1
+    case .blur: return 100
     case .vignette: return 2
     }
   }
@@ -964,6 +968,7 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
     case .temperature: filterValue = effects.first(of: TemperatureFeature.self)?.value ?? 0
     case .highlights: filterValue = effects.first(of: HighlightsFeature.self)?.value ?? 0
     case .shadows: filterValue = effects.first(of: ShadowsFeature.self)?.value ?? 0
+    case .blur: filterValue = effects.first(of: GaussianBlurFeature.self)?.editingStackFilterValue ?? 0
     case .vignette: filterValue = effects.first(of: VignetteFeature.self)?.value ?? 0
     }
 
@@ -1002,6 +1007,8 @@ enum PhotosCropAdjustmentParameter: CaseIterable, Identifiable, Equatable {
       upsert(value, into: &effects, make: { HighlightsFeature(value: $0) }, update: { $0.value = $1 })
     case .shadows:
       upsert(value, into: &effects, make: { ShadowsFeature(value: $0) }, update: { $0.value = $1 })
+    case .blur:
+      upsert(value, into: &effects, make: { GaussianBlurFeature(value: $0) }, update: { $0.radius = .editingStackFilterValue($1) })
     case .vignette:
       upsert(value, into: &effects, make: { VignetteFeature(value: $0) }, update: { $0.value = $1 })
     }
@@ -1066,6 +1073,24 @@ enum PhotosCropEffectOrder {
       pipeline.effects.firstIndex { existing in
         rank(of: ObjectIdentifier(Swift.type(of: existing))) > newRank
       } ?? pipeline.effects.count
+    }
+  }
+}
+
+private extension GaussianBlurFeature {
+
+  /// The PhotosCrop adjustment-slider value when this blur was authored by the
+  /// global Adjust tool.
+  ///
+  /// Absolute-radius blurs do not have enough context here to map back onto a
+  /// source-relative slider value, so the PhotosCrop control treats them as
+  /// neutral and preserves them unless the user edits Blur.
+  var editingStackFilterValue: Double? {
+    switch radius {
+    case let .editingStackFilterValue(value):
+      return value
+    case .absolute:
+      return nil
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add Blur to the PhotosCrop Adjust parameter list.
- Write Blur edits into the global-effects node as `GaussianBlurFeature(value:)`.
- Add focused tests for blur insertion, neutral removal, and PhotosCrop effect ordering.

## Why
`GaussianBlurFeature` already existed in the parametric layer and PhotosCrop effect ordering, but PhotosCrop's Adjust UI did not expose a global Blur parameter. This makes Gaussian blur available as a first-class Feature adjustment in that UI.

## Validation
- BrightroomUI simulator build succeeded via XcodeBuildMCP.
- `BrightroomEngineTests/PhotosCropAdjustmentParameterTests` passed: 3 tests.