### PR TITLE
[codex] Refactor PhotosCrop feature tree ownership

### DIFF
--- a/Dev/Sources/SwiftUIDemo/ContentView.swift
+++ b/Dev/Sources/SwiftUIDemo/ContentView.swift
@@ -427,28 +427,34 @@ struct DemoPhotosCropView: View {
   @Environment(\.dismiss) private var dismiss
 
   @State var resultImage: ResultImage?
+  private let editingModel: PhotosCropEditingModel
   private let options: SwiftUIPhotosCropView.Options
 
+  @MainActor
   init(
     stack: EditingStack,
     options: SwiftUIPhotosCropView.Options = .init()
   ) {
     self._stack = .init(wrappedValue: stack)
+    self.editingModel = PhotosCropEditingModel(editingStack: stack)
     self.options = options
   }
 
+  @MainActor
   init(
     stack: @escaping () -> EditingStack,
     options: SwiftUIPhotosCropView.Options = .init()
   ) {
-    self._stack = .init(wrappedValue: stack())
+    let stack = stack()
+    self._stack = .init(wrappedValue: stack)
+    self.editingModel = PhotosCropEditingModel(editingStack: stack)
     self.options = options
   }
 
   var body: some View {
 
     SwiftUIPhotosCropView(
-      editingStack: stack,
+      editingModel: editingModel,
       options: options,
       onDone: {
         // Export straight to disk with bounded memory (strip render into an

--- a/Dev/Sources/SwiftUIDemo/MetalBrushSandbox/MetalBrushSandboxRootView.swift
+++ b/Dev/Sources/SwiftUIDemo/MetalBrushSandbox/MetalBrushSandboxRootView.swift
@@ -18,7 +18,7 @@ final class MetalBrushSandboxModel {
   }
 
   func reset() {
-    editingStack.set(localAdjustments: [])
+    replaceLocalAdjustments([])
     metrics = .init()
   }
 
@@ -38,15 +38,44 @@ final class MetalBrushSandboxModel {
   }
 
   private func applyExposure(_ exposure: Double) {
-    editingStack.set(effects: { effects in
+    editingStack.updateFeature(id: EditingFeatureTree.globalEffectsNodeID) { feature in
+      guard
+        case let .effect(effect) = feature,
+        var bundle = effect as? EffectPipelineFeature
+      else {
+        return
+      }
+
       if abs(exposure) < 0.001 {
-        effects.set(nil as ExposureFeature?)
+        bundle.pipeline.set(nil as ExposureFeature?)
       } else {
         // Fixed id: a fresh FeatureID per slider tick makes equal values
         // compare unequal and churns Equatable-keyed render caches.
-        effects.set(ExposureFeature(id: .init(rawValue: "sandbox.global-exposure"), value: exposure))
+        bundle.pipeline.set(
+          ExposureFeature(
+            id: .init(rawValue: "sandbox.global-exposure"),
+            value: exposure
+          )
+        )
       }
-    })
+
+      feature = .effect(bundle)
+    }
+  }
+
+  private func replaceLocalAdjustments(_ localAdjustments: [LocalAdjustmentFeature]) {
+    guard var edit = editingStack.loadedState?.currentEdit else {
+      return
+    }
+
+    EditingFeatureTree.replaceLocalAdjustments(
+      localAdjustments,
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
+    if editingStack.loadedState?.currentEdit != edit {
+      editingStack.loadedState?.currentEdit = edit
+    }
   }
 }
 

--- a/Dev/Tests/BrightroomEngineTests/CropSurfaceBlurRenderPathTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/CropSurfaceBlurRenderPathTests.swift
@@ -36,8 +36,7 @@ struct CropSurfaceBlurRenderPathTests {
       currentEdit: edit,
       thumbnailCIImage: ci,
       editingSourceCGImage: cg,
-      editingSourceCIImage: ci,
-      editingPreviewCIImage: edit.makePreviewImage(from: ci, purpose: .editingBase)
+      editingSourceCIImage: ci
     )
   }
 

--- a/Dev/Tests/BrightroomEngineTests/EditingFeatureDocumentTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EditingFeatureDocumentTests.swift
@@ -18,8 +18,8 @@ private extension MainFeature {
 }
 
 /// Contracts of the parametric editing document: `Edit` stores an
-/// `EditingDocument`, the engine never reorders its main tree, and history
-/// versions are whole-document snapshots with undo/redo.
+/// `EditingDocument`, the engine never reorders its main tree, and undo/redo
+/// checkpoints are whole-document values.
 struct EditingFeatureDocumentTests {
 
   private let imageSize = CGSize(width: 1200, height: 800)
@@ -29,13 +29,13 @@ struct EditingFeatureDocumentTests {
   }
 
   private func effectsFeature(
-    id: FeatureID = EditingStack.Edit.globalEffectsID,
+    id: FeatureID = EditingFeatureTree.globalEffectsNodeID,
     _ pipeline: EffectPipeline = .init()
   ) -> MainFeature {
     .effect(EffectPipelineFeature(id: id, pipeline: pipeline))
   }
 
-  private func cropFeature(id: FeatureID = EditingStack.Edit.finalCropID) -> MainFeature {
+  private func cropFeature(id: FeatureID = EditingFeatureTree.finalCropNodeID) -> MainFeature {
     .domain(CropFeature.test(imageSize: imageSize).with(id: id))
   }
 
@@ -65,18 +65,28 @@ struct EditingFeatureDocumentTests {
   // MARK: - Document shape
 
   @Test func `Canonical default document`() {
-    let edit = EditingStack.Edit(crop: makeCrop(), orientedImageSize: imageSize)
+    let edit = EditingFeatureTree.canonicalEdit(
+      finalCrop: makeCrop(),
+      orientedImageSize: imageSize
+    )
 
     #expect(edit.features.map(\.testKind) == ["effect", "crop"])
-    #expect(edit.features.first?.id == EditingStack.Edit.globalEffectsID)
-    #expect(edit.features.last?.id == EditingStack.Edit.finalCropID)
+    #expect(edit.features.first?.id == EditingFeatureTree.globalEffectsNodeID)
+    #expect(edit.features.last?.id == EditingFeatureTree.finalCropNodeID)
   }
 
   @Test func `Local adjustments projection inserts before final crop`() {
-    var edit = EditingStack.Edit(crop: makeCrop(), orientedImageSize: imageSize)
+    var edit = EditingFeatureTree.canonicalEdit(
+      finalCrop: makeCrop(),
+      orientedImageSize: imageSize
+    )
     let adjustment = makeAdjustment()
 
-    edit.localAdjustments = [adjustment]
+    EditingFeatureTree.replaceLocalAdjustments(
+      [adjustment],
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
 
     #expect(
       edit.features.map(\.testKind) == ["effect", "localAdjustment", "crop"]
@@ -108,7 +118,11 @@ struct EditingFeatureDocumentTests {
     replacedAdjustment.effectPipeline = EffectPipeline(effects: [
       ExposureFeature(value: 0.5)
     ])
-    edit.localAdjustments = [replacedAdjustment]
+    EditingFeatureTree.replaceLocalAdjustments(
+      [replacedAdjustment],
+      in: &edit,
+      insertingBefore: nil
+    )
 
     #expect(
       edit.features.map(\.testKind) == ["localAdjustment", "effect", "crop"]
@@ -116,24 +130,81 @@ struct EditingFeatureDocumentTests {
     #expect(edit.localAdjustments == [replacedAdjustment])
   }
 
+  @Test func `Effect features preserve separate effect nodes`() {
+    let first = EffectPipeline(effects: [BrightnessFeature(value: 0.1)])
+    let second = EffectPipeline(effects: [ContrastFeature(value: 0.2)])
+    let secondEffectsID = FeatureID(rawValue: "test.second-global-effects")
+
+    let firstNode = effectsFeature(id: EditingFeatureTree.globalEffectsNodeID, first)
+    let secondNode = effectsFeature(id: secondEffectsID, second)
+
+    let edit = makeEdit(features: [
+      firstNode,
+      .localAdjustment(makeAdjustment()),
+      secondNode,
+      cropFeature(),
+    ])
+
+    #expect(edit.effectFeatures == [firstNode, secondNode])
+  }
+
+  @Test func `Edit equality is document equality, not render crop equivalence`() {
+    let cropID = EditingFeatureTree.finalCropNodeID
+    let exactCrop = CropFeature(
+      id: cropID,
+      cropRect: CGRect(x: 0, y: 0, width: 100, height: 100)
+    )
+    let subpixelCrop = CropFeature(
+      id: cropID,
+      cropRect: CGRect(
+        x: 0.000000001,
+        y: 0,
+        width: 99.999999998,
+        height: 100
+      )
+    )
+    let exactEdit = EditingFeatureTree.canonicalEdit(
+      finalCrop: exactCrop,
+      orientedImageSize: CGSize(width: 100, height: 100)
+    )
+    let subpixelEdit = EditingFeatureTree.canonicalEdit(
+      finalCrop: subpixelCrop,
+      orientedImageSize: CGSize(width: 100, height: 100)
+    )
+
+    #expect(
+      exactCrop.isRenderingEquivalent(
+        to: subpixelCrop,
+        orientedImageSize: CGSize(width: 100, height: 100)
+      )
+    )
+    #expect(EditingFeatureTree(edit: exactEdit) != EditingFeatureTree(edit: subpixelEdit))
+    #expect(exactEdit != subpixelEdit)
+  }
+
   @Test func `Update feature keeps kind stable and rejects unknown IDs`() {
-    var edit = EditingStack.Edit(crop: makeCrop(), orientedImageSize: imageSize)
+    var edit = EditingFeatureTree.canonicalEdit(
+      finalCrop: makeCrop(),
+      orientedImageSize: imageSize
+    )
 
     #expect(
       !edit.updateFeature(id: FeatureID(rawValue: "unknown")) { _ in }
     )
 
     let newCrop = CropFeature(
-      id: EditingStack.Edit.finalCropID,
+      id: EditingFeatureTree.finalCropNodeID,
       displayCropRect: CropGeometry.cropRect(toFitAspectRatio: .square, in: imageSize),
       imageSize: imageSize
     )
     #expect(
-      edit.updateFeature(id: EditingStack.Edit.finalCropID) { feature in
-        feature = .domain(newCrop)
-      }
+      EditingFeatureTree.updateCropFeature(
+        id: EditingFeatureTree.finalCropNodeID,
+        in: &edit,
+        with: newCrop
+      )
     )
-    #expect(edit.crop == newCrop)
+    #expect(EditingFeatureTree(edit: edit).finalCrop == newCrop)
   }
 
   // MARK: - Undo / redo
@@ -158,11 +229,7 @@ struct EditingFeatureDocumentTests {
       currentEdit: initialEdit,
       thumbnailCIImage: sourceCIImage,
       editingSourceCGImage: cgImage,
-      editingSourceCIImage: sourceCIImage,
-      editingPreviewCIImage: initialEdit.makePreviewImage(
-        from: sourceCIImage,
-        purpose: .editingBase
-      )
+      editingSourceCIImage: sourceCIImage
     )
   }
 
@@ -170,27 +237,27 @@ struct EditingFeatureDocumentTests {
     var loaded = makeLoaded()
     let v0 = loaded.currentEdit
 
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
     var v1 = v0
     v1.effects = EffectPipeline(effects: [BrightnessFeature(value: 0.1)])
     loaded.currentEdit = v1
 
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
     var v2 = v1
-    v2.localAdjustments = [makeAdjustment()]
+    v2.setPhotosCropLocalAdjustmentsForTest([makeAdjustment()])
     loaded.currentEdit = v2
 
-    loaded.undoEditing()
+    loaded.undo()
     #expect(loaded.currentEdit == v1)
     #expect(loaded.canRedo)
 
-    loaded.undoEditing()
+    loaded.undo()
     #expect(loaded.currentEdit == v0)
 
-    loaded.redoEditing()
+    loaded.redo()
     #expect(loaded.currentEdit == v1)
 
-    loaded.redoEditing()
+    loaded.redo()
     #expect(loaded.currentEdit == v2)
     #expect(!loaded.canRedo)
   }
@@ -214,58 +281,66 @@ struct EditingFeatureDocumentTests {
     ])
 
     let adjustmentC = makeAdjustment()
-    edit.localAdjustments = [adjustmentA, adjustmentB, adjustmentC]
+    EditingFeatureTree.replaceLocalAdjustments(
+      [adjustmentA, adjustmentB, adjustmentC],
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
 
     #expect(
       edit.features.map(\.id) == [
-        EditingStack.Edit.globalEffectsID,
+        EditingFeatureTree.globalEffectsNodeID,
         adjustmentA.id,
         secondEffectsID,
         adjustmentB.id,
         adjustmentC.id,
-        EditingStack.Edit.finalCropID,
+        EditingFeatureTree.finalCropNodeID,
       ]
     )
 
     // Removing an adjustment keeps the others in place.
-    edit.localAdjustments = [adjustmentA, adjustmentB]
+    EditingFeatureTree.replaceLocalAdjustments(
+      [adjustmentA, adjustmentB],
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
     #expect(
       edit.features.map(\.id) == [
-        EditingStack.Edit.globalEffectsID,
+        EditingFeatureTree.globalEffectsNodeID,
         adjustmentA.id,
         secondEffectsID,
         adjustmentB.id,
-        EditingStack.Edit.finalCropID,
+        EditingFeatureTree.finalCropNodeID,
       ]
     )
   }
 
-  @Test func `Commit style snapshot undo changes state on first press`() {
-    // PhotosCrop snapshots AFTER mutating (commit style): history.last equals
-    // currentEdit at settled states. One undo press must still change state.
+  @Test func `Commit style checkpoint undo changes state on first press`() {
+    // PhotosCrop commits AFTER mutating: the latest checkpoint can equal the
+    // current edit at settled states. One undo press must still change state.
     var loaded = makeLoaded()
     let v0 = loaded.currentEdit
 
     var v1 = v0
     v1.effects = EffectPipeline(effects: [BrightnessFeature(value: 0.1)])
     loaded.currentEdit = v1
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
 
     var v2 = v1
-    v2.localAdjustments = [makeAdjustment()]
+    v2.setPhotosCropLocalAdjustmentsForTest([makeAdjustment()])
     loaded.currentEdit = v2
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
 
     #expect(loaded.canUndo)
-    loaded.undoEditing()
+    loaded.undo()
     #expect(loaded.currentEdit == v1)
 
-    loaded.undoEditing()
+    loaded.undo()
     #expect(loaded.currentEdit == v0)
 
-    loaded.redoEditing()
+    loaded.redo()
     #expect(loaded.currentEdit == v1)
-    loaded.redoEditing()
+    loaded.redo()
     #expect(loaded.currentEdit == v2)
     #expect(!loaded.canRedo)
   }
@@ -273,20 +348,36 @@ struct EditingFeatureDocumentTests {
   @Test func `New version clears redo`() {
     var loaded = makeLoaded()
 
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
     var v1 = loaded.currentEdit
     v1.effects = EffectPipeline(effects: [BrightnessFeature(value: 0.1)])
     loaded.currentEdit = v1
 
-    loaded.undoEditing()
+    loaded.undo()
     #expect(loaded.canRedo)
 
     var divergent = loaded.currentEdit
     divergent.effects = EffectPipeline(effects: [ContrastFeature(value: 0.1)])
     loaded.currentEdit = divergent
-    loaded.makeVersion()
+    loaded.commitCurrentEdit()
 
     #expect(!loaded.canRedo)
+  }
+
+  @Test func `Commit current edit if needed skips duplicate checkpoints`() {
+    var loaded = makeLoaded()
+
+    loaded.commitCurrentEditIfNeeded()
+    #expect(loaded.currentRevision == 0)
+
+    var edited = loaded.currentEdit
+    edited.effects = EffectPipeline(effects: [BrightnessFeature(value: 0.1)])
+    loaded.currentEdit = edited
+    loaded.commitCurrentEditIfNeeded()
+    #expect(loaded.currentRevision == 1)
+
+    loaded.commitCurrentEditIfNeeded()
+    #expect(loaded.currentRevision == 1)
   }
 }
 

--- a/Dev/Tests/BrightroomEngineTests/EditingPreviewExportParityTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EditingPreviewExportParityTests.swift
@@ -70,9 +70,9 @@ struct EditingPreviewExportParityTests {
     )
     var edit = EditingStack.Edit.test(imageSize: CGSize(width: 60, height: 24))
     edit.effects = EffectPipeline(effects: [ExposureFeature(value: 0.4)])
-    edit.localAdjustments = [
+    edit.setPhotosCropLocalAdjustmentsForTest([
       Self.makeBlurLayer(radius: 8, center: CGPoint(x: 30, y: 12)),
-    ]
+    ])
 
     let exported = try await export(edit, source: source)
     let preview = try previewComposition(edit, source: source)
@@ -100,14 +100,14 @@ struct EditingPreviewExportParityTests {
     )
     let cropRect = CGRect(x: 30, y: 0, width: 30, height: 24)
     var edit = EditingStack.Edit.test(imageSize: CGSize(width: 60, height: 24))
-    edit.crop = CropFeature.test(
+    edit.setFinalCropForTest(CropFeature.test(
       imageSize: CGSize(width: 60, height: 24),
       cropRect: cropRect
-    )
+    ))
     edit.effects = EffectPipeline(effects: [ExposureFeature(value: 0.4)])
-    edit.localAdjustments = [
+    edit.setPhotosCropLocalAdjustmentsForTest([
       Self.makeBlurLayer(radius: 8, center: CGPoint(x: 30, y: 12)),
-    ]
+    ])
 
     let exported = try await export(edit, source: source)
     let preview = try previewComposition(edit, source: source)
@@ -145,7 +145,7 @@ struct EditingPreviewExportParityTests {
       mask.isEnabled = false
       disabledLayer.maskTree.root = .brush(mask)
     }
-    disabledEdit.localAdjustments = [disabledLayer]
+    disabledEdit.setPhotosCropLocalAdjustmentsForTest([disabledLayer])
 
     // Reference: same document with no local adjustment at all.
     var globalOnlyEdit = EditingStack.Edit.test(imageSize: baseImageSize)
@@ -185,7 +185,7 @@ struct EditingPreviewExportParityTests {
       ),
       effectPipeline: EffectPipeline(effects: [ThrowingEffectFeature()])
     )
-    edit.localAdjustments = [throwingLayer]
+    edit.setPhotosCropLocalAdjustmentsForTest([throwingLayer])
 
     let error = await #expect(throws: (any Error).self) {
       _ = try await export(edit, source: source)

--- a/Dev/Tests/BrightroomEngineTests/EditingStackFeatureTreeTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EditingStackFeatureTreeTests.swift
@@ -32,7 +32,7 @@ struct EditingStackFeatureTreeTests {
     localAdjustmentIDs: [FeatureID] = []
   ) -> EditingStack.Edit {
     var edit = EditingStack.Edit.test(imageSize: CGSize(width: 1200, height: 800))
-    edit.localAdjustments = localAdjustmentIDs.map { id in
+    edit.setPhotosCropLocalAdjustmentsForTest(localAdjustmentIDs.map { id in
       LocalAdjustmentFeature(
         id: id,
         maskTree: MaskTree(
@@ -56,7 +56,7 @@ struct EditingStackFeatureTreeTests {
           GaussianBlurFeature(id: .init(rawValue: id.rawValue + ".blur"), radius: 10)
         ])
       )
-    }
+    })
     return edit
   }
 
@@ -91,7 +91,7 @@ struct EditingStackFeatureTreeTests {
     let edit = makeEdit(localAdjustmentIDs: [layer])
     let tree = EditingFeatureTree(edit: edit)
 
-    #expect(tree.finalCrop == edit.crop)
+    #expect(tree.finalCrop?.id == EditingFeatureTree.finalCropNodeID)
     #expect(tree.globalEffects == edit.effects)
     #expect(tree.localAdjustmentNodes.count == 1)
     #expect(
@@ -135,7 +135,7 @@ struct EditingStackFeatureTreeTests {
   @Test func `Update crop feature`() {
     var edit = makeEdit()
     let newCrop = CropFeature(
-      id: edit.crop.id,
+      id: EditingFeatureTree.finalCropNodeID,
       displayCropRect: CGRect(x: 100, y: 100, width: 400, height: 300),
       imageSize: CGSize(width: 1200, height: 800)
     )
@@ -148,7 +148,7 @@ struct EditingStackFeatureTreeTests {
     }
 
     #expect(result)
-    #expect(edit.crop == newCrop)
+    #expect(EditingFeatureTree(edit: edit).finalCrop == newCrop)
   }
 
   @Test func `Update global effects feature`() {

--- a/Dev/Tests/BrightroomEngineTests/EnginePerformanceWorkloadTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/EnginePerformanceWorkloadTests.swift
@@ -143,7 +143,7 @@ final class EnginePerformanceWorkloadTests: XCTestCase {
   private static func makeDocument(imageSize: CGSize) -> EditingStack.Edit {
     var edit = EditingStack.Edit.test(imageSize: imageSize)
     edit.effects = makeEffectPipeline()
-    edit.localAdjustments = [
+    edit.setPhotosCropLocalAdjustmentsForTest([
       LocalAdjustmentFeature(
         id: .init(rawValue: "perf.local"),
         maskTree: cachedMaskTree,
@@ -151,8 +151,8 @@ final class EnginePerformanceWorkloadTests: XCTestCase {
           GaussianBlurFeature(id: .init(rawValue: "perf.local.blur"), value: 60)
         ])
       )
-    ]
-    edit.crop = CropFeature.test(
+    ])
+    edit.setFinalCropForTest(CropFeature.test(
       imageSize: imageSize,
       cropRect: CGRect(
         x: imageSize.width * 0.1,
@@ -160,7 +160,7 @@ final class EnginePerformanceWorkloadTests: XCTestCase {
         width: imageSize.width * 0.8,
         height: imageSize.height * 0.8
       ).integral
-    )
+    ))
     return edit
   }
 }

--- a/Dev/Tests/BrightroomEngineTests/LocalAdjustmentRenderingTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/LocalAdjustmentRenderingTests.swift
@@ -30,9 +30,9 @@ struct LocalAdjustmentRenderingTests {
     let sourceCIImage = CIImage(cgImage: sourceImage)
     var edit = EditingStack.Edit.test(imageSize: CGSize(width: 40, height: 20))
     edit.effects = EffectPipeline(effects: [BrightnessFeature(value: 0.2)])
-    edit.localAdjustments = [
+    edit.setPhotosCropLocalAdjustmentsForTest([
       Self.makeBlurLayer(radius: 6, center: CGPoint(x: 20, y: 10)),
-    ]
+    ])
 
     let editingPreview = edit.makePreviewImage(from: sourceCIImage, purpose: .editing)
     let editingImage = try #require(
@@ -44,7 +44,7 @@ struct LocalAdjustmentRenderingTests {
     )
   }
 
-  @Test func `Loaded editing preview skips automatic local adjustment rasterization`() throws {
+  @Test func `Editing base preview skips local adjustment rasterization`() throws {
     let sourceImage = Self.makeSplitImage(
       width: 40,
       height: 20,
@@ -52,33 +52,18 @@ struct LocalAdjustmentRenderingTests {
       rightWhite: 0.25
     )
     let sourceCIImage = CIImage(cgImage: sourceImage)
-    let imageSource = ImageSource(cgImage: sourceImage)
-    let initialEdit = EditingStack.Edit.test(imageSize: CGSize(width: 40, height: 20))
-    var loadedState = EditingStack.Loaded(
-      imageSource: imageSource,
-      metadata: .init(
-        orientation: .up,
-        imageSize: CGSize(width: 40, height: 20)
-      ),
-      initialEditing: initialEdit,
-      currentEdit: initialEdit,
-      thumbnailCIImage: sourceCIImage,
-      editingSourceCGImage: sourceImage,
-      editingSourceCIImage: sourceCIImage,
-      editingPreviewCIImage: initialEdit.makePreviewImage(
-        from: sourceCIImage,
-        purpose: .editingBase
-      )
+    var editWithLocalAdjustment = EditingStack.Edit.test(
+      imageSize: CGSize(width: 40, height: 20)
     )
-    var editWithLocalAdjustment = initialEdit
-    editWithLocalAdjustment.localAdjustments = [
+    editWithLocalAdjustment.setPhotosCropLocalAdjustmentsForTest([
       Self.makeExposureLayer(value: 1, center: CGPoint(x: 20, y: 10)),
-    ]
+    ])
 
-    loadedState.currentEdit = editWithLocalAdjustment
-
-    let loadedPreviewImage = try #require(
-      Self.context.createCGImage(loadedState.editingPreviewImage, from: sourceCIImage.extent)
+    let editingBasePreviewImage = try #require(
+      Self.context.createCGImage(
+        editWithLocalAdjustment.makePreviewImage(from: sourceCIImage, purpose: .editingBase),
+        from: sourceCIImage.extent
+      )
     )
     let fullEditingPreviewImage = try #require(
       Self.context.createCGImage(
@@ -87,12 +72,12 @@ struct LocalAdjustmentRenderingTests {
       )
     )
 
-    #expect(
-      Self.rgba(in: sourceImage, x: 20, y: 10) == Self.rgba(in: loadedPreviewImage, x: 20, y: 10)
-    )
-    #expect(
-      Self.rgba(in: fullEditingPreviewImage, x: 20, y: 10).red > Self.rgba(in: sourceImage, x: 20, y: 10).red
-    )
+    let sourcePixel = Self.rgba(in: sourceImage, x: 20, y: 10)
+    let editingBasePixel = Self.rgba(in: editingBasePreviewImage, x: 20, y: 10)
+    let fullEditingPixel = Self.rgba(in: fullEditingPreviewImage, x: 20, y: 10)
+
+    #expect(sourcePixel == editingBasePixel)
+    #expect(fullEditingPixel.red > sourcePixel.red)
   }
 
   @Test func `Exposure local adjustment applies only inside mask`() throws {

--- a/Dev/Tests/BrightroomEngineTests/MaskedPreviewExportScaleConsistencyTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/MaskedPreviewExportScaleConsistencyTests.swift
@@ -54,8 +54,7 @@ struct MaskedPreviewExportScaleConsistencyTests {
       currentEdit: edit,
       thumbnailCIImage: sourceEdgeCI,
       editingSourceCGImage: sourceEdgeCG,
-      editingSourceCIImage: sourceEdgeCI,
-      editingPreviewCIImage: edit.makePreviewImage(from: sourceEdgeCI, purpose: .editingBase)
+      editingSourceCIImage: sourceEdgeCI
     )
 
     let blur = EffectPipeline(effects: [GaussianBlurFeature(value: 40)])
@@ -145,8 +144,7 @@ struct MaskedPreviewExportScaleConsistencyTests {
       currentEdit: edit,
       thumbnailCIImage: sourceEdgeCI,
       editingSourceCGImage: sourceEdgeCG,
-      editingSourceCIImage: sourceEdgeCI,
-      editingPreviewCIImage: edit.makePreviewImage(from: sourceEdgeCI, purpose: .editingBase)
+      editingSourceCIImage: sourceEdgeCI
     )
 
     let blur = EffectPipeline(effects: [GaussianBlurFeature(value: 40)])

--- a/Dev/Tests/BrightroomEngineTests/PhotosCropEditingModelTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/PhotosCropEditingModelTests.swift
@@ -1,0 +1,187 @@
+import CoreImage
+import CoreGraphics
+import Testing
+import UIKit
+
+@testable import BrightroomEngine
+@testable import BrightroomParametric
+@testable import BrightroomUI
+
+@MainActor
+struct PhotosCropEditingModelTests {
+
+  @Test func `PhotosCrop model reads loaded stack state`() {
+    let model = PhotosCropEditingModel(editingStack: makeStack())
+
+    #expect(model.isLoaded)
+  }
+
+  @Test func `PhotosCrop model owns editing stack for view dependency`() {
+    weak var retainedStack: EditingStack?
+    let model: PhotosCropEditingModel
+
+    do {
+      let stack = makeStack()
+      retainedStack = stack
+      model = PhotosCropEditingModel(editingStack: stack)
+    }
+
+    #expect(retainedStack != nil)
+    #expect(model.isLoaded)
+  }
+
+  @Test func `Feature focus is resolved by PhotosCrop policy`() {
+    let model = PhotosCropEditingModel(editingStack: makeStack())
+
+    #expect(
+      model.featureFocus(for: .crop) == CropViewFeatureFocus(
+        viewingPoint: .output,
+        editingTarget: .crop(id: EditingFeatureTree.finalCropNodeID)
+      )
+    )
+
+    #expect(
+      model.featureFocus(for: .blurMasking) == CropViewFeatureFocus(
+        viewingPoint: .output,
+        editingTarget: .localAdjustmentMask(
+          id: nil,
+          seedEffect: CropViewMaskingDefaults.blurEffectPipeline
+        )
+      )
+    )
+
+    #expect(model.featureFocus(for: .filters) == CropViewFeatureFocus(viewingPoint: .output))
+    #expect(model.featureFocus(for: .adjustments) == CropViewFeatureFocus(viewingPoint: .output))
+  }
+
+  @Test func `Global effect edits go through PhotosCrop model`() {
+    let stack = makeStack()
+    let model = PhotosCropEditingModel(editingStack: stack)
+    let preset = PresetFeature(
+      id: FeatureID(rawValue: "test-preset-feature"),
+      name: "Test",
+      identifier: "test",
+      effects: [BrightnessFeature(value: 0.1)]
+    )
+
+    model.selectFilterPreset(preset)
+    model.setAdjustmentValue(50, parameter: .exposure)
+
+    let effects = stack.loadedState?.currentEdit.effects
+    #expect(effects?.first(of: PresetFeature.self)?.identifier == "test")
+    #expect(effects?.first(of: ExposureFeature.self)?.value == 0.9)
+  }
+
+  @Test func `Global effect edits insert missing PhotosCrop node before local adjustments`() {
+    let stack = makeStack()
+    let model = PhotosCropEditingModel(editingStack: stack)
+    let adjustment = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "local-adjustment"),
+      maskTree: .init(root: .brush(.init())),
+      effectPipeline: EffectPipeline(effects: [GaussianBlurFeature(radius: 10)])
+    )
+
+    var loaded = stack.loadedState!
+    var edit = loaded.currentEdit
+    #expect(
+      EditingFeatureTree.removeFeature(
+        id: EditingFeatureTree.globalEffectsNodeID,
+        from: &edit
+      )
+    )
+    EditingFeatureTree.replaceLocalAdjustments(
+      [adjustment],
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
+    loaded.currentEdit = edit
+    stack.loadedState = loaded
+
+    model.setAdjustmentValue(50, parameter: .exposure)
+
+    let features = stack.loadedState?.currentEdit.features
+    #expect(features?.map(\.id) == [
+      EditingFeatureTree.globalEffectsNodeID,
+      adjustment.id,
+      EditingFeatureTree.finalCropNodeID,
+    ])
+    #expect(
+      stack.loadedState?.currentEdit.effects.first(of: ExposureFeature.self)?.value == 0.9
+    )
+  }
+
+  @Test func `PhotosCrop model commits undo checkpoints at tool boundary`() {
+    let stack = makeStack()
+    let model = PhotosCropEditingModel(editingStack: stack)
+    let preset = PresetFeature(
+      id: FeatureID(rawValue: "test-preset-feature"),
+      name: "Test",
+      identifier: "test",
+      effects: [BrightnessFeature(value: 0.1)]
+    )
+
+    model.selectFilterPreset(preset)
+    model.commitCurrentEditIfNeeded()
+
+    #expect(stack.loadedState?.canUndo == true)
+
+    stack.undo()
+    #expect(stack.loadedState?.currentEdit.effects.first(of: PresetFeature.self) == nil)
+
+    stack.redo()
+    #expect(
+      stack.loadedState?.currentEdit.effects.first(of: PresetFeature.self)?.identifier == "test"
+    )
+  }
+
+  @Test func `Blur mask clear removes only PhotosCrop blur layer`() {
+    let stack = makeStack()
+    let model = PhotosCropEditingModel(editingStack: stack)
+    let blurLayer = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "blur-layer"),
+      maskTree: .init(root: .brush(.init())),
+      effectPipeline: CropViewMaskingDefaults.blurEffectPipeline
+    )
+    let exposureLayer = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "exposure-layer"),
+      maskTree: .init(root: .brush(.init())),
+      effectPipeline: EffectPipeline(effects: [ExposureFeature(value: 0.2)])
+    )
+
+    var loaded = stack.loadedState!
+    var edit = loaded.currentEdit
+    edit.setPhotosCropLocalAdjustmentsForTest([blurLayer, exposureLayer])
+    loaded.currentEdit = edit
+    stack.loadedState = loaded
+
+    model.clearBlurMaskingLayer()
+
+    let remaining = stack.loadedState?.currentEdit.localAdjustments
+    #expect(remaining?.map(\.id) == [exposureLayer.id])
+  }
+
+  private func makeStack() -> EditingStack {
+    let size = CGSize(width: 40, height: 20)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    format.opaque = true
+    let cgImage = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+      UIColor.white.setFill()
+      UIRectFill(CGRect(origin: .zero, size: size))
+    }.cgImage!
+    let sourceCIImage = CIImage(cgImage: cgImage)
+    let initialEdit = EditingStack.Edit.test(imageSize: size)
+    let loaded = EditingStack.Loaded(
+      imageSource: ImageSource(cgImage: cgImage),
+      metadata: .init(orientation: .up, imageSize: size),
+      initialEditing: initialEdit,
+      currentEdit: initialEdit,
+      thumbnailCIImage: sourceCIImage,
+      editingSourceCGImage: cgImage,
+      editingSourceCIImage: sourceCIImage
+    )
+    let stack = EditingStack(imageProvider: .init(image: UIImage(cgImage: cgImage)))
+    stack.loadedState = loaded
+    return stack
+  }
+}

--- a/Dev/Tests/BrightroomEngineTests/PreviewExportVisualEvidenceTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/PreviewExportVisualEvidenceTests.swift
@@ -56,7 +56,7 @@ struct PreviewExportVisualEvidenceTests {
     //    composition of the same edit — these must look identical.
     var fullEdit = EditingStack.Edit.test(imageSize: imageSize)
     fullEdit.effects = effects
-    fullEdit.localAdjustments = [blurLayer]
+    fullEdit.setPhotosCropLocalAdjustmentsForTest([blurLayer])
 
     let export = try await renderExport(fullEdit, source: source)
     attach(cgImage: export, name: "2-export-no-crop")
@@ -73,7 +73,7 @@ struct PreviewExportVisualEvidenceTests {
       height: imageSize.height * 0.7
     ).integral
     var croppedEdit = fullEdit
-    croppedEdit.crop = CropFeature.test(imageSize: imageSize, cropRect: cropRect)
+    croppedEdit.setFinalCropForTest(CropFeature.test(imageSize: imageSize, cropRect: cropRect))
     let croppedExport = try await renderExport(croppedEdit, source: source)
     attach(cgImage: croppedExport, name: "4-export-with-crop")
 

--- a/Dev/Tests/BrightroomEngineTests/RendererEditTestSupport.swift
+++ b/Dev/Tests/BrightroomEngineTests/RendererEditTestSupport.swift
@@ -29,9 +29,30 @@ extension EditingStack.Edit {
   /// Test helper: the canonical default edit for an image of `imageSize`,
   /// optionally with a non-default final crop rect (y-down display space).
   static func test(imageSize: CGSize, cropRect: CGRect? = nil) -> Self {
-    .init(
-      crop: CropFeature.test(imageSize: imageSize, cropRect: cropRect),
+    EditingFeatureTree.canonicalEdit(
+      finalCrop: CropFeature.test(imageSize: imageSize, cropRect: cropRect),
       orientedImageSize: imageSize
+    )
+  }
+
+  /// Test helper for PhotosCrop-style documents: local adjustments are authored
+  /// before the built-in final crop node.
+  mutating func setPhotosCropLocalAdjustmentsForTest(
+    _ localAdjustments: [LocalAdjustmentFeature]
+  ) {
+    EditingFeatureTree.replaceLocalAdjustments(
+      localAdjustments,
+      in: &self,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
+  }
+
+  /// Test helper for replacing the built-in final crop node.
+  mutating func setFinalCropForTest(_ crop: CropFeature) {
+    _ = EditingFeatureTree.updateCropFeature(
+      id: EditingFeatureTree.finalCropNodeID,
+      in: &self,
+      with: crop
     )
   }
 }
@@ -51,9 +72,12 @@ extension BrightRoomImageRenderer.Edit {
     effects: EffectPipeline = .init(),
     localAdjustments: [LocalAdjustmentFeature] = []
   ) -> Self {
-    var edit = EditingStack.Edit(crop: crop, orientedImageSize: orientedImageSize)
+    var edit = EditingFeatureTree.canonicalEdit(
+      finalCrop: crop,
+      orientedImageSize: orientedImageSize
+    )
     edit.effects = effects
-    edit.localAdjustments = localAdjustments
+    edit.setPhotosCropLocalAdjustmentsForTest(localAdjustments)
     return .init(document: edit.makeEditingDocument(orientedImageSize: orientedImageSize))
   }
 }

--- a/Dev/Tests/BrightroomEngineTests/RendererTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/RendererTests.swift
@@ -324,28 +324,6 @@ struct RenderCropTests {
     #expect(abs(crop.straightenRadians - 0.25 * .pi / 180) <= 1e-12)
   }
 
-  @Test func `edit rendering equivalence uses pixel crop contract`() {
-    let initial = EditingStack.Edit.test(
-      imageSize: .init(width: 100, height: 100),
-      cropRect: .init(x: 0, y: 0, width: 100, height: 100)
-    )
-    let nearInteger = EditingStack.Edit.test(
-      imageSize: .init(width: 100, height: 100),
-      cropRect: .init(
-        x: 0.000000001,
-        y: 0.000000001,
-        width: 99.999999998,
-        height: 99.999999998
-      )
-    )
-    let inwardPixel = EditingStack.Edit.test(
-      imageSize: .init(width: 100, height: 100),
-      cropRect: .init(x: 0.2, y: 0, width: 99.8, height: 100)
-    )
-
-    #expect(initial.isRenderingEquivalent(to: nearInteger))
-    #expect(!initial.isRenderingEquivalent(to: inwardPixel))
-  }
 }
 
 /// Pins the shared y-flip + integer-snap contract on `CropFeature` that UI crop

--- a/Sources/BrightroomEngine/Core/EditingStack.Edit.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.Edit.swift
@@ -31,13 +31,13 @@ extension EditingStack {
   ///
   /// All editing state lives in a parametric `EditingDocument` — its
   /// `mainTree.features` order is the evaluation order. `Edit` is a thin wrapper
-  /// that adds the oriented source pixel size (`CropFeature` carries none) and
-  /// the engine's editing projections.
+  /// that adds the oriented source pixel size and the engine's editing
+  /// projections.
   ///
-  /// The named accessors (`crop`, `effects`, `localAdjustments`) are projections
-  /// over the main tree, kept so callers that only care about the canonical
-  /// arrangement do not need to walk features themselves. Their setters rewrite
-  /// the corresponding feature in place.
+  /// The remaining named accessors are compatibility projections over the main
+  /// tree. Crop is intentionally not projected here: crop nodes are addressed
+  /// through `EditingFeatureTree` by feature identity so multiple crop Features
+  /// can coexist without `Edit` choosing one as special.
   ///
   /// Pixel parameters use the BrightroomParametric vocabulary directly
   /// (`CropFeature`, `EffectPipelineFeature`/`EffectPipeline`,
@@ -46,49 +46,15 @@ extension EditingStack {
 
     /// The parametric editing document — the source of truth. Assembly (which
     /// features exist and in what order) is the host UI's responsibility; the
-    /// engine evaluates the main tree as-is. The document always contains at
-    /// least one crop domain feature; the last one acts as the final crop.
+    /// engine evaluates the main tree as-is.
     public private(set) var document: EditingDocument
 
-    /// The oriented source pixel size. `CropFeature` is expressed relative to
-    /// this size (its rect is snapped against it); storing it on `Edit` keeps a
-    /// document snapshot self-describing for history and tests.
+    /// The oriented source pixel size. Storing it on `Edit` keeps a document
+    /// snapshot self-describing for history and tests.
     public var orientedImageSize: CGSize
 
-    // MARK: - Well-known identities
-
-    /// The identity of the global effects node in the canonical document.
-    public static let globalEffectsID = FeatureID(
-      rawValue: "brightroom.editing-stack.global-effects"
-    )
-
-    /// The identity of the final crop node.
-    public static let finalCropID = FeatureID(
-      rawValue: "brightroom.editing-stack.final-crop"
-    )
-
-    /// Creates the canonical default document: a neutral effects pipeline
-    /// followed by the final crop. The crop is re-stamped with `finalCropID`.
-    init(crop: CropFeature, orientedImageSize: CGSize) {
-      var finalCrop = crop
-      finalCrop.id = Self.finalCropID
-      self.document = EditingDocument(
-        mainTree: MainTree(features: [
-          .effect(EffectPipelineFeature(id: Self.globalEffectsID, pipeline: .init())),
-          .domain(finalCrop),
-        ])
-      )
-      self.orientedImageSize = orientedImageSize
-    }
-
     /// Creates a document from an explicit parametric document.
-    ///
-    /// The main tree must contain at least one crop domain feature.
     public init(document: EditingDocument, orientedImageSize: CGSize) {
-      precondition(
-        document.mainTree.features.contains(where: Self.isCropFeature),
-        "An editing document requires at least one crop feature."
-      )
       self.document = document
       self.orientedImageSize = orientedImageSize
     }
@@ -103,20 +69,17 @@ extension EditingStack {
       document.mainTree.features
     }
 
-    /// The effects state in document order; the preview refresh key. With the
-    /// canonical bundled pipeline this is a single combined pipeline.
-    var effectsSequence: [EffectPipeline] {
-      [effects]
+    /// The effect nodes in document order; the preview refresh key.
+    var effectFeatures: [MainFeature] {
+      features.filter {
+        if case .effect = $0 {
+          return true
+        }
+        return false
+      }
     }
 
     // MARK: - Feature classification
-
-    private static func isCropFeature(_ feature: MainFeature) -> Bool {
-      if case let .domain(domain) = feature, domain is CropFeature {
-        return true
-      }
-      return false
-    }
 
     private static func caseTag(_ feature: MainFeature) -> Int {
       switch feature {
@@ -127,13 +90,6 @@ extension EditingStack {
     }
 
     // MARK: - Feature list mutations
-
-    private var finalCropIndex: Int {
-      guard let index = features.lastIndex(where: Self.isCropFeature) else {
-        preconditionFailure("An editing document requires at least one crop feature.")
-      }
-      return index
-    }
 
     /// Replaces the feature with `id`, keeping its case stable. Returns false
     /// when the feature does not exist or the mutation changed the case
@@ -160,26 +116,23 @@ extension EditingStack {
       return true
     }
 
-    /// Inserts a feature before the final crop — the position for everything
-    /// authored in the pre-final-crop domain.
-    public mutating func insertFeatureBeforeFinalCrop(_ feature: MainFeature) {
-      document.mainTree.features.insert(feature, at: finalCropIndex)
-    }
-
     /// Inserts a feature at an explicit position.
     public mutating func insertFeature(_ feature: MainFeature, at index: Int) {
       document.mainTree.features.insert(feature, at: index)
     }
 
-    /// Removes the feature with `id`. Crop features are not removable; the
-    /// document must keep its final crop. Returns false when nothing was
-    /// removed.
+    /// Replaces the ordered feature list.
+    ///
+    /// Use this for FeatureTree-level operations that need to preserve positions
+    /// while removing and inserting several nodes as one document edit.
+    public mutating func replaceFeatures(_ features: [MainFeature]) {
+      document.mainTree.features = features
+    }
+
+    /// Removes the feature with `id`. Returns false when nothing was removed.
     @discardableResult
     public mutating func removeFeature(id: FeatureID) -> Bool {
-      guard
-        let index = features.firstIndex(where: { $0.id == id }),
-        Self.isCropFeature(features[index]) == false
-      else {
+      guard let index = features.firstIndex(where: { $0.id == id }) else {
         return false
       }
 
@@ -188,23 +141,6 @@ extension EditingStack {
     }
 
     // MARK: - Canonical projections
-
-    /// The final crop: the last crop domain feature in the document.
-    /// In orientation.up, y-up (Core Image) coordinates.
-    public var crop: CropFeature {
-      get {
-        guard
-          case let .domain(domain) = features[finalCropIndex],
-          let crop = domain as? CropFeature
-        else {
-          preconditionFailure()
-        }
-        return crop
-      }
-      set {
-        document.mainTree.features[finalCropIndex] = .domain(newValue)
-      }
-    }
 
     /// The index of the bundled effect-pipeline node, if present.
     private var bundledEffectIndex: Int? {
@@ -222,7 +158,7 @@ extension EditingStack {
     /// present, and otherwise GATHERS any scattered raw effect features into one
     /// pipeline (back-compat for documents saved before the bundle existed). The
     /// setter always writes the canonical bundled node, anchored at
-    /// `globalEffectsID`.
+    /// `EditingFeatureTree.globalEffectsNodeID`.
     public var effects: EffectPipeline {
       get {
         if
@@ -247,8 +183,14 @@ extension EditingStack {
             EffectPipelineFeature(id: id, pipeline: newValue)
           )
         } else {
-          insertFeatureBeforeFinalCrop(
-            .effect(EffectPipelineFeature(id: Self.globalEffectsID, pipeline: newValue))
+          insertFeature(
+            .effect(
+              EffectPipelineFeature(
+                id: EditingFeatureTree.globalEffectsNodeID,
+                pipeline: newValue
+              )
+            ),
+            at: 0
           )
         }
       }
@@ -256,68 +198,16 @@ extension EditingStack {
 
     /// All local adjustments in document order.
     ///
-    /// The setter is position-preserving: adjustments matched by id update
-    /// their feature in place, removed adjustments drop their feature, and
-    /// new adjustments insert before the final crop. Reordering existing
-    /// adjustments is not expressible through this projection — mutate the
-    /// document directly.
+    /// Mutating the local-adjustment list is FeatureTree policy because new
+    /// layers need an insertion point in the ordered feature stack.
     public var localAdjustments: [LocalAdjustmentFeature] {
-      get {
-        features.compactMap {
-          if case let .localAdjustment(adjustment) = $0 {
-            return adjustment
-          }
-          return nil
+      features.compactMap {
+        if case let .localAdjustment(adjustment) = $0 {
+          return adjustment
         }
-      }
-      set {
-        var remaining = newValue
-        var features = document.mainTree.features
-        for index in features.indices.reversed() {
-          guard case let .localAdjustment(existing) = features[index] else {
-            continue
-          }
-          if let matched = remaining.firstIndex(where: { $0.id == existing.id }) {
-            let adjustment = remaining.remove(at: matched)
-            features[index] = .localAdjustment(adjustment)
-          } else {
-            features.remove(at: index)
-          }
-        }
-        document.mainTree.features = features
-        for adjustment in remaining {
-          insertFeatureBeforeFinalCrop(.localAdjustment(adjustment))
-        }
+        return nil
       }
     }
 
-    func isRenderingEquivalent(to other: Self) -> Bool {
-      guard orientedImageSize == other.orientedImageSize else {
-        return false
-      }
-      let lhsFeatures = features
-      let rhsFeatures = other.features
-      guard lhsFeatures.count == rhsFeatures.count else {
-        return false
-      }
-
-      return zip(lhsFeatures, rhsFeatures).allSatisfy { lhs, rhs in
-        // Crops compare through the engine's integer pixel-snap (sub-pixel
-        // differences that snap to the same render rect are equivalent); every
-        // other feature uses exact value equality via `MainFeature ==`.
-        if
-          case let .domain(a) = lhs, let cropA = a as? CropFeature,
-          case let .domain(b) = rhs, let cropB = b as? CropFeature
-        {
-          return cropsRenderingEquivalent(cropA, cropB)
-        }
-        return lhs == rhs
-      }
-    }
-
-    private func cropsRenderingEquivalent(_ a: CropFeature, _ b: CropFeature) -> Bool {
-      a.renderCrop(orientedImageSize: orientedImageSize)
-        == b.renderCrop(orientedImageSize: orientedImageSize)
-    }
   }
 }

--- a/Sources/BrightroomEngine/Core/EditingStack.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.swift
@@ -31,6 +31,128 @@ public enum EditingStackError: Error, Sendable {
   case unableToCreateRendererInLoading
 }
 
+/// A value-type undo/redo journal for document snapshots.
+///
+/// `EditingStack` owns this because history is a property of the editable
+/// document, while feature-specific UIs decide when the current edit should
+/// become a checkpoint.
+private struct EditingHistory<State: Equatable>: Equatable {
+
+  /// The edit the stack loaded with.
+  let initial: State
+
+  /// The edit currently being previewed and rendered.
+  var current: State
+
+  /// Committed undo checkpoints.
+  private var checkpoints: [State]
+
+  /// Checkpoints undone from `checkpoints`, available until the next commit.
+  private var redoStack: [State]
+
+  /// Creates a history journal around the loaded edit.
+  init(
+    initial: State,
+    current: State,
+    checkpoints: [State] = [],
+    redoStack: [State] = []
+  ) {
+    self.initial = initial
+    self.current = current
+    self.checkpoints = checkpoints
+    self.redoStack = redoStack
+  }
+
+  /// The current revision index, matching the number of committed checkpoints.
+  var revision: Int {
+    checkpoints.count
+  }
+
+  /// Whether undo can move the current edit to another state.
+  var canUndo: Bool {
+    if checkpoints.last == current {
+      return checkpoints.count > 1 || current != initial
+    }
+    return checkpoints.isEmpty == false || current != initial
+  }
+
+  /// Whether redo can move the current edit to another state.
+  var canRedo: Bool {
+    redoStack.isEmpty == false
+  }
+
+  /// Whether the current edit differs from the loaded edit.
+  var isDirty: Bool {
+    current != initial
+  }
+
+  /// Whether the current edit differs from the latest committed checkpoint.
+  var hasUncommittedChanges: Bool {
+    guard let latestCheckpoint = checkpoints.last else {
+      return current != initial
+    }
+    return latestCheckpoint != current
+  }
+
+  /// Commits the current edit when it differs from the latest checkpoint.
+  mutating func commitCurrentIfNeeded() {
+    guard hasUncommittedChanges else {
+      return
+    }
+    commitCurrent()
+  }
+
+  /// Commits the current edit as a checkpoint and clears redo.
+  mutating func commitCurrent() {
+    checkpoints.append(current)
+    redoStack = []
+  }
+
+  /// Reverts the current edit to the latest checkpoint, or the initial edit.
+  mutating func revertCurrent() {
+    current = checkpoints.last ?? initial
+  }
+
+  /// Reverts to the checkpoint at `revision`, clamping stale revision values.
+  mutating func revert(to revision: Int) {
+    let clamped = min(max(revision, 0), checkpoints.count)
+    checkpoints.removeSubrange(clamped..<checkpoints.count)
+    redoStack = []
+    current = checkpoints.last ?? initial
+  }
+
+  /// Moves the current edit to the previous checkpoint.
+  mutating func undo() {
+    // Commit-style checkpoints may leave `checkpoints.last == current`.
+    // Drop that duplicate first so one undo action changes visible state.
+    if checkpoints.last == current {
+      checkpoints.removeLast()
+    }
+    if let previous = checkpoints.popLast() {
+      redoStack.append(current)
+      current = previous
+    } else if current != initial {
+      redoStack.append(current)
+      current = initial
+    }
+  }
+
+  /// Reapplies the most recently undone checkpoint.
+  mutating func redo() {
+    guard let next = redoStack.popLast() else {
+      return
+    }
+    checkpoints.append(current)
+    current = next
+  }
+
+  /// Removes all committed and redo checkpoints without changing `current`.
+  mutating func removeAllCheckpoints() {
+    checkpoints = []
+    redoStack = []
+  }
+}
+
 /// A stateful object that manages current editing status from original image.
 /// And supports rendering a result image.
 ///
@@ -73,40 +195,22 @@ open class EditingStack: Hashable {
 
     public let metadata: ImageProvider.ImageMetadata
 
-    private let initialEditing: Edit
+    private var editHistory: EditingHistory<Edit>
 
-    /**
-
-     - TODO: Should be marked as `fileprivate(set)`, but compile fails in CocoaPods installed.
-     */
+    /// The edit currently being previewed and rendered.
     public var currentEdit: Edit {
-      didSet {
-        // Keyed on every effects feature, not just the first projection;
-        // a document may carry more than one.
-        if currentEdit.effectsSequence != oldValue.effectsSequence {
-          editingPreviewImage = currentEdit.makePreviewImage(
-            from: editingSourceImage,
-            purpose: .editingBase
-          )
-        }
+      get {
+        editHistory.current
+      }
+      set {
+        editHistory.current = newValue
       }
     }
 
     /// Won't change from initial state
     public var imageSize: CGSize {
-      initialEditing.imageSize
+      editHistory.initial.imageSize
     }
-
-    /**
-     A stack of editing history: snapshots of the feature-list document.
-     */
-    public fileprivate(set) var history: [Edit] = []
-
-    /**
-     Versions undone from `history`, available for redo until the next
-     mutationsnapshot.
-     */
-    public fileprivate(set) var redoHistory: [Edit] = []
 
     public fileprivate(set) var thumbnailImage: CIImage
 
@@ -117,41 +221,24 @@ open class EditingStack: Hashable {
      */
     public let editingSourceImage: CIImage
 
-    /**
-     A lightweight editing preview used by legacy interactive views.
-     Local adjustments are intentionally excluded from automatic refresh because
-     their mask rasterization can be expensive and should be owned by the render
-     path that knows its target resolution.
-     */
-    public fileprivate(set) var editingPreviewImage: CIImage
-
     public var canUndo: Bool {
-      // Mirror undoEditing: a history top equal to the current edit is
-      // skipped, and an empty history can still undo back to the initial
-      // editing when there are uncommitted changes.
-      if history.last == currentEdit {
-        return history.count > 1 || currentEdit != initialEditing
-      }
-      return history.count > 0 || currentEdit != initialEditing
+      editHistory.canUndo
     }
 
     public var canRedo: Bool {
-      return redoHistory.count > 0
+      editHistory.canRedo
     }
 
     /**
      A boolean value that indicates if EditingStack has updates against the original image.
      */
     public var isDirty: Bool {
-      return currentEdit.isRenderingEquivalent(to: initialEditing) == false
+      editHistory.isDirty
     }
 
-    public var hasUncommitedChanges: Bool {
-      guard let latestHistory = history.last else {
-        return currentEdit.isRenderingEquivalent(to: initialEditing) == false
-      }
-
-      return latestHistory.isRenderingEquivalent(to: currentEdit) == false
+    /// Whether the current edit differs from the latest committed checkpoint.
+    public var hasUncommittedChanges: Bool {
+      editHistory.hasUncommittedChanges
     }
 
     // MARK: - Initializers
@@ -161,21 +248,21 @@ open class EditingStack: Hashable {
       metadata: ImageProvider.ImageMetadata,
       initialEditing: EditingStack.Edit,
       currentEdit: EditingStack.Edit,
-      history: [EditingStack.Edit] = [],
+      checkpoints: [EditingStack.Edit] = [],
       thumbnailCIImage: CIImage,
       editingSourceCGImage: CGImage,
-      editingSourceCIImage: CIImage,
-      editingPreviewCIImage: CIImage
+      editingSourceCIImage: CIImage
     ) {
       self.imageSource = imageSource
       self.metadata = metadata
-      self.initialEditing = initialEditing
-      self.currentEdit = currentEdit
-      self.history = history
+      self.editHistory = EditingHistory(
+        initial: initialEditing,
+        current: currentEdit,
+        checkpoints: checkpoints
+      )
       self.thumbnailImage = thumbnailCIImage
       self.editingSourceCGImage = editingSourceCGImage
       self.editingSourceImage = editingSourceCIImage
-      self.editingPreviewImage = editingPreviewCIImage
     }
 
     // MARK: - Functions
@@ -187,47 +274,36 @@ open class EditingStack: Hashable {
         .removingExtentOffset()
     }
 
-    mutating func makeVersion() {
-      history.append(currentEdit)
-      redoHistory = []
+    var currentRevision: Revision {
+      editHistory.revision
     }
 
-    mutating func revertCurrentEditing() {
-      currentEdit = history.last ?? initialEditing
+    mutating func commitCurrentEditIfNeeded() {
+      editHistory.commitCurrentIfNeeded()
+    }
+
+    mutating func commitCurrentEdit() {
+      editHistory.commitCurrent()
+    }
+
+    mutating func revertCurrentEdit() {
+      editHistory.revertCurrent()
     }
 
     mutating func revert(to revision: Revision) {
-      // A captured revision can go stale when undo or history purges shrink
-      // the stack; clamp instead of trapping on the invalid range.
-      let clamped = min(max(revision, 0), history.count)
-      history.removeSubrange(clamped..<history.count)
-      redoHistory = []
-      currentEdit = history.last ?? initialEditing
+      editHistory.revert(to: revision)
     }
 
-    mutating func undoEditing() {
-      // Commit-style snapshots (PhotosCrop snapshots when leaving a tool)
-      // leave history.last equal to currentEdit at settled states; drop it so
-      // one undo press always changes visible state and redoHistory gets no
-      // duplicates.
-      if history.last == currentEdit {
-        history.removeLast()
-      }
-      if let last = history.popLast() {
-        redoHistory.append(currentEdit)
-        currentEdit = last
-      } else if currentEdit != initialEditing {
-        redoHistory.append(currentEdit)
-        currentEdit = initialEditing
-      }
+    mutating func undo() {
+      editHistory.undo()
     }
 
-    mutating func redoEditing() {
-      guard let next = redoHistory.popLast() else {
-        return
-      }
-      history.append(currentEdit)
-      currentEdit = next
+    mutating func redo() {
+      editHistory.redo()
+    }
+
+    mutating func removeAllHistory() {
+      editHistory.removeAllCheckpoints()
     }
 
   }
@@ -373,7 +449,10 @@ open class EditingStack: Hashable {
               == (metadata.imageSize.width > metadata.imageSize.height)
           )
 
-          let initialEdit = Edit(crop: crop, orientedImageSize: metadata.imageSize)
+          let initialEdit = EditingFeatureTree.canonicalEdit(
+            finalCrop: crop,
+            orientedImageSize: metadata.imageSize
+          )
 
           /**
            Upload the editing source into a persistent GPU texture off the main
@@ -404,11 +483,7 @@ open class EditingStack: Hashable {
               currentEdit: initialEdit,
               thumbnailCIImage: _thumbnailImage,
               editingSourceCGImage: editingSourceCGImage,
-              editingSourceCIImage: editingSource,
-              editingPreviewCIImage: initialEdit.makePreviewImage(
-                from: editingSource,
-                purpose: .editingBase
-              )
+              editingSourceCIImage: editingSource
             )
 
             self.loadedState = loaded
@@ -429,84 +504,45 @@ open class EditingStack: Hashable {
 
   // MARK: - Functions
 
-  /**
-   Adds a new snapshot as a history.
-   */
-  public func takeSnapshot() {
-    loadedState?.makeVersion()
+  /// Commits the current edit as an undo checkpoint when it changed.
+  public func commitCurrentEditIfNeeded() {
+    _pixelengine_ensureMainThread()
+    loadedState?.commitCurrentEditIfNeeded()
   }
 
   public typealias Revision = Int
 
   public var currentRevision: Revision? {
-    loadedState?.history.count
+    loadedState?.currentRevision
   }
 
   public func revert(to revision: Revision) {
+    _pixelengine_ensureMainThread()
     loadedState?.revert(to: revision)
   }
 
-  /**
-   Reverts the current editing.
-   */
-  public func revertEdit() {
+  /// Reverts the current edit to the latest checkpoint, or the initial edit.
+  public func revertCurrentEdit() {
     _pixelengine_ensureMainThread()
-    loadedState?.revertCurrentEditing()
+    loadedState?.revertCurrentEdit()
   }
 
-  /**
-   Undo editing, pulling the latest history back into the current edit.
-   The undone version stays available for `redoEdit`.
-   */
-  public func undoEdit() {
+  /// Moves the current edit to the previous checkpoint.
+  public func undo() {
     _pixelengine_ensureMainThread()
-    loadedState?.undoEditing()
+    loadedState?.undo()
   }
 
-  /**
-   Redo the most recently undone version. No-op when there is nothing to redo.
-   Any new snapshot clears the redo stack.
-   */
-  public func redoEdit() {
+  /// Reapplies the most recently undone checkpoint.
+  public func redo() {
     _pixelengine_ensureMainThread()
-    loadedState?.redoEditing()
+    loadedState?.redo()
   }
 
-  /**
-   Purges the all of the history
-   */
-  public func removeAllEditsHistory() {
+  /// Removes all undo and redo checkpoints without changing the current edit.
+  public func removeAllHistory() {
     _pixelengine_ensureMainThread()
-    loadedState?.history = []
-    loadedState?.redoHistory = []
-  }
-
-  public func set(effects: (inout EffectPipeline) -> Void) {
-    _pixelengine_ensureMainThread()
-    applyIfChanged {
-      effects(&$0.effects)
-    }
-  }
-
-  public func crop(_ value: CropFeature) {
-    _pixelengine_ensureMainThread()
-    applyIfChanged {
-      $0.crop = value
-    }
-  }
-
-  public func set(localAdjustments: [LocalAdjustmentFeature]) {
-    _pixelengine_ensureMainThread()
-    applyIfChanged {
-      $0.localAdjustments = localAdjustments
-    }
-  }
-
-  public func append(localAdjustment: LocalAdjustmentFeature) {
-    _pixelengine_ensureMainThread()
-    applyIfChanged {
-      $0.localAdjustments.append(localAdjustment)
-    }
+    loadedState?.removeAllHistory()
   }
 
   // `sending`: the renderer is freshly created here and not retained by the
@@ -538,20 +574,13 @@ open class EditingStack: Hashable {
     return renderer
   }
 
-  private func applyIfChanged(_ perform: (inout Edit) -> Void) {
-    guard loadedState != nil else {
-      return
-    }
-    perform(&loadedState!.currentEdit)
-  }
-
   private func adjustCropExtent(
     image: CIImage,
     imageSize: CGSize,
     completion: @escaping (CropFeature) -> Void
   ) {
     let crop = CropFeature(
-      id: Edit.finalCropID,
+      id: EditingFeatureTree.finalCropNodeID,
       displayCropRect: CGRect(origin: .zero, size: imageSize),
       imageSize: imageSize
     )

--- a/Sources/BrightroomEngine/Core/EditingStackFeatureTree.swift
+++ b/Sources/BrightroomEngine/Core/EditingStackFeatureTree.swift
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import CoreGraphics
 import Foundation
 import BrightroomParametric
 
@@ -62,12 +63,45 @@ public struct EditingFeatureTree: Equatable {
 
   /// The identity of the global effects node.
   ///
-  /// Present in every canonical document (created by `Edit.init(crop:)`), so
+  /// Present in every canonical document, so
   /// UI can anchor editing affordances to a stable identity.
-  public static let globalEffectsNodeID = EditingStack.Edit.globalEffectsID
+  public static let globalEffectsNodeID = FeatureID(
+    rawValue: "brightroom.editing-stack.global-effects"
+  )
 
   /// The identity of the final crop node.
-  public static let finalCropNodeID = EditingStack.Edit.finalCropID
+  public static let finalCropNodeID = FeatureID(
+    rawValue: "brightroom.editing-stack.final-crop"
+  )
+
+  /// Creates the canonical default document used by Photos-style editors.
+  ///
+  /// This is FeatureTree policy rather than `EditingStack.Edit` storage policy:
+  /// the stack stores whatever ordered features the document carries, while this
+  /// factory chooses the built-in arrangement of global effects followed by the
+  /// final crop.
+  public static func canonicalDocument(finalCrop crop: CropFeature) -> EditingDocument {
+    var finalCrop = crop
+    finalCrop.id = finalCropNodeID
+    return EditingDocument(
+      mainTree: MainTree(features: [
+        .effect(EffectPipelineFeature(id: globalEffectsNodeID, pipeline: .init())),
+        .domain(finalCrop),
+      ])
+    )
+  }
+
+  /// Creates the canonical default edit used when an `EditingStack` first loads
+  /// an image.
+  public static func canonicalEdit(
+    finalCrop crop: CropFeature,
+    orientedImageSize: CGSize
+  ) -> EditingStack.Edit {
+    EditingStack.Edit(
+      document: canonicalDocument(finalCrop: crop),
+      orientedImageSize: orientedImageSize
+    )
+  }
 
   // MARK: - Projection
 
@@ -88,15 +122,20 @@ public struct EditingFeatureTree: Equatable {
     nodes.firstIndex(where: { $0.id == id })
   }
 
-  /// The final crop feature.
-  public var finalCrop: CropFeature? {
+  /// The crop feature addressed by a tree identity.
+  public func crop(id: FeatureID) -> CropFeature? {
     guard
-      case let .domain(domain)? = node(id: Self.finalCropNodeID),
+      case let .domain(domain)? = node(id: id),
       let crop = domain as? CropFeature
     else {
       return nil
     }
     return crop
+  }
+
+  /// The final crop feature in the built-in Photos-style arrangement.
+  public var finalCrop: CropFeature? {
+    crop(id: Self.finalCropNodeID)
   }
 
   /// The global effects feature.
@@ -117,6 +156,16 @@ public struct EditingFeatureTree: Equatable {
         return true
       }
       return false
+    }
+  }
+
+  /// The local adjustments in evaluation order.
+  public var localAdjustments: [LocalAdjustmentFeature] {
+    localAdjustmentNodes.compactMap {
+      guard case let .localAdjustment(adjustment) = $0 else {
+        return nil
+      }
+      return adjustment
     }
   }
 
@@ -163,6 +212,14 @@ public struct EditingFeatureTree: Equatable {
 
   // MARK: - Mutation core
 
+  /// Whether a main-tree node is a crop domain feature.
+  public static func isCropFeature(_ feature: MainFeature) -> Bool {
+    if case let .domain(domain) = feature, domain is CropFeature {
+      return true
+    }
+    return false
+  }
+
   /// Applies a payload mutation to the node with `id` inside `edit`.
   ///
   /// The mutation must keep the payload kind stable. Returns false when the
@@ -176,16 +233,72 @@ public struct EditingFeatureTree: Equatable {
     edit.updateFeature(id: id, mutate: mutate)
   }
 
+  /// Replaces a crop node by identity, preserving the node identity even when
+  /// the caller built the replacement from transient UI state.
+  @discardableResult
+  static func updateCropFeature(
+    id: FeatureID,
+    in edit: inout EditingStack.Edit,
+    with crop: CropFeature
+  ) -> Bool {
+    updateFeature(id: id, in: &edit) { feature in
+      guard case .domain = feature else {
+        return
+      }
+
+      var crop = crop
+      crop.id = id
+      feature = .domain(crop)
+    }
+  }
+
   /// Removes the feature with `id` from `edit`.
   ///
-  /// Crop features are structural and not removable. Returns false when
-  /// nothing was removed.
+  /// Returns false when nothing was removed.
   @discardableResult
   static func removeFeature(
     id: FeatureID,
     from edit: inout EditingStack.Edit
   ) -> Bool {
-    edit.removeFeature(id: id)
+    guard
+      let node = EditingFeatureTree(edit: edit).node(id: id),
+      isCropFeature(node) == false
+    else {
+      return false
+    }
+
+    return edit.removeFeature(id: id)
+  }
+
+  /// Replaces all local-adjustment nodes while preserving existing node
+  /// positions and inserting new nodes before `insertionTargetID`.
+  ///
+  /// The insertion target is host policy. PhotosCrop passes the final crop node
+  /// so newly painted local adjustments stay in the pre-final-crop domain.
+  public static func replaceLocalAdjustments(
+    _ localAdjustments: [LocalAdjustmentFeature],
+    in edit: inout EditingStack.Edit,
+    insertingBefore insertionTargetID: FeatureID?
+  ) {
+    var remaining = localAdjustments
+    var features = edit.features
+    for index in features.indices.reversed() {
+      guard case let .localAdjustment(existing) = features[index] else {
+        continue
+      }
+      if let matched = remaining.firstIndex(where: { $0.id == existing.id }) {
+        let adjustment = remaining.remove(at: matched)
+        features[index] = .localAdjustment(adjustment)
+      } else {
+        features.remove(at: index)
+      }
+    }
+
+    let insertionIndex = insertionTargetID
+      .flatMap { id in features.firstIndex(where: { $0.id == id }) }
+      ?? features.count
+    features.insert(contentsOf: remaining.map(MainFeature.localAdjustment), at: insertionIndex)
+    edit.replaceFeatures(features)
   }
 }
 
@@ -214,58 +327,6 @@ extension EditingStack {
     }
 
     guard EditingFeatureTree.updateFeature(id: id, in: &edit, mutate: mutate) else {
-      return false
-    }
-
-    applyFeatureTreeEdit(edit)
-    return true
-  }
-
-  /// Mutates the global effects pipeline feature.
-  public func updateGlobalEffectsFeature(
-    _ mutate: (inout EffectPipeline) -> Void
-  ) {
-    updateFeature(id: EditingFeatureTree.globalEffectsNodeID) { feature in
-      guard
-        case let .effect(effect) = feature,
-        var bundle = effect as? EffectPipelineFeature
-      else {
-        return
-      }
-      mutate(&bundle.pipeline)
-      feature = .effect(bundle)
-    }
-  }
-
-  /// Appends a local adjustment feature before the final crop and returns its
-  /// tree identity.
-  @discardableResult
-  public func appendFeature(
-    localAdjustment adjustment: LocalAdjustmentFeature
-  ) -> FeatureID {
-    _pixelengine_ensureMainThread()
-
-    guard var edit = loadedState?.currentEdit else {
-      return adjustment.id
-    }
-    edit.insertFeatureBeforeFinalCrop(.localAdjustment(adjustment))
-    loadedState?.currentEdit = edit
-    return adjustment.id
-  }
-
-  /// Removes the feature node with `id`.
-  ///
-  /// Crop features are structural and not removable; everything else is.
-  /// Returns false when nothing was removed.
-  @discardableResult
-  public func removeFeature(id: FeatureID) -> Bool {
-    _pixelengine_ensureMainThread()
-
-    guard var edit = loadedState?.currentEdit else {
-      return false
-    }
-
-    guard EditingFeatureTree.removeFeature(id: id, from: &edit) else {
       return false
     }
 

--- a/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
@@ -26,8 +26,8 @@ import MetalKit
 import BrightroomEngine
 import BrightroomParametric
 
-/// A UIKit canvas that previews a point in the EditingStack's FeatureTree and
-/// edits a feature node that may live at a different point.
+/// A UIKit canvas that previews a point in the document FeatureTree and edits
+/// a feature node that may live at a different point.
 ///
 /// Based on the editing vision in `docs/vision-of-editing.md`, this view treats
 /// tool edits as Features that happen before the final crop:
@@ -391,25 +391,25 @@ final class CropView: UIView {
     }
 
     func updateRenderedEditPreview(
-      loadedState: EditingStack.Loaded,
+      document: CropViewDocumentSnapshot,
       crop: CropEditingState
     ) {
       guard crop.imageSize == canvasSize, let canvasView else {
         return
       }
 
-      let key = CanvasInputKey(loadedState: loadedState, crop: crop)
+      let key = CanvasInputKey(document: document, crop: crop)
       guard currentCanvasInputKey != key || canvasView.hasRenderImages == false else {
         canvasView.isHidden = false
         return
       }
 
       let renderPlan = CanvasRenderPlan(
-        localAdjustments: loadedState.currentEdit.localAdjustments
+        localAdjustments: document.localAdjustments
       )
       guard
         let images = EditingCanvasRenderImageFactory.makeRenderImages(
-          loadedState: loadedState,
+          document: document,
           canvasSize: crop.imageSize,
           mode: renderPlan.canvasMode
         )
@@ -536,7 +536,7 @@ final class CropView: UIView {
 
     /// Inputs that determine the output of
     /// `EditingCanvasRenderImageFactory.makeCropOutputRenderImages`. The source
-    /// image is compared by identity; `EditingStack.Loaded` stores it as an
+    /// image is compared by identity; `CropViewDocumentSnapshot` stores it as an
     /// immutable property, so a new editing source always produces a new
     /// instance.
     struct CanvasRenderInputKey: Equatable {
@@ -586,7 +586,7 @@ final class CropView: UIView {
     }
 
     func updateCanvas(
-      loadedState: EditingStack.Loaded,
+      document: CropViewDocumentSnapshot,
       geometry: EditingCanvasCropOutputGeometry,
       mode: EditingCanvasMode,
       committedStrokes: [EditingCanvasStrokeRecord]
@@ -597,8 +597,8 @@ final class CropView: UIView {
       outputGeometry = geometry
 
       let inputKey = CanvasRenderInputKey(
-        sourceImage: ObjectIdentifier(loadedState.editingSourceImage),
-        effects: loadedState.currentEdit.effects,
+        sourceImage: ObjectIdentifier(document.editingSourceImage),
+        effects: document.effects,
         geometry: geometry,
         mode: mode
       )
@@ -609,7 +609,7 @@ final class CropView: UIView {
       if currentCanvasRenderInputKey != inputKey || canvasView.hasRenderImages == false {
         guard
           let images = EditingCanvasRenderImageFactory.makeCropOutputRenderImages(
-            loadedState: loadedState,
+            document: document,
             geometry: geometry,
             mode: mode
           )
@@ -719,7 +719,7 @@ final class CropView: UIView {
     }
   }
 
-  let editingStack: EditingStack
+  private let document: CropViewDocument
 
   #if DEBUG
   private let _debug_shapeLayer: CAShapeLayer = {
@@ -744,7 +744,6 @@ final class CropView: UIView {
   /// geometry it resolves against has changed.
   private var appliedCanvasBrush: EditingCanvasBrush?
   private var canvasStrokeSmoothing: EditingCanvasStrokeSmoothingConfiguration = .init()
-  private let strokeCommitPipeline = EditingCanvasStrokeCommitPipeline()
   /// True while an external control streams straighten angle changes before
   /// committing the resulting crop extent.
   ///
@@ -815,37 +814,17 @@ final class CropView: UIView {
 
   private var stateHandler: @MainActor (StateSnapshot) -> Void = { _ in }
 
-  var isAutoApplyEditingStackEnabled = false
-
   private var lastLaidOutCrop: CropEditingState?
 
   // MARK: - Initializers
 
-  /**
-   Creates an instance for using as standalone.
-
-   This initializer offers us to get cropping function without detailed setup.
-   To get a result image, call `renderImage()`.
-   */
-  convenience init(
-    image: UIImage,
-    contentInset: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
-  ) throws {
-    self.init(
-      editingStack: .init(
-        imageProvider: .init(image: image)
-      ),
-      contentInset: contentInset
-    )
-  }
-
   init(
-    editingStack: EditingStack,
+    document: CropViewDocument,
     contentInset: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
   ) {
     _pixeleditor_ensureMainThread()
 
-    self.editingStack = editingStack
+    self.document = document
     self.contentInset = contentInset
 
     super.init(frame: .zero)
@@ -1054,70 +1033,50 @@ final class CropView: UIView {
     self.stateHandler = handler
   }
 
-  func loadCurrentEditingStackState() {
-    let loadedState = editingStack.requireLoadedStateForLoadedUIView()
-    load(
-      crop: CropEditingState(
-        cropFeature: loadedState.currentEdit.crop,
-        imageSize: loadedState.currentEdit.imageSize
-      )
-    )
-    updateDisplay(loadedState: loadedState)
+  func loadCurrentDocumentState() {
+    let snapshot = document.requireSnapshotForLoadedCropView()
+    guard let crop = displayCropEditingState(in: snapshot) else {
+      return
+    }
+    load(crop: crop)
+    updateDisplay(document: snapshot)
   }
 
-  func updateCurrentEditingStackDisplay() {
-    guard let loadedState = editingStack.loadedState else {
+  func updateCurrentDocumentDisplay() {
+    guard let snapshot = document.snapshot else {
       return
     }
 
-    let stackCrop = CropEditingState(
-      cropFeature: loadedState.currentEdit.crop,
-      imageSize: loadedState.currentEdit.imageSize
-    )
-    if state.proposedCrop == nil || state.proposedCrop?.imageSize != stackCrop.imageSize {
-      load(crop: stackCrop)
-    } else if
-      isAutoApplyEditingStackEnabled,
-      isStreamingAdjustmentAngle == false,
-      state.adjustmentKind.isEmpty,
-      cropSurface.scrollView.isTracking == false,
-      cropSurface.scrollView.isDragging == false,
-      cropSurface.scrollView.isDecelerating == false,
-      isZoomInteractionActive == false,
-      let proposedCrop = state.proposedCrop,
-      proposedCrop.isRenderingEquivalent(to: stackCrop) == false
-    {
-      // Reloading the document crop also re-lays out the scroll view with a
-      // non-animated `customZoom`. Wait for UIKit scroll/zoom settling first so
-      // a live bounce-back is not cancelled by an unrelated document refresh.
-      // Under auto-apply this view's own edits always land in the stack, so a
-      // rendering-relevant difference means the document crop changed outside
-      // this view (undo, revert, external mutation) — follow the document.
-      load(crop: stackCrop)
+    guard let documentCrop = displayCropEditingState(in: snapshot) else {
+      return
+    }
+    if state.proposedCrop == nil || state.proposedCrop?.imageSize != documentCrop.imageSize {
+      load(crop: documentCrop)
     }
 
-    updateDisplay(loadedState: loadedState)
+    updateDisplay(document: snapshot)
   }
 
   /**
    Renders an image according to the editing.
 
-   - Attension: This operation can be run background-thread.
+   - Attention: The UI crop state is committed on the main actor before the
+     renderer performs its asynchronous work.
    */
   func renderImage() async throws -> BrightRoomImageRenderer.Rendered? {
-    applyEditingStack()
-    return try await editingStack.makeRenderer().render()
+    applyDocumentChanges()
+    return try await document.renderImage()
   }
 
   /**
-   Applies the current state to the EditingStack.
+   Applies the current crop state to the document.
    */
-  func applyEditingStack() {
-    guard let crop = state.proposedCrop else {
-      EditorLog.error(.cropView, "EditingStack has not completed loading.")
+  func applyDocumentChanges() {
+    guard let crop = record() ?? state.proposedCrop else {
+      EditorLog.error(.cropView, "CropViewDocument has not completed loading.")
       return
     }
-    applyCropToEditingStackIfRenderingChanged(crop)
+    applyCropToDocumentIfRenderingChanged(crop)
   }
 
   func resetCrop() {
@@ -1305,7 +1264,7 @@ extension CropView {
     }
   }
 
-  private func updateDisplay(loadedState: EditingStack.Loaded) {
+  private func updateDisplay(document: CropViewDocumentSnapshot) {
     guard let crop = state.proposedCrop else {
       return
     }
@@ -1341,7 +1300,7 @@ extension CropView {
         return
       }
 
-      updateCanvasContent(loadedState: loadedState, crop: crop)
+      updateCanvasContent(document: document, crop: crop)
       updateCropDisplayViewport()
 
     } else if let seedEffect = resolvedMaskSeedEffect {
@@ -1357,9 +1316,9 @@ extension CropView {
       // committed effect keeps the preview equal to the exported result even
       // when the host recomputes the seed effect from a new crop.
       toolSurface.updateCanvas(
-        loadedState: loadedState,
+        document: document,
         geometry: geometry,
-        mode: .localAdjustment(effect: committedCanvasLocalEffect(in: loadedState) ?? seedEffect),
+        mode: .localAdjustment(effect: committedCanvasLocalEffect() ?? seedEffect),
         committedStrokes: currentToolCommittedStrokes(in: geometry)
       )
       updateToolCropDisplayViewport()
@@ -1373,10 +1332,10 @@ extension CropView {
       }
 
       let renderPlan = CanvasRenderPlan(
-        localAdjustments: loadedState.currentEdit.localAdjustments
+        localAdjustments: document.localAdjustments
       )
       toolSurface.updateCanvas(
-        loadedState: loadedState,
+        document: document,
         geometry: geometry,
         mode: renderPlan.canvasMode,
         committedStrokes: renderPlan.committedStrokes(in: geometry)
@@ -1395,7 +1354,7 @@ extension CropView {
       return false
     case .after:
       guard
-        let tree = editingStack.featureTree,
+        let tree = document.snapshot?.featureTree,
         let includes = tree.point(
           featureFocus.viewingPoint,
           includes: EditingFeatureTree.finalCropNodeID
@@ -1448,15 +1407,15 @@ extension CropView {
     var effects: EffectPipeline
     var localAdjustments: [LocalAdjustmentFeature]
 
-    init(loadedState: EditingStack.Loaded, crop: CropEditingState) {
-      let previewSourceImage = loadedState.editingSourceImage.removingExtentOffset()
+    init(document: CropViewDocumentSnapshot, crop: CropEditingState) {
+      let previewSourceImage = document.editingSourceImage.removingExtentOffset()
       self.imageSize = crop.imageSize
       // Extent alone cannot detect a same-size source replacement (the
       // editing source is always capped to the same max pixel size).
-      self.sourceImage = ObjectIdentifier(loadedState.editingSourceImage)
+      self.sourceImage = ObjectIdentifier(document.editingSourceImage)
       self.sourceExtent = previewSourceImage.extent
-      self.effects = loadedState.currentEdit.effects
-      self.localAdjustments = loadedState.currentEdit.localAdjustments
+      self.effects = document.effects
+      self.localAdjustments = document.localAdjustments
     }
   }
 
@@ -1518,6 +1477,22 @@ extension CropView {
         }
       }
     }
+  }
+
+  /// The crop state that defines the canvas display domain for the current
+  /// document.
+  ///
+  /// PhotosCrop currently displays the built-in final crop as the viewport even
+  /// when a tool edits an upstream feature. Crop editing writes through
+  /// `featureFocus.cropTargetID`; display resolution stays here so those two
+  /// responsibilities do not collapse back into `Edit.crop`.
+  private func displayCropEditingState(
+    in document: CropViewDocumentSnapshot
+  ) -> CropEditingState? {
+    return CropEditingState(
+      cropFeature: document.displayCrop,
+      imageSize: document.imageSize
+    )
   }
 
   private func makeCropDisplayViewport() -> CropDisplayViewport? {
@@ -1771,10 +1746,6 @@ extension CropView {
 
     state.proposedCrop = crop
 
-    if isAutoApplyEditingStackEnabled {
-      applyCropToEditingStackIfRenderingChanged(crop)
-    }
-
     emitStateSnapshot()
 
     return true
@@ -1835,10 +1806,12 @@ extension CropView {
   private func debugLogScrollViewAdjustment(_ event: String) {}
   #endif
 
-  private func applyCropToEditingStackIfRenderingChanged(_ crop: CropEditingState) {
-    let feature = crop.makeCropFeature()
-    guard let currentCrop = editingStack.loadedState?.currentEdit.crop else {
-      editingStack.crop(feature)
+  private func applyCropToDocumentIfRenderingChanged(_ crop: CropEditingState) {
+    let targetID = featureFocus.cropTargetID ?? crop.id
+    var feature = crop.makeCropFeature()
+    feature.id = targetID
+    guard let currentCrop = document.snapshot?.cropFeature(id: targetID) else {
+      document.updateCropFeature(id: targetID, with: feature)
       return
     }
 
@@ -1848,7 +1821,7 @@ extension CropView {
       return
     }
 
-    editingStack.crop(feature)
+    document.updateCropFeature(id: targetID, with: feature)
   }
 
   private func updateCropLayout(
@@ -2835,38 +2808,18 @@ extension CropView: UIGestureRecognizerDelegate {
     let previousViewingIncludedFinalCrop = viewingPointIncludesFinalCrop
     let leavesCropEditing = wasCropEditing && focus.isCropEditing == false
     if leavesCropEditing {
-      // Leaving crop editing commits the currently visible crop viewport
-      // before the tool surface derives its display geometry — unless, under
-      // auto-apply, the document crop diverged from this session (cancel /
-      // revert / undo mutated the stack while the viewport still shows the
-      // old crop). Re-recording then would write the stale viewport back
-      // into the document; instead the document-follow branch in
-      // updateCurrentEditingStackDisplay resyncs the view below.
-      let documentDiverged: Bool = {
-        guard
-          isAutoApplyEditingStackEnabled,
-          let stackCrop = editingStack.loadedState?.currentEdit.crop,
-          let proposedCrop = state.proposedCrop
-        else {
-          return false
-        }
-        return proposedCrop.makeCropFeature().isRenderingEquivalent(
-          to: stackCrop,
-          orientedImageSize: proposedCrop.imageSize
-        ) == false
-      }()
-      if documentDiverged == false {
-        record()
-      }
+      // Leaving crop editing commits the currently visible crop viewport before
+      // the tool surface derives its display geometry.
+      applyDocumentChanges()
     }
 
     featureFocus = focus
 
     if previousSeedEffect?.editingCanvasEffectIdentity != resolvedMaskSeedEffect(of: focus)?.editingCanvasEffectIdentity {
-      strokeCommitPipeline.resetLayerTracking()
+      document.resetMaskLayerTracking()
     }
     if let layerID = focus.maskTargetLayerID {
-      strokeCommitPipeline.adoptLayer(id: layerID)
+      document.adoptMaskLayer(id: layerID)
     }
 
     // The tool surface needs a geometry re-sync when entering it from crop
@@ -2876,7 +2829,7 @@ extension CropView: UIGestureRecognizerDelegate {
       && previousViewingIncludedFinalCrop != viewingPointIncludesFinalCrop
 
     applySurfaceMode(syncsToolViewportFromCrop: leavesCropEditing || crossesFinalCrop)
-    updateCurrentEditingStackDisplay()
+    updateCurrentDocumentDisplay()
   }
 
   func setMaskingBrush(_ brush: CropViewMaskingBrush) {
@@ -2899,7 +2852,7 @@ extension CropView: UIGestureRecognizerDelegate {
       imageDiameter = CropViewMaskingDefaults.imageSpaceBrushDiameter(
         pointDiameter: value,
         viewportSize: bounds.size,
-        crop: editingStack.loadedState?.currentEdit.crop
+        crop: document.snapshot?.featureTree.finalCrop
       )
     }
     return .init(
@@ -3001,7 +2954,7 @@ extension CropView: UIGestureRecognizerDelegate {
   }
 
   fileprivate func updateCanvasContent(
-    loadedState: EditingStack.Loaded,
+    document: CropViewDocumentSnapshot,
     crop: CropEditingState
   ) {
     guard featureFocus.isCropEditing else {
@@ -3009,7 +2962,7 @@ extension CropView: UIGestureRecognizerDelegate {
       return
     }
 
-    cropSurface.updateRenderedEditPreview(loadedState: loadedState, crop: crop)
+    cropSurface.updateRenderedEditPreview(document: document, crop: crop)
   }
 
   fileprivate func commitCanvasStroke(
@@ -3027,8 +2980,8 @@ extension CropView: UIGestureRecognizerDelegate {
       committedRecord = record
     }
 
-    appendRecordToEditingStack(committedRecord)
-    syncCommittedStrokesFromEditingStack()
+    appendRecordToDocument(committedRecord)
+    syncCommittedStrokesFromDocument()
     completion()
   }
 
@@ -3052,15 +3005,14 @@ extension CropView: UIGestureRecognizerDelegate {
     resolvedMaskSeedEffect(of: featureFocus)
   }
 
-  private func appendRecordToEditingStack(_ record: EditingCanvasStrokeRecord) {
+  private func appendRecordToDocument(_ record: EditingCanvasStrokeRecord) {
     guard let currentLocalEffect = resolvedMaskSeedEffect else {
       return
     }
 
-    strokeCommitPipeline.append(
+    document.appendMaskStroke(
       record: record,
-      effect: currentLocalEffect,
-      to: editingStack
+      effect: currentLocalEffect
     )
   }
 
@@ -3069,20 +3021,15 @@ extension CropView: UIGestureRecognizerDelegate {
   /// Document parameters are frozen at layer creation. The focus's seed effect
   /// may drift afterwards (the default blur seed derives from the current
   /// crop), so already-painted layers must not be rewritten to match it.
-  private func committedCanvasLocalEffect(
-    in loadedState: EditingStack.Loaded
-  ) -> EffectPipeline? {
+  private func committedCanvasLocalEffect() -> EffectPipeline? {
     guard let currentLocalEffect = resolvedMaskSeedEffect else {
       return nil
     }
 
-    return strokeCommitPipeline.committedEffect(
-      matching: currentLocalEffect,
-      in: loadedState
-    )
+    return document.committedMaskEffect(matching: currentLocalEffect)
   }
 
-  private func syncCommittedStrokesFromEditingStack() {
+  private func syncCommittedStrokesFromDocument() {
     let sourceRecords = currentSourceCommittedStrokes()
     cropSurface.setCommittedStrokes(sourceRecords)
 
@@ -3108,9 +3055,6 @@ extension CropView: UIGestureRecognizerDelegate {
   }
 
   private func currentSourceCommittedStrokes() -> [EditingCanvasStrokeRecord] {
-    strokeCommitPipeline.committedRecords(
-      matching: resolvedMaskSeedEffect,
-      in: editingStack
-    )
+    document.committedMaskRecords(matching: resolvedMaskSeedEffect)
   }
 }

--- a/Sources/BrightroomUI/Shared/Components/Crop/CropViewDocument.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropViewDocument.swift
@@ -1,0 +1,174 @@
+import CoreGraphics
+import CoreImage
+
+import BrightroomEngine
+import BrightroomParametric
+
+/// Read-only document state consumed by `CropView`.
+///
+/// The snapshot is a stable projection of the current edit for one UI update.
+/// It intentionally carries FeatureTree vocabulary, not `EditingStack`, so the
+/// crop canvas can render and edit a focused feature without knowing which
+/// owner stores history, undo, or persistence.
+struct CropViewDocumentSnapshot {
+
+  /// The downsampled, display-oriented source image used by live canvas
+  /// rendering.
+  var editingSourceImage: CIImage
+
+  /// The crop used as CropView's visible display frame.
+  ///
+  /// This is currently PhotosCrop's final crop. A host may still direct edits
+  /// at another crop node through `CropViewFeatureFocus`.
+  var displayCrop: CropFeature
+
+  /// The current parametric feature tree.
+  var featureTree: EditingFeatureTree
+
+  /// The image size used by crop geometry.
+  var imageSize: CGSize
+
+  /// Global effects evaluated by the canvas preview.
+  var effects: EffectPipeline
+
+  /// Local adjustment layers in the current edit graph.
+  var localAdjustments: [LocalAdjustmentFeature]
+
+  init?(
+    loadedState: EditingStack.Loaded
+  ) {
+    let tree = EditingFeatureTree(edit: loadedState.currentEdit)
+    guard let displayCrop = tree.finalCrop else {
+      return nil
+    }
+
+    self.editingSourceImage = loadedState.editingSourceImage
+    self.displayCrop = displayCrop
+    self.featureTree = tree
+    self.imageSize = loadedState.currentEdit.imageSize
+    self.effects = loadedState.currentEdit.effects
+    self.localAdjustments = loadedState.currentEdit.localAdjustments
+  }
+
+  /// The crop feature addressed by a FeatureTree node identity.
+  func cropFeature(id: FeatureID) -> CropFeature? {
+    featureTree.crop(id: id)
+  }
+}
+
+/// The document boundary used by `CropView`.
+///
+/// The class owns the bridge from CropView's display/editing contract to
+/// Brightroom's `EditingStack`: it exposes read-only snapshots and accepts
+/// explicit FeatureTree editing commands.
+///
+/// A hosted `CropView` is the single writer for its active crop target while it
+/// is mounted. External crop mutation during that editing session is
+/// unsupported; higher-level tools should route crop edits through this
+/// document boundary, then use `EditingStack` history for committed checkpoints.
+@MainActor
+final class CropViewDocument {
+
+  private let editingStack: EditingStack
+  private let strokeCommitPipeline = EditingCanvasStrokeCommitPipeline()
+
+  init(editingStack: EditingStack) {
+    self.editingStack = editingStack
+  }
+
+  /// The latest edit projection available to the crop canvas.
+  var snapshot: CropViewDocumentSnapshot? {
+    editingStack.loadedState.flatMap(CropViewDocumentSnapshot.init)
+  }
+
+  /// Starts any asynchronous source-image preparation required before a
+  /// snapshot can be produced.
+  func start() {
+    editingStack.start()
+  }
+
+  /// Renders the current document after pending CropView edits have been
+  /// committed by the caller.
+  func renderImage() async throws -> BrightRoomImageRenderer.Rendered? {
+    try await editingStack.makeRenderer().render()
+  }
+
+  /// Replaces an existing crop feature by FeatureTree node identity.
+  @discardableResult
+  func updateCropFeature(
+    id: FeatureID,
+    with crop: CropFeature
+  ) -> Bool {
+    guard editingStack.featureTree?.crop(id: id) != nil else {
+      return false
+    }
+
+    return editingStack.updateFeature(id: id) { feature in
+      var crop = crop
+      crop.id = id
+      feature = .domain(crop)
+    }
+  }
+
+  /// Forgets the tracked mask layer used by subsequent brush commits.
+  func resetMaskLayerTracking() {
+    strokeCommitPipeline.resetLayerTracking()
+  }
+
+  /// Uses an existing local-adjustment layer as the next mask commit target.
+  func adoptMaskLayer(id: FeatureID) {
+    strokeCommitPipeline.adoptLayer(id: id)
+  }
+
+  /// Appends a brush stroke to the active local-adjustment mask layer.
+  func appendMaskStroke(
+    record: EditingCanvasStrokeRecord,
+    effect: EffectPipeline
+  ) {
+    strokeCommitPipeline.append(
+      record: record,
+      effect: effect,
+      to: editingStack,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
+  }
+
+  /// The effect pipeline persisted on the active local-adjustment mask layer.
+  func committedMaskEffect(
+    matching effect: EffectPipeline
+  ) -> EffectPipeline? {
+    guard let loadedState = editingStack.loadedState else {
+      return nil
+    }
+
+    return strokeCommitPipeline.committedEffect(
+      matching: effect,
+      in: loadedState
+    )
+  }
+
+  /// The active local-adjustment mask layer's strokes in source coordinates.
+  func committedMaskRecords(
+    matching effect: EffectPipeline?
+  ) -> [EditingCanvasStrokeRecord] {
+    strokeCommitPipeline.committedRecords(
+      matching: effect,
+      in: editingStack
+    )
+  }
+
+  /// Returns the current snapshot for a branch that has already checked the
+  /// document is loaded.
+  func requireSnapshotForLoadedCropView(
+    file: StaticString = #fileID,
+    line: UInt = #line
+  ) -> CropViewDocumentSnapshot {
+    assert(
+      snapshot != nil,
+      "SwiftUI loaded branch created or updated a CropView while CropViewDocument.snapshot was nil.",
+      file: file,
+      line: line
+    )
+    return snapshot!
+  }
+}

--- a/Sources/BrightroomUI/Shared/Components/Crop/CropViewFeatureFocus.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropViewFeatureFocus.swift
@@ -152,4 +152,12 @@ public struct CropViewFeatureFocus: Equatable, Sendable {
     }
     return id
   }
+
+  /// The explicitly targeted crop node id, when the focus edits crop geometry.
+  var cropTargetID: FeatureID? {
+    guard case let .crop(id) = editingTarget else {
+      return nil
+    }
+    return id
+  }
 }

--- a/Sources/BrightroomUI/Shared/Components/Crop/SwiftUICropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/SwiftUICropView.swift
@@ -23,28 +23,6 @@ import UIKit
 import SwiftUI
 import BrightroomEngine
 
-final class _PixelEditor_WrapperViewController<BodyView: UIView>: UIViewController {
-  
-  let bodyView: BodyView
-  
-  init(bodyView: BodyView) {
-    self.bodyView = bodyView
-    super.init(nibName: nil, bundle: nil)
-  }
-  
-  @available(*, unavailable)
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    
-    view.addSubview(bodyView)
-    AutoLayoutTools.setEdge(bodyView, view)
-  }
-}
-
 @available(iOS 14, *)
 public struct SwiftUICropView: View {
 
@@ -139,7 +117,7 @@ public struct SwiftUICropView: View {
   private let cropInsideOverlay: ((AdjustmentKind?) -> AnyView)?
   private let cropOutsideOverlay: ((AdjustmentKind?) -> AnyView)?
 
-  private let editingStack: EditingStack
+  private let document: CropViewDocument
 
   private var rotationInput: Binding<CropEditingState.Rotation?> = .constant(nil)
   private var adjustmentAngleInput: Binding<CropEditingState.AdjustmentAngle?> = .constant(nil)
@@ -151,7 +129,6 @@ public struct SwiftUICropView: View {
 
   private let stateHandler: @MainActor (StateSnapshot) -> Void
   private let isGuideInteractionEnabled: Bool
-  private let isAutoApplyEditingStackEnabled: Bool
   private let areAnimationsEnabled: Bool
   private let contentInset: UIEdgeInsets?
   private var featureFocus: CropViewFeatureFocus = .finalCrop
@@ -161,16 +138,14 @@ public struct SwiftUICropView: View {
   public init<InsideOverlay: View, OutsideOverlay: View>(
     editingStack: EditingStack,
     isGuideInteractionEnabled: Bool = true,
-    isAutoApplyEditingStackEnabled: Bool = false,
     areAnimationsEnabled: Bool = true,
     contentInset: UIEdgeInsets? = nil,
     @ViewBuilder cropInsideOverlay: @escaping (AdjustmentKind?) -> InsideOverlay,
     @ViewBuilder cropOutsideOverlay: @escaping (AdjustmentKind?) -> OutsideOverlay,
     stateHandler: @escaping @MainActor (StateSnapshot) -> Void = { _ in }
   ) {
-    self.editingStack = editingStack
+    self.document = CropViewDocument(editingStack: editingStack)
     self.isGuideInteractionEnabled = isGuideInteractionEnabled
-    self.isAutoApplyEditingStackEnabled = isAutoApplyEditingStackEnabled
     self.areAnimationsEnabled = areAnimationsEnabled
     self.contentInset = contentInset
     self.cropInsideOverlay = { AnyView(cropInsideOverlay($0)) }
@@ -181,16 +156,30 @@ public struct SwiftUICropView: View {
   public init(
     editingStack: EditingStack,
     isGuideInteractionEnabled: Bool = true,
-    isAutoApplyEditingStackEnabled: Bool = false,
     areAnimationsEnabled: Bool = true,
     contentInset: UIEdgeInsets? = nil,
     stateHandler: @escaping @MainActor (StateSnapshot) -> Void = { _ in }
   ) {
     self.cropInsideOverlay = nil
     self.cropOutsideOverlay = nil
-    self.editingStack = editingStack
+    self.document = CropViewDocument(editingStack: editingStack)
     self.isGuideInteractionEnabled = isGuideInteractionEnabled
-    self.isAutoApplyEditingStackEnabled = isAutoApplyEditingStackEnabled
+    self.areAnimationsEnabled = areAnimationsEnabled
+    self.contentInset = contentInset
+    self.stateHandler = stateHandler
+  }
+
+  init(
+    document: CropViewDocument,
+    isGuideInteractionEnabled: Bool = true,
+    areAnimationsEnabled: Bool = true,
+    contentInset: UIEdgeInsets? = nil,
+    stateHandler: @escaping @MainActor (StateSnapshot) -> Void = { _ in }
+  ) {
+    self.cropInsideOverlay = nil
+    self.cropOutsideOverlay = nil
+    self.document = document
+    self.isGuideInteractionEnabled = isGuideInteractionEnabled
     self.areAnimationsEnabled = areAnimationsEnabled
     self.contentInset = contentInset
     self.stateHandler = stateHandler
@@ -198,9 +187,9 @@ public struct SwiftUICropView: View {
 
   public var body: some View {
     ZStack {
-      if editingStack.loadedState != nil {
+      if document.snapshot != nil {
         LoadedCropViewRepresentable(
-          editingStack: editingStack,
+          document: document,
           cropInsideOverlay: cropInsideOverlay,
           cropOutsideOverlay: cropOutsideOverlay,
           rotationInput: rotationInput,
@@ -212,7 +201,6 @@ public struct SwiftUICropView: View {
           adjustmentAngleCommitAction: _adjustmentAngleCommitAction,
           stateHandler: stateHandler,
           isGuideInteractionEnabled: isGuideInteractionEnabled,
-          isAutoApplyEditingStackEnabled: isAutoApplyEditingStackEnabled,
           areAnimationsEnabled: areAnimationsEnabled,
           contentInset: contentInset,
           featureFocus: featureFocus,
@@ -227,7 +215,7 @@ public struct SwiftUICropView: View {
       }
     }
     .onAppear {
-      editingStack.start()
+      document.start()
     }
   }
 
@@ -316,11 +304,9 @@ public struct SwiftUICropView: View {
 }
 
 @available(iOS 14, *)
-private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
+private struct LoadedCropViewRepresentable: UIViewRepresentable {
 
-  typealias UIViewControllerType = _PixelEditor_WrapperViewController<CropView>
-
-  let editingStack: EditingStack
+  let document: CropViewDocument
   let cropInsideOverlay: ((SwiftUICropView.AdjustmentKind?) -> AnyView)?
   let cropOutsideOverlay: ((SwiftUICropView.AdjustmentKind?) -> AnyView)?
   let rotationInput: Binding<CropEditingState.Rotation?>
@@ -332,7 +318,6 @@ private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
   let adjustmentAngleCommitAction: SwiftUICropView.AdjustmentAngleCommitAction?
   let stateHandler: @MainActor (SwiftUICropView.StateSnapshot) -> Void
   let isGuideInteractionEnabled: Bool
-  let isAutoApplyEditingStackEnabled: Bool
   let areAnimationsEnabled: Bool
   let contentInset: UIEdgeInsets?
   let featureFocus: CropViewFeatureFocus
@@ -343,15 +328,14 @@ private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
     Coordinator()
   }
 
-  func makeUIViewController(context: Context) -> _PixelEditor_WrapperViewController<CropView> {
+  func makeUIView(context: Context) -> CropView {
     let view: CropView
     if let contentInset {
-      view = .init(editingStack: editingStack, contentInset: contentInset)
+      view = .init(document: document, contentInset: contentInset)
     } else {
-      view = .init(editingStack: editingStack)
+      view = .init(document: document)
     }
 
-    view.isAutoApplyEditingStackEnabled = isAutoApplyEditingStackEnabled
     view.isGuideInteractionEnabled = isGuideInteractionEnabled
     view.areAnimationsEnabled = areAnimationsEnabled
     view.setMaskingBrush(maskingBrush)
@@ -369,22 +353,17 @@ private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
 
     configureActions(on: view)
     context.coordinator.applySwiftUIInputs {
-      view.loadCurrentEditingStackState()
+      view.loadCurrentDocumentState()
     }
 
-    return .init(bodyView: view)
+    return view
   }
 
-  func updateUIViewController(_ uiViewController: _PixelEditor_WrapperViewController<CropView>, context: Context) {
-    let cropView = uiViewController.bodyView
+  func updateUIView(_ cropView: CropView, context: Context) {
     bindStateHandler(to: cropView, coordinator: context.coordinator)
 
     if cropView.isGuideInteractionEnabled != isGuideInteractionEnabled {
       cropView.isGuideInteractionEnabled = isGuideInteractionEnabled
-    }
-
-    if cropView.isAutoApplyEditingStackEnabled != isAutoApplyEditingStackEnabled {
-      cropView.isAutoApplyEditingStackEnabled = isAutoApplyEditingStackEnabled
     }
 
     if cropView.areAnimationsEnabled != areAnimationsEnabled {
@@ -410,7 +389,7 @@ private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
     cropView.setCanvasStrokeSmoothing(strokeSmoothing)
     cropView.setFeatureFocus(featureFocus)
 
-    cropView.updateCurrentEditingStackDisplay()
+    cropView.updateCurrentDocumentDisplay()
     configureActions(on: cropView)
   }
 
@@ -440,7 +419,7 @@ private struct LoadedCropViewRepresentable: UIViewControllerRepresentable {
     }
 
     applyAction?.onCall = { [weak cropView] in
-      cropView?.applyEditingStack()
+      cropView?.applyDocumentChanges()
     }
 
     adjustmentAngleCommitAction?.onCall = { [weak cropView] angle in

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasRenderImageFactory.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasRenderImageFactory.swift
@@ -10,12 +10,43 @@ enum EditingCanvasRenderImageFactory {
     displayedContentRect: CGRect? = nil,
     mode: EditingCanvasMode
   ) -> EditingCanvasRenderImages? {
+    makeRenderImages(
+      editingSourceImage: loadedState.editingSourceImage,
+      effects: loadedState.currentEdit.effects,
+      canvasSize: canvasSize,
+      displayedContentRect: displayedContentRect,
+      mode: mode
+    )
+  }
+
+  static func makeRenderImages(
+    document: CropViewDocumentSnapshot,
+    canvasSize: CGSize,
+    displayedContentRect: CGRect? = nil,
+    mode: EditingCanvasMode
+  ) -> EditingCanvasRenderImages? {
+    makeRenderImages(
+      editingSourceImage: document.editingSourceImage,
+      effects: document.effects,
+      canvasSize: canvasSize,
+      displayedContentRect: displayedContentRect,
+      mode: mode
+    )
+  }
+
+  private static func makeRenderImages(
+    editingSourceImage: CIImage,
+    effects: EffectPipeline,
+    canvasSize: CGSize,
+    displayedContentRect: CGRect? = nil,
+    mode: EditingCanvasMode
+  ) -> EditingCanvasRenderImages? {
     let canvasRect = CGRect(origin: .zero, size: canvasSize)
     let renderBounds = sanitizedRenderBounds(
       displayedContentRect,
       canvasRect: canvasRect
     )
-    let previewSourceImage = loadedState.editingSourceImage.removingExtentOffset()
+    let previewSourceImage = editingSourceImage.removingExtentOffset()
     let sourceImage = displayOrientedImage(previewSourceImage, canvasSize: previewSourceImage.extent.size)
     let displaySourceExtent = sourceImage.extent
     guard displaySourceExtent.width > 0, displaySourceExtent.height > 0 else {
@@ -38,7 +69,7 @@ enum EditingCanvasRenderImageFactory {
     switch mode {
     case .viewportBase:
       baseImage = EditingCanvasImageProcessing.clippedToSourceAlpha(
-        loadedState.currentEdit.effects
+        effects
         .applyIgnoringFailure(to: viewportSourceImage)
         .cropped(to: renderBounds),
         source: viewportSourceImage
@@ -59,7 +90,7 @@ enum EditingCanvasRenderImageFactory {
       // export produces — preview and export stay consistent (modulo the
       // inherent downscale/upscale resampling difference).
       let sourceBase = EditingCanvasImageProcessing.clippedToSourceAlpha(
-        loadedState.currentEdit.effects.applyIgnoringFailure(to: sourceImage),
+        effects.applyIgnoringFailure(to: sourceImage),
         source: sourceImage
       )
       let sourceAdjusted = EditingCanvasImageProcessing.clippedToSourceAlpha(
@@ -80,7 +111,7 @@ enum EditingCanvasRenderImageFactory {
       usesPreparedBaseImage = true
 
     case .renderedEditPreview:
-      let previewImage = loadedState.currentEdit.effects
+      let previewImage = effects
         .applyIgnoringFailure(to: scaledPreviewSourceImage)
         .cropped(to: canvasRect)
       let displayPreviewImage = displayOrientedImage(previewImage, canvasSize: canvasSize)
@@ -93,7 +124,7 @@ enum EditingCanvasRenderImageFactory {
 
     return .init(
       source: viewportSourceImage,
-      effects: loadedState.currentEdit.effects,
+      effects: effects,
       base: baseImage,
       adjusted: adjustedImage,
       localEffect: renderEffect,
@@ -106,9 +137,36 @@ enum EditingCanvasRenderImageFactory {
     geometry: EditingCanvasCropOutputGeometry,
     mode: EditingCanvasMode
   ) -> EditingCanvasRenderImages? {
+    makeCropOutputRenderImages(
+      editingSourceImage: loadedState.editingSourceImage,
+      effects: loadedState.currentEdit.effects,
+      geometry: geometry,
+      mode: mode
+    )
+  }
+
+  static func makeCropOutputRenderImages(
+    document: CropViewDocumentSnapshot,
+    geometry: EditingCanvasCropOutputGeometry,
+    mode: EditingCanvasMode
+  ) -> EditingCanvasRenderImages? {
+    makeCropOutputRenderImages(
+      editingSourceImage: document.editingSourceImage,
+      effects: document.effects,
+      geometry: geometry,
+      mode: mode
+    )
+  }
+
+  private static func makeCropOutputRenderImages(
+    editingSourceImage: CIImage,
+    effects: EffectPipeline,
+    geometry: EditingCanvasCropOutputGeometry,
+    mode: EditingCanvasMode
+  ) -> EditingCanvasRenderImages? {
     let canvasRect = geometry.outputBounds
     let sourceRect = CGRect(origin: .zero, size: geometry.sourceImageSize)
-    let previewSourceImage = loadedState.editingSourceImage.removingExtentOffset()
+    let previewSourceImage = editingSourceImage.removingExtentOffset()
     let displaySourceImage = displayOrientedImage(previewSourceImage, canvasSize: previewSourceImage.extent.size)
     let sourceImage = scaledImage(
       displaySourceImage,
@@ -129,7 +187,7 @@ enum EditingCanvasRenderImageFactory {
     switch mode {
     case .viewportBase:
       baseImage = EditingCanvasImageProcessing.clippedToSourceAlpha(
-        loadedState.currentEdit.effects.applyIgnoringFailure(to: cropOutputSourceImage)
+        effects.applyIgnoringFailure(to: cropOutputSourceImage)
           .cropped(to: canvasRect),
         source: cropOutputSourceImage
       )
@@ -144,7 +202,7 @@ enum EditingCanvasRenderImageFactory {
       // is a fraction of the image extent, so it upscales to the same
       // fractional blur the full-resolution export produces.
       let displayFiltered = EditingCanvasImageProcessing.clippedToSourceAlpha(
-        loadedState.currentEdit.effects.applyIgnoringFailure(to: displaySourceImage),
+        effects.applyIgnoringFailure(to: displaySourceImage),
         source: displaySourceImage
       )
       let displayAdjusted = EditingCanvasImageProcessing.clippedToSourceAlpha(
@@ -170,7 +228,7 @@ enum EditingCanvasRenderImageFactory {
 
     case .renderedEditPreview:
       let filteredSourceImage = EditingCanvasImageProcessing.clippedToSourceAlpha(
-        loadedState.currentEdit.effects
+        effects
           .applyIgnoringFailure(to: sourceImage)
           .cropped(to: sourceExtent),
         source: sourceImage
@@ -186,7 +244,7 @@ enum EditingCanvasRenderImageFactory {
 
     return .init(
       source: cropOutputSourceImage,
-      effects: loadedState.currentEdit.effects,
+      effects: effects,
       base: baseImage,
       adjusted: adjustedImage,
       localEffect: renderEffect,

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasStrokeCommitPipeline.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasStrokeCommitPipeline.swift
@@ -13,7 +13,7 @@ import BrightroomParametric
 /// - A committed layer's effect pipeline is frozen at creation. Appending
 ///   strokes never rewrites the pipeline, because UI-side effect values may
 ///   drift and committed document parameters must stay stable.
-/// - `updateEffect(_:in:)` exists for deliberate effect changes only
+  /// - `updateEffect(_:in:insertingBefore:)` exists for deliberate effect changes only
 ///   (e.g. the user adjusts the effect parameter of the active layer).
 final class EditingCanvasStrokeCommitPipeline {
 
@@ -38,7 +38,8 @@ final class EditingCanvasStrokeCommitPipeline {
   func append(
     record: EditingCanvasStrokeRecord,
     effect: EffectPipeline,
-    to editingStack: EditingStack
+    to editingStack: EditingStack,
+    insertingBefore insertionTargetID: FeatureID?
   ) {
     var localAdjustments = editingStack.loadedState?.currentEdit.localAdjustments ?? []
     let layerIndex: Int
@@ -59,13 +60,18 @@ final class EditingCanvasStrokeCommitPipeline {
 
     localAdjustments[layerIndex].isEnabled = true
     localAdjustments[layerIndex].maskTree.appendCanvasBrushStroke(record.brushMaskStroke)
-    editingStack.set(localAdjustments: localAdjustments)
+    replaceLocalAdjustments(
+      localAdjustments,
+      in: editingStack,
+      insertingBefore: insertionTargetID
+    )
   }
 
   /// Deliberately updates the tracked layer's effect pipeline.
   func updateEffect(
     _ effect: EffectPipeline,
-    in editingStack: EditingStack
+    in editingStack: EditingStack,
+    insertingBefore insertionTargetID: FeatureID?
   ) {
     var localAdjustments = editingStack.loadedState?.currentEdit.localAdjustments ?? []
     guard let layerIndex = layerIndex(in: localAdjustments, matching: effect) else {
@@ -77,7 +83,33 @@ final class EditingCanvasStrokeCommitPipeline {
     }
 
     localAdjustments[layerIndex].effectPipeline = effect
-    editingStack.set(localAdjustments: localAdjustments)
+    replaceLocalAdjustments(
+      localAdjustments,
+      in: editingStack,
+      insertingBefore: insertionTargetID
+    )
+  }
+
+  /// Rewrites the local-adjustment Features while preserving their current
+  /// document positions. New layers are inserted before the caller-selected
+  /// FeatureTree target.
+  func replaceLocalAdjustments(
+    _ localAdjustments: [LocalAdjustmentFeature],
+    in editingStack: EditingStack,
+    insertingBefore insertionTargetID: FeatureID?
+  ) {
+    guard var edit = editingStack.loadedState?.currentEdit else {
+      return
+    }
+
+    EditingFeatureTree.replaceLocalAdjustments(
+      localAdjustments,
+      in: &edit,
+      insertingBefore: insertionTargetID
+    )
+    if editingStack.loadedState?.currentEdit != edit {
+      editingStack.loadedState?.currentEdit = edit
+    }
   }
 
   /// The effect pipeline persisted on the tracked layer, if one exists.

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasView.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasView.swift
@@ -339,7 +339,11 @@ public final class _EditingCanvasView: UIView, UIScrollViewDelegate, UIGestureRe
     canvasView?.reset()
     canvasView?.setCommittedStrokes([])
     if let currentEditingStack {
-      currentEditingStack.set(localAdjustments: [])
+      strokeCommitPipeline.replaceLocalAdjustments(
+        [],
+        in: currentEditingStack,
+        insertingBefore: EditingFeatureTree.finalCropNodeID
+      )
     }
     strokeCommitPipeline.resetLayerTracking()
     updateVisibleContentRect()
@@ -398,7 +402,8 @@ public final class _EditingCanvasView: UIView, UIScrollViewDelegate, UIGestureRe
     strokeCommitPipeline.append(
       record: record,
       effect: currentLocalEffect,
-      to: currentEditingStack
+      to: currentEditingStack,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
     )
   }
 
@@ -409,7 +414,11 @@ public final class _EditingCanvasView: UIView, UIScrollViewDelegate, UIGestureRe
       return
     }
 
-    strokeCommitPipeline.updateEffect(localEffect, in: currentEditingStack)
+    strokeCommitPipeline.updateEffect(
+      localEffect,
+      in: currentEditingStack,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
   }
 
   private func syncCommittedStrokesFromEditingStack() {

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/SwiftUIEditingCanvasView.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/SwiftUIEditingCanvasView.swift
@@ -1,4 +1,5 @@
 import BrightroomEngine
+import BrightroomParametric
 import SwiftUI
 import UIKit
 
@@ -29,7 +30,10 @@ public struct SwiftUIEditingCanvasView: View {
           mode: mode,
           interactionMode: interactionMode ?? mode.defaultInteractionMode,
           displayedImageRect: displayedImageRect
-            ?? loadedState.currentEdit.crop.displayCropRect(imageSize: loadedState.currentEdit.imageSize),
+            ?? EditingFeatureTree(edit: loadedState.currentEdit)
+              .finalCrop?
+              .displayCropRect(imageSize: loadedState.currentEdit.imageSize)
+            ?? CGRect(origin: .zero, size: loadedState.currentEdit.imageSize),
           brush: brush,
           smoothing: smoothing,
           onMetricsChange: onMetricsChange

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -28,7 +28,7 @@ import BrightroomParametric
 
 struct PhotosCropContentView: View {
 
-  let editingStack: EditingStack
+  let editingModel: PhotosCropEditingModel
   let options: SwiftUIPhotosCropView.Options
   let localizedStrings: SwiftUIPhotosCropView.LocalizedStrings
   let onDone: @MainActor () -> Void
@@ -47,13 +47,13 @@ struct PhotosCropContentView: View {
   @State private var adjustmentAngleCommitAction = SwiftUICropView.AdjustmentAngleCommitAction()
 
   init(
-    editingStack: EditingStack,
+    editingModel: PhotosCropEditingModel,
     options: SwiftUIPhotosCropView.Options,
     localizedStrings: SwiftUIPhotosCropView.LocalizedStrings,
     onDone: @escaping @MainActor () -> Void,
     onCancel: @escaping @MainActor () -> Void
   ) {
-    self.editingStack = editingStack
+    self.editingModel = editingModel
     self.options = options
     self.localizedStrings = localizedStrings
     self.onDone = onDone
@@ -68,9 +68,9 @@ struct PhotosCropContentView: View {
   }
 
   var body: some View {
-    let loadedState = editingStack.loadedState
-    let originalAspectRatio = loadedState.map { PixelAspectRatio($0.imageSize) }
-    let isLoaded = loadedState != nil
+    let model = editingModel
+    let originalAspectRatio = model.originalAspectRatio
+    let isLoaded = model.isLoaded
     let bottomControlHeight: CGFloat = 120
     let bottomControlMaxWidth: CGFloat = 560
 
@@ -81,7 +81,7 @@ struct PhotosCropContentView: View {
 
         VStack(spacing: 0) {
           PhotosCropCanvasHost(
-            editingStack: editingStack,
+            editingModel: model,
             mode: editingMode,
             blurMaskingState: blurMaskingState,
             rotation: $rotation,
@@ -90,7 +90,8 @@ struct PhotosCropContentView: View {
             resetAction: resetAction,
             rotateAction: rotateAction,
             applyAction: applyAction,
-            adjustmentAngleCommitAction: adjustmentAngleCommitAction
+            adjustmentAngleCommitAction: adjustmentAngleCommitAction,
+            featureFocus: model.featureFocus(for: editingMode)
           )
           .layoutPriority(1)
 
@@ -100,8 +101,8 @@ struct PhotosCropContentView: View {
             aspectRatioSelection: aspectRatioSelection,
             blurMaskingState: blurMaskingState,
             filterPresets: options.filterPresets,
-            filterPreviewBaseImage: loadedState?.thumbnailImage,
-            currentEffects: loadedState?.currentEdit.effects,
+            filterPreviewBaseImage: model.filterPreviewBaseImage,
+            currentEffects: model.currentEffects,
             adjustmentParameter: adjustmentParameter,
             localizedStrings: localizedStrings,
             adjustmentAngle: adjustmentAngle,
@@ -130,7 +131,7 @@ struct PhotosCropContentView: View {
           cancelTitle: localizedStrings.button_cancel_title,
           doneTitle: localizedStrings.button_done_title,
           isLoaded: isLoaded,
-          hasCropChanges: hasCropChanges(loadedState: loadedState),
+          hasCropChanges: model.hasCropChanges(),
           isDoneEnabled: isLoaded,
           mode: editingMode,
           isSelectingAspectRatio: isSelectingAspectRatio,
@@ -144,7 +145,7 @@ struct PhotosCropContentView: View {
       }
       .foregroundStyle(.white)
       .task {
-        editingStack.start()
+        model.start()
       }
       .onChange(of: isAspectRatioControlAvailable) { _, isAvailable in
         if isAvailable == false {
@@ -171,37 +172,6 @@ struct PhotosCropContentView: View {
     case .fixed:
       return false
     }
-  }
-
-  /// Whether the crop differs from what the Reset button would restore.
-  ///
-  /// Reset only restores the crop (`CropEditingState.makeInitial()`), so its
-  /// visibility tracks crop state alone — painting a blur mask must not
-  /// surface a Reset button that would do nothing.
-  ///
-  /// The extent comparison tolerates sub-pixel drift because leaving Crop
-  /// mode re-commits the guide's laid-out geometry, which can differ from
-  /// the document crop by a fraction of a pixel.
-  private func hasCropChanges(loadedState: EditingStack.Loaded?) -> Bool {
-    guard let loadedState else {
-      return false
-    }
-
-    // Lower the stored crop into the UI working model so the comparison stays in
-    // the same y-down display space the reset (`makeInitial`) produces.
-    let crop = CropEditingState(
-      cropFeature: loadedState.currentEdit.crop,
-      imageSize: loadedState.currentEdit.imageSize
-    )
-    let initial = crop.makeInitial()
-    let tolerance: CGFloat = 1
-
-    return crop.rotation != initial.rotation
-      || abs(crop.adjustmentAngle.radians - initial.adjustmentAngle.radians) > 0.0001
-      || abs(crop.cropExtent.minX - initial.cropExtent.minX) > tolerance
-      || abs(crop.cropExtent.minY - initial.cropExtent.minY) > tolerance
-      || abs(crop.cropExtent.width - initial.cropExtent.width) > tolerance
-      || abs(crop.cropExtent.height - initial.cropExtent.height) > tolerance
   }
 
   private func rotate() {
@@ -251,23 +221,19 @@ struct PhotosCropContentView: View {
       return
     }
 
-    // Leaving a tool commits its work as a version, so undo/redo steps at
-    // tool granularity. The stack snapshots the whole feature-list document.
-    if editingStack.loadedState?.hasUncommitedChanges == true {
-      editingStack.takeSnapshot()
+    if editingMode == .crop {
+      applyAction()
     }
+
+    // Leaving a tool commits its work as a checkpoint, so undo/redo steps at
+    // tool granularity. The stack owns the whole feature-list history.
+    editingModel.commitCurrentEditIfNeeded()
 
     editingMode = mode
   }
 
-  /// Writes the selected preset into the global-effects feature node.
   private func selectFilterPreset(_ preset: PresetFeature?) {
-    editingStack.updateGlobalEffectsFeature { effects in
-      guard effects.first(of: PresetFeature.self)?.identifier != preset?.identifier else {
-        return
-      }
-      effects.set(preset, insertionIndex: PhotosCropEffectOrder.insertionIndex(for: PresetFeature.self))
-    }
+    editingModel.selectFilterPreset(preset)
   }
 
   private func selectAdjustmentParameter(_ parameter: PhotosCropAdjustmentParameter) {
@@ -277,33 +243,17 @@ struct PhotosCropContentView: View {
     adjustmentParameter = parameter
   }
 
-  /// Writes a slider value for the selected parameter into the global-effects
-  /// feature node.
   private func setAdjustmentValue(_ sliderValue: Double) {
-    editingStack.updateGlobalEffectsFeature { effects in
-      adjustmentParameter.apply(sliderValue: sliderValue, to: &effects)
-    }
+    editingModel.setAdjustmentValue(sliderValue, parameter: adjustmentParameter)
   }
 
   private func clearBlurMaskingLayer() {
-    let blurIdentity = CropViewMaskingDefaults.blurEffectPipeline.editingCanvasEffectIdentity
-    let localAdjustments = editingStack.loadedState?.currentEdit.localAdjustments ?? []
-    let remainingLocalAdjustments = localAdjustments.filter {
-      $0.effectPipeline.editingCanvasEffectIdentity != blurIdentity
-    }
-
-    guard remainingLocalAdjustments != localAdjustments else {
-      return
-    }
-
-    editingStack.set(localAdjustments: remainingLocalAdjustments)
+    editingModel.clearBlurMaskingLayer()
   }
 
   private func finish() {
     applyAction()
-    if editingStack.loadedState?.hasUncommitedChanges == true {
-      editingStack.takeSnapshot()
-    }
+    editingModel.commitCurrentEditIfNeeded()
     onDone()
   }
 
@@ -326,7 +276,7 @@ struct PhotosCropContentView: View {
 /// interaction surface `SwiftUICropView` exposes. Future modes are represented
 /// here even before their controls are implemented so the UI tree can settle
 /// around the same routing model.
-private enum PhotosCropEditingMode: CaseIterable, Equatable, Identifiable {
+enum PhotosCropEditingMode: CaseIterable, Equatable, Identifiable {
   case crop
   case blurMasking
   case filters
@@ -404,7 +354,7 @@ private struct PhotosCropBlurMaskingState: Equatable {
 
 private struct PhotosCropCanvasHost: View {
 
-  let editingStack: EditingStack
+  let editingModel: PhotosCropEditingModel
   let mode: PhotosCropEditingMode
   let blurMaskingState: PhotosCropBlurMaskingState
   let rotation: Binding<CropEditingState.Rotation?>
@@ -414,12 +364,12 @@ private struct PhotosCropCanvasHost: View {
   let rotateAction: SwiftUICropView.RotateAction
   let applyAction: SwiftUICropView.ApplyAction
   let adjustmentAngleCommitAction: SwiftUICropView.AdjustmentAngleCommitAction
+  let featureFocus: CropViewFeatureFocus
 
   var body: some View {
     SwiftUICropView(
-      editingStack: editingStack,
-      isGuideInteractionEnabled: mode == .crop,
-      isAutoApplyEditingStackEnabled: true
+      editingModel: editingModel,
+      isGuideInteractionEnabled: mode == .crop
     )
     .rotation(rotation)
     .adjustmentAngle(adjustmentAngle)
@@ -433,23 +383,6 @@ private struct PhotosCropCanvasHost: View {
     .registerAdjustmentAngleCommitAction(adjustmentAngleCommitAction)
   }
 
-  /// The FeatureTree focus for the current editing mode.
-  ///
-  /// Every mode views the evaluated output (`.output`); what changes is the
-  /// adjustment point. Crop edits the final crop node, blur masking paints a
-  /// pre-crop local adjustment (CropView derives the blur seed from the
-  /// current crop), and filters/adjustments edit the global effects node
-  /// through controls outside the canvas.
-  private var featureFocus: CropViewFeatureFocus {
-    switch mode {
-    case .crop:
-      return .finalCrop
-    case .blurMasking:
-      return .masking()
-    case .filters, .adjustments:
-      return .output
-    }
-  }
 }
 
 private struct PhotosCropControlHost: View {
@@ -1825,11 +1758,13 @@ private enum PhotosCropAspectRatioDirection {
 
 private struct PhotosCropPreviewHost: View {
 
-  @State private var editingStack = PhotosCropPreviewFixtures.makeEditingStack()
+  private let editingModel = PhotosCropEditingModel(
+    editingStack: PhotosCropPreviewFixtures.makeEditingStack()
+  )
 
   var body: some View {
     SwiftUIPhotosCropView(
-      editingStack: editingStack,
+      editingModel: editingModel,
       onDone: {},
       onCancel: {}
     )

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropEditingModel.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropEditingModel.swift
@@ -1,0 +1,290 @@
+//
+// Copyright (c) 2026 Muukii <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+
+import BrightroomEngine
+import BrightroomParametric
+
+/// PhotosCrop's policy layer over `EditingStack`'s generic FeatureTree.
+///
+/// PhotosCrop views depend on this model rather than talking to `EditingStack`
+/// directly. The stack still owns the document, history, and renderer; this
+/// model owns the Photos-style interpretation of that document: which node is
+/// the final crop, which effect bundle backs filter/adjustment controls, and
+/// how the blur mask layer is found or cleared.
+@MainActor
+public final class PhotosCropEditingModel {
+
+  /// The stack whose current edit is interpreted as a PhotosCrop document.
+  private let editingStack: EditingStack
+
+  /// The stable crop-canvas document for this PhotosCrop editing session.
+  private let cropViewDocumentStore: CropViewDocument
+
+  public init(editingStack: EditingStack) {
+    self.editingStack = editingStack
+    self.cropViewDocumentStore = CropViewDocument(editingStack: editingStack)
+  }
+
+  /// The crop-canvas document used at the boundary where PhotosCrop hosts the
+  /// reusable `CropView`.
+  ///
+  /// Keep this access narrow: PhotosCrop-specific feature choices should be
+  /// expressed as model operations, not as ad-hoc stack mutations in views.
+  var cropViewDocument: CropViewDocument {
+    cropViewDocumentStore
+  }
+
+  /// The current loaded state, if the stack has finished image preparation.
+  var loadedState: EditingStack.Loaded? {
+    editingStack.loadedState
+  }
+
+  /// The current FeatureTree projection owned by PhotosCrop's editing policy.
+  ///
+  /// This is projected from the stack at access time so CropView commits, undo,
+  /// redo, and external stack mutations cannot leave the model with a stale
+  /// tree. PhotosCrop still owns *how* the tree is interpreted and edited.
+  var featureTree: EditingFeatureTree? {
+    loadedState.map { EditingFeatureTree(edit: $0.currentEdit) }
+  }
+
+  /// Whether the editor has an image ready for controls and canvas display.
+  var isLoaded: Bool {
+    loadedState != nil
+  }
+
+  /// The original oriented source aspect ratio used by the crop controls.
+  var originalAspectRatio: PixelAspectRatio? {
+    loadedState.map { PixelAspectRatio($0.imageSize) }
+  }
+
+  /// The thumbnail base image used by filter swatches.
+  var filterPreviewBaseImage: CIImage? {
+    loadedState?.thumbnailImage
+  }
+
+  /// The global effects node exposed to filter and adjustment controls.
+  var currentEffects: EffectPipeline? {
+    featureTree?.globalEffects ?? loadedState?.currentEdit.effects
+  }
+
+  /// Starts image preparation.
+  func start() {
+    editingStack.start()
+  }
+
+  /// Commits the current PhotosCrop document as an undo checkpoint when needed.
+  func commitCurrentEditIfNeeded() {
+    editingStack.commitCurrentEditIfNeeded()
+  }
+
+  /// The `CropView` focus for a PhotosCrop toolbar mode.
+  func featureFocus(for mode: PhotosCropEditingMode) -> CropViewFeatureFocus {
+    switch mode {
+    case .crop:
+      return .init(
+        viewingPoint: .output,
+        editingTarget: .crop(id: EditingFeatureTree.finalCropNodeID)
+      )
+    case .blurMasking:
+      return .init(
+        viewingPoint: .output,
+        editingTarget: .localAdjustmentMask(
+          id: nil,
+          seedEffect: CropViewMaskingDefaults.blurEffectPipeline
+        )
+      )
+    case .filters, .adjustments:
+      return .init(viewingPoint: .output)
+    }
+  }
+
+  /// Whether the final crop differs from PhotosCrop's Reset target.
+  ///
+  /// Reset only restores the crop geometry, so this intentionally ignores
+  /// effects and mask layers.
+  func hasCropChanges(tolerance: CGFloat = 1) -> Bool {
+    guard let crop = finalCropEditingState else {
+      return false
+    }
+
+    let initial = crop.makeInitial()
+    return crop.rotation != initial.rotation
+      || abs(crop.adjustmentAngle.radians - initial.adjustmentAngle.radians) > 0.0001
+      || abs(crop.cropExtent.minX - initial.cropExtent.minX) > tolerance
+      || abs(crop.cropExtent.minY - initial.cropExtent.minY) > tolerance
+      || abs(crop.cropExtent.width - initial.cropExtent.width) > tolerance
+      || abs(crop.cropExtent.height - initial.cropExtent.height) > tolerance
+  }
+
+  /// Writes the selected preset into PhotosCrop's global-effects node.
+  func selectFilterPreset(_ preset: PresetFeature?) {
+    updateGlobalEffects { effects in
+      guard effects.first(of: PresetFeature.self)?.identifier != preset?.identifier else {
+        return
+      }
+      effects.set(
+        preset,
+        insertionIndex: PhotosCropEffectOrder.insertionIndex(for: PresetFeature.self)
+      )
+    }
+  }
+
+  /// Writes an adjustment slider value into PhotosCrop's global-effects node.
+  func setAdjustmentValue(
+    _ sliderValue: Double,
+    parameter: PhotosCropAdjustmentParameter
+  ) {
+    updateGlobalEffects { effects in
+      parameter.apply(sliderValue: sliderValue, to: &effects)
+    }
+  }
+
+  /// Removes PhotosCrop's blur-mask local adjustment layer, if one exists.
+  func clearBlurMaskingLayer() {
+    let blurIdentity = CropViewMaskingDefaults.blurEffectPipeline.editingCanvasEffectIdentity
+    let localAdjustments = featureTree?.localAdjustments ?? []
+    let remainingLocalAdjustments = localAdjustments.filter {
+      $0.effectPipeline.editingCanvasEffectIdentity != blurIdentity
+    }
+
+    guard remainingLocalAdjustments != localAdjustments else {
+      return
+    }
+
+    replaceLocalAdjustments(remainingLocalAdjustments)
+  }
+
+  /// Mutates PhotosCrop's global-effects node.
+  private func updateGlobalEffects(
+    _ mutate: (inout EffectPipeline) -> Void
+  ) {
+    guard var edit = loadedState?.currentEdit else {
+      return
+    }
+
+    if edit.updateFeature(id: EditingFeatureTree.globalEffectsNodeID, mutate: { feature in
+      if
+        case let .effect(effect) = feature,
+        var bundle = effect as? EffectPipelineFeature
+      {
+        mutate(&bundle.pipeline)
+        feature = .effect(bundle)
+      }
+    }) {
+      applyEditIfChanged(edit)
+      return
+    }
+
+    var pipeline = EffectPipeline()
+    mutate(&pipeline)
+    guard pipeline.isEmpty == false else {
+      return
+    }
+
+    edit.insertFeature(
+      .effect(
+        EffectPipelineFeature(
+          id: EditingFeatureTree.globalEffectsNodeID,
+          pipeline: pipeline
+        )
+      ),
+      at: globalEffectsInsertionIndex(in: edit)
+    )
+    applyEditIfChanged(edit)
+  }
+
+  /// Rewrites PhotosCrop's local-adjustment layer list in the pre-final-crop
+  /// domain.
+  private func replaceLocalAdjustments(
+    _ localAdjustments: [LocalAdjustmentFeature]
+  ) {
+    guard var edit = loadedState?.currentEdit else {
+      return
+    }
+
+    EditingFeatureTree.replaceLocalAdjustments(
+      localAdjustments,
+      in: &edit,
+      insertingBefore: EditingFeatureTree.finalCropNodeID
+    )
+    applyEditIfChanged(edit)
+  }
+
+  /// PhotosCrop inserts global effects before local adjustments and the final
+  /// crop. This keeps effects global to the pre-final-crop image domain without
+  /// teaching `EditingStack.Edit` where PhotosCrop wants that node to live.
+  private func globalEffectsInsertionIndex(in edit: EditingStack.Edit) -> Int {
+    let features = edit.features
+    let finalCropIndex = features.firstIndex {
+      $0.id == EditingFeatureTree.finalCropNodeID
+    } ?? features.count
+
+    for index in features.indices where index < finalCropIndex {
+      if case .localAdjustment = features[index] {
+        return index
+      }
+    }
+
+    return finalCropIndex
+  }
+
+  private func applyEditIfChanged(_ edit: EditingStack.Edit) {
+    if editingStack.loadedState?.currentEdit != edit {
+      editingStack.loadedState?.currentEdit = edit
+    }
+  }
+
+  private var finalCropEditingState: CropEditingState? {
+    guard
+      let loadedState,
+      let crop = featureTree?.finalCrop
+    else {
+      return nil
+    }
+
+    return CropEditingState(
+      cropFeature: crop,
+      imageSize: loadedState.currentEdit.imageSize
+    )
+  }
+}
+
+extension SwiftUICropView {
+
+  /// Creates the reusable crop canvas through PhotosCrop's editing model.
+  ///
+  /// This keeps PhotosCrop views depending on `PhotosCropEditingModel`; the
+  /// model is the narrow boundary that maps PhotosCrop policy onto the shared
+  /// crop canvas document.
+  init(
+    editingModel: PhotosCropEditingModel,
+    isGuideInteractionEnabled: Bool
+  ) {
+    self.init(
+      document: editingModel.cropViewDocument,
+      isGuideInteractionEnabled: isGuideInteractionEnabled
+    )
+  }
+}

--- a/Sources/BrightroomUI/builtin/PhotosCrop/SwiftUIPhotosCropView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/SwiftUIPhotosCropView.swift
@@ -63,20 +63,20 @@ public struct SwiftUIPhotosCropView: View {
     }
   }
 
-  private let editingStack: EditingStack
+  private let editingModel: PhotosCropEditingModel
   private let options: Options
   private let localizedStrings: LocalizedStrings
   private let onDone: @MainActor () -> Void
   private let onCancel: @MainActor () -> Void
 
   public init(
-    editingStack: EditingStack,
+    editingModel: PhotosCropEditingModel,
     options: Options = .init(),
     localizedStrings: LocalizedStrings = .init(),
     onDone: @escaping @MainActor () -> Void,
     onCancel: @escaping @MainActor () -> Void
   ) {
-    self.editingStack = editingStack
+    self.editingModel = editingModel
     self.options = options
     self.localizedStrings = localizedStrings
     self.onDone = onDone
@@ -85,7 +85,7 @@ public struct SwiftUIPhotosCropView: View {
 
   public var body: some View {
     PhotosCropContentView(
-      editingStack: editingStack,
+      editingModel: editingModel,
       options: options,
       localizedStrings: localizedStrings,
       onDone: onDone,

--- a/docs/MIGRATION_TO_V4.md
+++ b/docs/MIGRATION_TO_V4.md
@@ -119,21 +119,25 @@ Important type renames:
 | `editingStack.store.state.loadedState` | `editingStack.loadedState` |
 | `editingStack.store.state.isLoading` | `editingStack.isLoading` |
 | `editingStack.store.state.hasStartedEditing` | `editingStack.hasStartedEditing` |
-| `editingStack.commit { ... }` | use public methods such as `set(filters:)`, `crop(_:)`, `takeSnapshot()`, `undoEdit()` |
+| `editingStack.commit { ... }` | use document mutation APIs, then `commitCurrentEditIfNeeded()` and `undo()` |
 
-The public editing operations remain the preferred way to mutate an editing
-stack:
+FeatureTree mutation APIs remain the preferred way to mutate an editing stack:
 
 ```swift
-editingStack.set { filters in
-  var exposure = FilterExposure()
-  exposure.value = 0.3
-  filters.exposure = exposure
+editingStack.updateFeature(id: EditingFeatureTree.globalEffectsNodeID) { feature in
+  guard
+    case let .effect(effect) = feature,
+    var bundle = effect as? EffectPipelineFeature
+  else {
+    return
+  }
+
+  bundle.pipeline.set(ExposureFeature(value: 0.3))
+  feature = .effect(bundle)
 }
 
-editingStack.crop(crop)
-editingStack.takeSnapshot()
-editingStack.undoEdit()
+editingStack.commitCurrentEditIfNeeded()
+editingStack.undo()
 let renderer = try editingStack.makeRenderer()
 ```
 
@@ -279,10 +283,11 @@ After:
 
 ```swift
 let editingStack = EditingStack(imageProvider: imageProvider)
+let editingModel = PhotosCropEditingModel(editingStack: editingStack)
 
 let cropController = UIHostingController(
   rootView: SwiftUIPhotosCropView(
-    editingStack: editingStack,
+    editingModel: editingModel,
     options: .init(),
     localizedStrings: .init(),
     onDone: {

--- a/docs/metal-brush-local-adjustment-tile-canvas.md
+++ b/docs/metal-brush-local-adjustment-tile-canvas.md
@@ -216,13 +216,10 @@ Implementation status:
 
 - `EditingStack.Edit.makePreviewImage(from:purpose:)` is the shared policy
   entrypoint.
-- `EditingStack.Loaded.editingPreviewImage` uses `.editing`.
-- `EditingStack.Loaded.cropInteractionPreviewImage` uses `.cropInteraction`.
-- `EditingStack.Loaded.imageForCrop` is the current `CGImage` materialization
-  used by Crop UI and follows the crop interaction policy.
-- Crop interaction currently returns the normalized source image only; adding
-  lightweight color-only adjustments should be a product decision, not an
-  accidental side effect of reusing the editing preview.
+- `.editingBase` skips local adjustments so mask rasterization remains owned by
+  the render path that knows its target resolution.
+- `.editing` includes local adjustments and is used by explicit preview/export
+  parity tests.
 
 ### Local Adjustment Effect Policy
 

--- a/docs/performance-notes.md
+++ b/docs/performance-notes.md
@@ -112,8 +112,6 @@ performance is already good.
 
 - Mask rasters are memoized (`LocalAdjustmentMaskRasterStore`, 32 MB/entry,
   64 MB total) — repeated previews of the same mask are free.
-- `EditingStack.Loaded.editingPreviewImage` only recomputes when the effects
-  sequence actually changes (keyed on `effectsSequence`).
-- The export and preview share one composition path (proven equivalent by
-  `EditingPreviewExportParityTests`), so there is no duplicated render logic to
+- The export and explicit preview composition path are proven equivalent by
+  `EditingPreviewExportParityTests`, so there is no duplicated render logic to
   optimize twice.


### PR DESCRIPTION
## Summary

- Introduce `PhotosCropEditingModel` as the PhotosCrop policy layer over the generic FeatureTree document.
- Add `CropViewDocument` so CropView edits through a document boundary instead of depending on `EditingStack` directly.
- Move undo/redo checkpoint storage behind `EditingHistory` and expose clearer stack APIs: `commitCurrentEditIfNeeded`, `undo`, `redo`, `revertCurrentEdit`, and `removeAllHistory`.
- Remove legacy crop-specific stack helpers and update demos, docs, and render tests to use FeatureTree-oriented mutation paths.

## Validation

- `BrightroomEngineTests`: 152 passed on iPhone 17 simulator.
- `BrightroomUI` simulator build: succeeded.
- `SwiftUIDemo` simulator build: succeeded.
- `git diff --check`: passed.

Note: `SwiftUIDemo` still reports existing iOS 17 `onChange(of:perform:)` deprecation warnings unrelated to this change.