### PR TITLE
Add BrightroomParametric foundation

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,6 +33,16 @@ jobs:
         with:
           xcode-version: "26.2"
       - uses: actions/checkout@v2
+      - name: Test BrightroomParametric
+        run: |
+          set -o pipefail && xcodebuild \
+            -scheme Brightroom-Package \
+            test \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2' \
+            -only-testing:BrightroomParametricTests \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            | xcbeautify
       - name: Build
         run: |
           set -o pipefail && xcodebuild \

--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     .iOS(.v17)
   ],
   products: [
+    .library(name: "BrightroomParametric", targets: ["BrightroomParametric"]),
     .library(name: "BrightroomEngine", targets: ["BrightroomEngine"]),
     .library(name: "BrightroomUI", targets: ["BrightroomUI"]),
   ],
@@ -15,6 +16,14 @@ let package = Package(
     .package(url: "https://github.com/FluidGroup/TransitionPatch", from: "1.0.3"),
   ],
   targets: [
+    .target(
+      name: "BrightroomParametric",
+      exclude: [
+        // Included by the compiled `.metal` sources; not a standalone package
+        // input.
+        "BrushStampFalloff.metalh"
+      ]
+    ),
     .target(
       name: "BrightroomEngine",
       dependencies: [
@@ -28,6 +37,10 @@ let package = Package(
         .product(name: "StateGraph", package: "swift-state-graph"),
         "TransitionPatch",
       ]
+    ),
+    .testTarget(
+      name: "BrightroomParametricTests",
+      dependencies: ["BrightroomParametric"]
     ),
   ]
 )

--- a/Sources/BrightroomParametric/BrushMaskRenderShader.metal
+++ b/Sources/BrightroomParametric/BrushMaskRenderShader.metal
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Metal render source for the in-flight brush stroke, rasterized into a mask
+// texture for low-latency live painting feedback. This source and the Core Image
+// brush-stamp kernel share brushStampAlpha from BrushStampFalloff.metalh.
+
+#include "BrushStampFalloff.metalh"
+
+struct BrushStampUniforms {
+  float2 canvasSize;
+  float2 center;
+  float radius;
+  float hardness;
+  float opacity;
+  float padding;
+};
+
+struct BrushStampVertexOut {
+  float4 position [[position]];
+  float2 local;
+};
+
+vertex BrushStampVertexOut brushStampVertex(
+  uint vertexID [[vertex_id]],
+  constant BrushStampUniforms& brush [[buffer(0)]]
+) {
+  constexpr float2 corners[4] = {
+    float2(-1.0, -1.0),
+    float2( 1.0, -1.0),
+    float2(-1.0,  1.0),
+    float2( 1.0,  1.0)
+  };
+
+  float2 local = corners[vertexID];
+  float2 pixel = brush.center + local * brush.radius;
+  float2 position = float2(
+    pixel.x / brush.canvasSize.x * 2.0 - 1.0,
+    1.0 - pixel.y / brush.canvasSize.y * 2.0
+  );
+
+  BrushStampVertexOut out;
+  out.position = float4(position, 0.0, 1.0);
+  out.local = local;
+  return out;
+}
+
+fragment float4 brushStampFragment(
+  BrushStampVertexOut in [[stage_in]],
+  constant BrushStampUniforms& brush [[buffer(0)]]
+) {
+  // `in.local` is the [-1, 1] quad coordinate, so its length is already the
+  // normalized distance the shared falloff expects.
+  float normalizedDistance = length(in.local);
+  float alpha = brushStampAlpha(normalizedDistance, brush.hardness, brush.opacity);
+  return float4(alpha, alpha, alpha, alpha);
+}

--- a/Sources/BrightroomParametric/BrushStampFalloff.metalh
+++ b/Sources/BrightroomParametric/BrushStampFalloff.metalh
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#pragma once
+
+#include <metal_stdlib>
+using namespace metal;
+
+// Shared brush falloff used by the committed parametric brush mask and the live
+// in-flight-stroke render shader. The function takes a normalized distance:
+// 0 at the stamp center, 1 at the radius edge.
+inline float brushStampAlpha(float normalizedDistance, float hardness, float opacity) {
+  if (normalizedDistance > 1.0) {
+    return 0.0;
+  }
+  float alpha = 1.0;
+  if (hardness < 0.999) {
+    float start = clamp(hardness, 0.0, 0.998);
+    alpha = 1.0 - smoothstep(start, 1.0, normalizedDistance);
+  }
+  return alpha * clamp(opacity, 0.0, 1.0);
+}

--- a/Sources/BrightroomParametric/BrushStampMetalLibrary.swift
+++ b/Sources/BrightroomParametric/BrushStampMetalLibrary.swift
@@ -1,0 +1,61 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Locates the build-compiled Metal library bundled with BrightroomParametric.
+///
+/// `ParametricKernels.metal` and `BrushMaskRenderShader.metal` are compiled by
+/// the package/Xcode Metal build step into `default.metallib`. The parametric
+/// renderer loads Core Image kernels from this library, and BrightroomUI loads
+/// the live brush-mask vertex/fragment functions from the same library.
+public enum BrushStampMetalLibrary {
+
+  /// Returns the URL for the bundled `default.metallib`.
+  public static func url() throws -> URL {
+    guard let url = Bundle.module.url(forResource: "default", withExtension: "metallib") else {
+      throw BrushStampMetalLibraryError.missingResource("default.metallib")
+    }
+    return url
+  }
+
+  /// Returns the bundled `default.metallib` contents.
+  public static func data() throws -> Data {
+    let url = try url()
+    do {
+      return try Data(contentsOf: url)
+    } catch {
+      throw BrushStampMetalLibraryError.unreadableResource(
+        "default.metallib: \(String(describing: error))"
+      )
+    }
+  }
+}
+
+/// Errors thrown while loading BrightroomParametric's compiled Metal library.
+public enum BrushStampMetalLibraryError: Error, Equatable, Sendable {
+
+  /// The package resource bundle does not contain `default.metallib`.
+  case missingResource(String)
+
+  /// The compiled Metal library exists but could not be read.
+  case unreadableResource(String)
+}

--- a/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
+++ b/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
@@ -1,0 +1,422 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+// Core Image recipes for the built-in features.
+//
+// The parameter structs stay pure data in ParametricFeatureModel.swift; their
+// evaluation behavior lives here as capability conformances. Every effect is
+// extent-preserving (`cropped(to: image.extent)`).
+
+// MARK: - Domain features
+
+extension CropFeature: DomainFeatureType {
+
+  public func validate() throws {
+    guard cropRect.isParametricValidExtent else {
+      throw FeatureGraphCompilerError.invalidCropRect(id, cropRect)
+    }
+  }
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    try validate()
+
+    let absoluteCropRect = cropRect.offsetBy(
+      dx: image.extent.minX,
+      dy: image.extent.minY
+    )
+
+    // Rotate the source about the crop-rect center BEFORE extracting the crop
+    // window, so a free straighten angle pulls in surrounding source content —
+    // matching the engine's CGContext crop, which rotates the destination about
+    // the same center and then clips to the crop rect. The engine rotates the
+    // destination CTM by `-aggregatedRotation`, which in its y-up context shows
+    // the content rotated `+aggregatedRotation`; reproducing that as an image
+    // rotation in Core Image's y-up space means rotating by the NEGATED angle.
+    // For the default `.zero` / 0 rotation this is the identity transform, so
+    // the crop reduces to a pure extent change (existing crop behavior is
+    // unchanged).
+    let angle = -aggregatedRotationRadians
+
+    let cropped: CIImage
+    if angle == 0 {
+      cropped = image.cropped(to: absoluteCropRect)
+    } else {
+      let center = CGPoint(x: absoluteCropRect.midX, y: absoluteCropRect.midY)
+      let rotateAboutCenter = CGAffineTransform(translationX: center.x, y: center.y)
+        .rotated(by: angle)
+        .translatedBy(x: -center.x, y: -center.y)
+      // Match the engine's fixed crop-rect canvas: a rotation can leave parts of
+      // the crop rect uncovered (triangular corners under a free angle, bands
+      // under a quarter turn). Compositing over a transparent canvas of the crop
+      // rect keeps the output extent exactly the crop rect instead of shrinking
+      // it to the rotated content's intersection. `CIImage(color:)` is the
+      // infinite-extent transparent source (unlike `CIImage.empty()`, whose
+      // extent is empty and would crop away to nothing).
+      let canvas = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+        .cropped(to: absoluteCropRect)
+      cropped = image
+        .transformed(by: rotateAboutCenter)
+        .cropped(to: absoluteCropRect)
+        .composited(over: canvas)
+    }
+
+    return cropped.transformed(
+      by: CGAffineTransform(
+        translationX: -absoluteCropRect.minX,
+        y: -absoluteCropRect.minY
+      )
+    )
+  }
+}
+
+// MARK: - Image effects
+
+extension PresetFeature: ImageEffectFeatureType {
+
+  public var childFeatures: [any Feature] { effects }
+
+  public func validate() throws {
+    for effect in effects {
+      try effect.validate()
+    }
+  }
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    try effects
+      .filter(\.isEnabled)
+      .reduce(image) { image, effect in
+        try effect.apply(to: image, context: context)
+      }
+  }
+}
+
+extension EffectPipelineFeature: ImageEffectFeatureType {
+
+  public var childFeatures: [any Feature] { pipeline.effects }
+
+  public func validate() throws {
+    for effect in pipeline.effects {
+      try effect.validate()
+    }
+  }
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    try pipeline.apply(to: image, context: context)
+  }
+}
+
+extension ColorCubeFeature: ImageEffectFeatureType {
+
+  private var expectedByteCount: Int {
+    dimension * dimension * dimension * 4 * MemoryLayout<Float>.size
+  }
+
+  public func validate() throws {
+    guard cubeData.count == expectedByteCount else {
+      throw FeatureGraphCompilerError.invalidColorCubeData(
+        id,
+        expectedByteCount: expectedByteCount,
+        actualByteCount: cubeData.count
+      )
+    }
+  }
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    try validate()
+
+    let filter = ParametricColorCubeHelper.makeColorCubeFilter(
+      cubeData: cubeData,
+      dimension: dimension,
+      cacheKey: identifier
+    )
+    filter.setValue(image, forKeyPath: kCIInputImageKey)
+
+    guard let filtered = filter.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CIColorCubeWithColorSpace")
+    }
+
+    let foreground = filtered.applyingFilter(
+      "CIColorMatrix",
+      parameters: [
+        "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+        "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+        "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+        "inputAVector": CIVector(x: 0, y: 0, z: 0, w: CGFloat(amount)),
+        "inputBiasVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+      ]
+    )
+
+    guard let output = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: foreground,
+        kCIInputBackgroundImageKey: image,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    return output.cropped(to: image.extent)
+  }
+}
+
+extension BrightnessFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CIColorControls",
+      parameters: ["inputBrightness": value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension ContrastFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CIColorControls",
+      parameters: [kCIInputContrastKey: 1 + value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension SaturationFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CIColorControls",
+      parameters: [kCIInputSaturationKey: 1 + value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension ExposureFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    guard abs(value) > 0.0001 else {
+      return image
+    }
+    return image.applyingFilter(
+      "CIExposureAdjust",
+      parameters: [kCIInputEVKey: value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension HighlightsFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CIHighlightShadowAdjust",
+      parameters: ["inputHighlightAmount": 1 - value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension ShadowsFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CIHighlightShadowAdjust",
+      parameters: ["inputShadowAmount": value]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension HighlightShadowTintFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    let shadow = CIImage(color: shadowColor.parametricCIColor)
+      .cropped(to: image.extent)
+    guard let shadowOutput = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: shadow,
+        kCIInputBackgroundImageKey: image,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    let highlight = CIImage(color: highlightColor.parametricCIColor)
+      .cropped(to: image.extent)
+    guard let highlightOutput = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: highlight,
+        kCIInputBackgroundImageKey: shadowOutput,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    return highlightOutput.cropped(to: image.extent)
+  }
+}
+
+extension TemperatureFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    image.applyingFilter(
+      "CITemperatureAndTint",
+      parameters: [
+        "inputNeutral": CIVector(x: CGFloat(value) + 6500, y: 0),
+        "inputTargetNeutral": CIVector(x: 6500, y: 0),
+      ]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension SharpenFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    let radius = ParametricRadiusCalculator.radius(
+      value: radius,
+      max: ParametricFilterConstants.gaussianBlurSliderMax,
+      imageExtent: context.radiusReferenceExtent ?? image.extent
+    )
+    return image.applyingFilter(
+      "CISharpenLuminance",
+      parameters: [
+        "inputRadius": radius,
+        "inputSharpness": sharpness,
+      ]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension GaussianBlurFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    let radius: Double
+    switch self.radius {
+    case let .absolute(value):
+      radius = value
+    case let .editingStackFilterValue(value):
+      radius = ParametricRadiusCalculator.radius(
+        value: value,
+        max: ParametricFilterConstants.gaussianBlurSliderMax,
+        imageExtent: context.radiusReferenceExtent ?? image.extent
+      )
+    }
+
+    guard radius > 0.0001 else {
+      return image
+    }
+    return image
+      .clamped(to: image.extent)
+      .applyingFilter(
+        "CIGaussianBlur",
+        parameters: [kCIInputRadiusKey: radius]
+      )
+      .cropped(to: image.extent)
+  }
+}
+
+extension UnsharpMaskFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    let radius = ParametricRadiusCalculator.radius(
+      value: radius,
+      max: ParametricFilterConstants.unsharpMaskRadiusSliderMax,
+      imageExtent: context.radiusReferenceExtent ?? image.extent
+    )
+    return image.applyingFilter(
+      "CIUnsharpMask",
+      parameters: [
+        "inputIntensity": intensity,
+        "inputRadius": radius,
+      ]
+    )
+    .cropped(to: image.extent)
+  }
+}
+
+extension VignetteFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    ParametricVignetteRenderer.apply(value: value, to: image)
+  }
+}
+
+extension FadeFeature: ImageEffectFeatureType {
+
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    let foreground = CIImage(
+      color: CIColor(
+        red: 1,
+        green: 1,
+        blue: 1,
+        alpha: CGFloat(intensity)
+      )
+    )
+    .cropped(to: image.extent)
+
+    guard let output = CIFilter(
+      name: "CISourceOverCompositing",
+      parameters: [
+        kCIInputImageKey: foreground,
+        kCIInputBackgroundImageKey: image,
+      ]
+    )?.outputImage else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CISourceOverCompositing")
+    }
+
+    return output.cropped(to: image.extent)
+  }
+}
+
+// MARK: - Helpers
+
+extension ParametricRGBAColor {
+
+  var parametricCIColor: CIColor {
+    CIColor(
+      red: CGFloat(red),
+      green: CGFloat(green),
+      blue: CGFloat(blue),
+      alpha: CGFloat(alpha)
+    )
+  }
+}
+
+extension CGRect {
+
+  var isParametricValidExtent: Bool {
+    origin.x.isFinite
+      && origin.y.isFinite
+      && size.width.isFinite
+      && size.height.isFinite
+      && size.width > 0
+      && size.height > 0
+  }
+}

--- a/Sources/BrightroomParametric/CIImageStreamingFileWriter.swift
+++ b/Sources/BrightroomParametric/CIImageStreamingFileWriter.swift
@@ -1,0 +1,240 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+/// Encodes a (potentially very large) `CIImage` to a file with **bounded peak
+/// memory**, instead of the ~`W·H·4`-byte spike that
+/// `CIContext.write{JPEG,HEIF}Representation` / `createCGImage(from: fullExtent)`
+/// incur (they materialize the whole bitmap in RAM before encoding).
+///
+/// Strategy (system frameworks only, no third-party encoder):
+/// 1. Back the full-resolution bitmap with a memory-mapped **temp file** sized
+///    `W·H·4`. The bytes live on DISK; dirty pages flush under memory pressure,
+///    so they are not pinned in RAM.
+/// 2. Render the `CIImage` into that buffer **one horizontal strip at a time**
+///    via `CIContext.render(_:toBitmap:rowBytes:bounds:format:colorSpace:)`.
+///    `bounds` selects only the strip's source region, and Core Image pulls the
+///    exact input ROI it needs (including a blur's halo across strip edges), so
+///    the per-strip render working set is ≈ one strip + halo — not the whole
+///    image.
+/// 3. Wrap the mmap'd buffer in a `CGImage` whose pixels are supplied lazily by
+///    a direct `CGDataProvider`. `CGImageDestination` then demand-pages through
+///    the provider during encode, so the encoder never forces the whole bitmap
+///    resident either (proven pattern; see dhoerl/PhotoScroller).
+///
+/// Peak RAM ≈ one strip + Core Image render scratch + the encoder's working set,
+/// while the full-resolution bytes stay on disk. The scratch file is removed
+/// when the backing `CGImage`/provider is released (after `Finalize`).
+///
+/// - Note: The encode step's exact paging behavior is not Apple-documented;
+///   confirm the win on-device with Instruments (Allocations / VM Tracker).
+/// - Note: Output is opaque-correct. Pixels are rendered as `kCIFormatRGBA8` and
+///   tagged premultiplied-last; Brightroom's export is opaque (alpha == 1), so
+///   premultiplied vs. straight alpha is moot here.
+enum CIImageStreamingFileWriter {
+
+  enum WriterError: Swift.Error {
+    case invalidExtent
+    case scratchCreationFailed
+    case mmapFailed
+    case providerCreationFailed
+    case cgImageCreationFailed
+    case destinationCreationFailed
+    case finalizeFailed
+  }
+
+  /// Output rows rendered per `render(_:toBitmap:bounds:)` call. Bounds the
+  /// per-strip working set; smaller = lower peak (more, smaller GPU readbacks).
+  static let defaultStripHeight = 512
+
+  static func write(
+    _ image: CIImage,
+    to url: URL,
+    fileType: ParametricExportRenderer.ExportFileType,
+    context: CIContext,
+    colorSpace: CGColorSpace,
+    stripHeight: Int = defaultStripHeight
+  ) throws {
+    let extent = image.extent
+    guard
+      extent.isNull == false,
+      extent.isInfinite == false,
+      extent.width >= 1,
+      extent.height >= 1
+    else {
+      throw WriterError.invalidExtent
+    }
+
+    let width = Int(extent.width.rounded())
+    let height = Int(extent.height.rounded())
+    let bytesPerPixel = 4
+    let rowBytes = width * bytesPerPixel
+    let totalBytes = rowBytes * height
+
+    // 1. Disk-backed scratch buffer (sparse file, mmap'd).
+    let scratchURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("brightroom-export-scratch-\(UUID().uuidString).raw")
+
+    let fd = open(scratchURL.path, O_RDWR | O_CREAT | O_TRUNC, 0o600)
+    guard fd >= 0 else {
+      throw WriterError.scratchCreationFailed
+    }
+    guard ftruncate(fd, off_t(totalBytes)) == 0 else {
+      close(fd)
+      try? FileManager.default.removeItem(at: scratchURL)
+      throw WriterError.scratchCreationFailed
+    }
+    let mapped = mmap(nil, totalBytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)
+    guard let base = mapped, base != MAP_FAILED else {
+      close(fd)
+      try? FileManager.default.removeItem(at: scratchURL)
+      throw WriterError.mmapFailed
+    }
+
+    // 2. Render strip-by-strip into the mmap'd buffer.
+    //
+    // The destination buffer is top-left origin (row 0 = top), but CIImage is
+    // y-up (origin bottom-left). Display rows [top, top+h) map to the y-up band
+    // [maxY - top - h, maxY - top]; `render(_:toBitmap:bounds:)` writes that
+    // band top-first into `dst`, so placing it at row offset `top` keeps the
+    // output oriented exactly like `createCGImage`.
+    let minX = extent.minX
+    let maxY = extent.maxY
+    var top = 0
+    while top < height {
+      let h = min(stripHeight, height - top)
+      let bounds = CGRect(
+        x: minX,
+        y: maxY - CGFloat(top) - CGFloat(h),
+        width: CGFloat(width),
+        height: CGFloat(h)
+      )
+      context.render(
+        image,
+        toBitmap: base.advanced(by: top * rowBytes),
+        rowBytes: rowBytes,
+        bounds: bounds,
+        format: .RGBA8,
+        colorSpace: colorSpace
+      )
+      top += h
+    }
+
+    // 3. Lazy CGImage over the mmap'd buffer. From here the `scratch` owns the
+    //    unmap/close/unlink, run from the provider's release callback — so once
+    //    the provider (hence CGImage, hence destination) is gone, cleanup runs.
+    let scratch = MmapScratch(url: scratchURL, fd: fd, base: base, size: totalBytes)
+    let info = Unmanaged.passRetained(scratch).toOpaque()
+    var callbacks = CGDataProviderDirectCallbacks(
+      version: 0,
+      getBytePointer: { info in
+        UnsafeRawPointer(Unmanaged<MmapScratch>.fromOpaque(info!).takeUnretainedValue().base)
+      },
+      releaseBytePointer: nil,
+      getBytesAtPosition: nil,
+      releaseInfo: { info in
+        Unmanaged<MmapScratch>.fromOpaque(info!).takeRetainedValue().cleanup()
+      }
+    )
+    guard let provider = CGDataProvider(directInfo: info, size: off_t(totalBytes), callbacks: &callbacks) else {
+      Unmanaged<MmapScratch>.fromOpaque(info).release()
+      scratch.cleanup()
+      throw WriterError.providerCreationFailed
+    }
+    // `provider` now owns `scratch` cleanup via `releaseInfo`.
+
+    let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
+      | CGBitmapInfo.byteOrder32Big.rawValue
+    guard let cgImage = CGImage(
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bitsPerPixel: 32,
+      bytesPerRow: rowBytes,
+      space: colorSpace,
+      bitmapInfo: CGBitmapInfo(rawValue: bitmapInfo),
+      provider: provider,
+      decode: nil,
+      shouldInterpolate: false,
+      intent: .defaultIntent
+    ) else {
+      throw WriterError.cgImageCreationFailed
+    }
+
+    // 4. Encode. CGImageDestination demand-pages pixels through the provider.
+    let utType: UTType
+    var options: [CFString: Any] = [:]
+    switch fileType {
+    case .jpeg(let quality):
+      utType = .jpeg
+      options[kCGImageDestinationLossyCompressionQuality] = quality
+    case .heif(let quality):
+      utType = .heic
+      options[kCGImageDestinationLossyCompressionQuality] = quality
+    case .png:
+      utType = .png
+    }
+
+    guard
+      let destination = CGImageDestinationCreateWithURL(
+        url as CFURL,
+        utType.identifier as CFString,
+        1,
+        nil
+      )
+    else {
+      throw WriterError.destinationCreationFailed
+    }
+    CGImageDestinationAddImage(destination, cgImage, options as CFDictionary)
+    guard CGImageDestinationFinalize(destination) else {
+      throw WriterError.finalizeFailed
+    }
+    // `cgImage` / `provider` drop here → `scratch.cleanup()` removes the temp file.
+    withExtendedLifetime(cgImage) {}
+  }
+
+  /// Owns the lifetime of the mmap'd scratch file; `cleanup` is driven by the
+  /// `CGDataProvider`'s release callback.
+  private final class MmapScratch {
+    let url: URL
+    let fd: Int32
+    let base: UnsafeMutableRawPointer
+    let size: Int
+
+    init(url: URL, fd: Int32, base: UnsafeMutableRawPointer, size: Int) {
+      self.url = url
+      self.fd = fd
+      self.base = base
+      self.size = size
+    }
+
+    func cleanup() {
+      munmap(base, size)
+      close(fd)
+      try? FileManager.default.removeItem(at: url)
+    }
+  }
+}

--- a/Sources/BrightroomParametric/ColorCube/ColorCubeFeature+Loading.swift
+++ b/Sources/BrightroomParametric/ColorCube/ColorCubeFeature+Loading.swift
@@ -1,0 +1,289 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+
+import Accelerate
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// Errors raised while materializing a color-cube feature from a LUT file.
+public enum ColorCubeFeatureLoadingError: Error, Equatable, LocalizedError, Sendable {
+
+  /// ImageIO could not decode the LUT image.
+  case failedToCreateImage(String)
+
+  /// The image dimensions do not describe a complete three-dimensional cube.
+  case unableToInferCubeDimension(width: Int, height: Int)
+
+  /// The `.cube` file does not contain a `LUT_3D_SIZE` directive.
+  case missingLUT3DSize
+
+  /// The `LUT_3D_SIZE` value is malformed.
+  case invalidLUT3DSize(String, line: Int)
+
+  /// One-dimensional LUTs are not supported by `ColorCubeFeature`.
+  case unsupportedLUT1DSize(line: Int)
+
+  /// The parser encountered an unsupported directive.
+  case invalidDirective(String, line: Int)
+
+  /// A domain or input-range directive is malformed.
+  case invalidDomain(String, line: Int)
+
+  /// Only the default zero-to-one input domain is currently supported.
+  case unsupportedDomain(domainMin: [Float], domainMax: [Float])
+
+  /// A color data row is malformed.
+  case invalidDataLine(String, line: Int)
+
+  /// The number of color rows does not match the declared cube dimension.
+  case mismatchedDataCount(expected: Int, actual: Int)
+
+  public var errorDescription: String? {
+    switch self {
+    case .failedToCreateImage(let name):
+      return "Could not decode LUT image '\(name)'."
+    case .unableToInferCubeDimension(let width, let height):
+      return "The \(width)×\(height) LUT image does not contain a complete color cube."
+    case .missingLUT3DSize:
+      return "The LUT is missing a LUT_3D_SIZE directive."
+    case .invalidLUT3DSize(let value, let line):
+      return "Invalid LUT_3D_SIZE '\(value)' at line \(line)."
+    case .unsupportedLUT1DSize(let line):
+      return "LUT_1D_SIZE is not supported at line \(line)."
+    case .invalidDirective(let value, let line):
+      return "Invalid LUT directive '\(value)' at line \(line)."
+    case .invalidDomain(let value, let line):
+      return "Invalid LUT domain '\(value)' at line \(line)."
+    case .unsupportedDomain(let domainMin, let domainMax):
+      return "Only the default 0...1 LUT domain is supported; received \(domainMin)...\(domainMax)."
+    case .invalidDataLine(let value, let line):
+      return "Invalid LUT color data '\(value)' at line \(line)."
+    case .mismatchedDataCount(let expected, let actual):
+      return "Expected \(expected) LUT color rows, but found \(actual)."
+    }
+  }
+}
+
+extension ColorCubeFeature {
+
+  /// Creates a color-cube feature from an Adobe or DaVinci Resolve `.cube` file.
+  ///
+  /// The caller remains responsible for opening any security-scoped file access
+  /// before invoking this initializer.
+  ///
+  /// - Parameters:
+  ///   - url: The local URL of a three-dimensional `.cube` file.
+  ///   - id: A stable feature identifier. The file name is used by default.
+  ///   - name: A display name. The file's `TITLE` or base name is used by default.
+  ///   - amount: The opacity used when compositing the LUT result.
+  public init(
+    contentsOfCubeFile url: URL,
+    id: FeatureID? = nil,
+    name: String? = nil,
+    amount: Double = 1
+  ) throws {
+    let parsed = try _ColorCubeTextParser().parse(contentsOf: url)
+    let identifier = url.lastPathComponent
+    self.init(
+      id: id ?? FeatureID(rawValue: identifier),
+      name: name ?? parsed.title ?? url.deletingPathExtension().lastPathComponent,
+      identifier: identifier,
+      amount: amount,
+      dimension: parsed.dimension,
+      cubeData: parsed.cubeData
+    )
+  }
+
+  /// Creates a color-cube feature from a square Hald/CLUT PNG or JPEG file.
+  ///
+  /// When `dimension` is omitted, it is inferred from the image's pixel count,
+  /// which must equal `dimension³`.
+  ///
+  /// - Parameters:
+  ///   - url: The local URL of a square LUT image.
+  ///   - id: A stable feature identifier. The file name is used by default.
+  ///   - name: A display name. The file's base name is used by default.
+  ///   - amount: The opacity used when compositing the LUT result.
+  ///   - dimension: An explicit color-cube dimension, or `nil` to infer it.
+  public init(
+    cubeImageAt url: URL,
+    id: FeatureID? = nil,
+    name: String? = nil,
+    amount: Double = 1,
+    dimension: Int? = nil
+  ) throws {
+    guard
+      let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+      let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+    else {
+      throw ColorCubeFeatureLoadingError.failedToCreateImage(url.lastPathComponent)
+    }
+
+    let identifier = url.lastPathComponent
+    try self.init(
+      cubeImage: image,
+      id: id ?? FeatureID(rawValue: identifier),
+      name: name ?? url.deletingPathExtension().lastPathComponent,
+      identifier: identifier,
+      amount: amount,
+      dimension: dimension
+    )
+  }
+
+  /// Creates a color-cube feature from an in-memory square LUT image.
+  ///
+  /// The image is normalized to tightly packed RGBA8 pixels before conversion,
+  /// so its original bit depth and alpha layout do not leak into cube data.
+  public init(
+    cubeImage: CGImage,
+    id: FeatureID = .init(),
+    name: String,
+    identifier: String,
+    amount: Double = 1,
+    dimension: Int? = nil
+  ) throws {
+    let resolvedDimension =
+      try dimension
+      ?? Self.inferCubeDimension(width: cubeImage.width, height: cubeImage.height)
+    let cubeData = try Self.makeCubeData(
+      from: cubeImage,
+      dimension: resolvedDimension
+    )
+
+    self.init(
+      id: id,
+      name: name,
+      identifier: identifier,
+      amount: amount,
+      dimension: resolvedDimension,
+      cubeData: cubeData
+    )
+  }
+
+  /// Infers the cube dimension `d` when `width × height == d³`.
+  public static func inferCubeDimension(width: Int, height: Int) throws -> Int {
+    let (pixelCount, overflowed) = width.multipliedReportingOverflow(by: height)
+    guard overflowed == false, pixelCount > 0 else {
+      throw ColorCubeFeatureLoadingError.unableToInferCubeDimension(
+        width: width,
+        height: height
+      )
+    }
+
+    let approximate = Int(cbrt(Double(pixelCount)).rounded())
+    for candidate in [approximate - 1, approximate, approximate + 1]
+    where candidate > 1 {
+      if Self.cubePixelCount(dimension: candidate) == pixelCount {
+        return candidate
+      }
+    }
+
+    throw ColorCubeFeatureLoadingError.unableToInferCubeDimension(
+      width: width,
+      height: height
+    )
+  }
+
+  private static func makeCubeData(
+    from image: CGImage,
+    dimension: Int
+  ) throws -> Data {
+    let width = image.width
+    let height = image.height
+    guard let expectedPixelCount = Self.cubePixelCount(dimension: dimension) else {
+      throw ColorCubeFeatureLoadingError.unableToInferCubeDimension(
+        width: width,
+        height: height
+      )
+    }
+
+    let (imagePixelCount, imagePixelCountOverflowed) =
+      width.multipliedReportingOverflow(by: height)
+    guard
+      imagePixelCountOverflowed == false,
+      imagePixelCount == expectedPixelCount
+    else {
+      throw ColorCubeFeatureLoadingError.unableToInferCubeDimension(
+        width: width,
+        height: height
+      )
+    }
+
+    let componentCount = expectedPixelCount * 4
+    var rgbaBytes = [UInt8](repeating: 0, count: componentCount)
+
+    let didRender = rgbaBytes.withUnsafeMutableBytes { storage -> Bool in
+      guard
+        let context = CGContext(
+          data: storage.baseAddress,
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bytesPerRow: width * 4,
+          space: CGColorSpaceCreateDeviceRGB(),
+          bitmapInfo:
+            CGImageAlphaInfo.premultipliedLast.rawValue
+            | CGBitmapInfo.byteOrder32Big.rawValue
+        )
+      else {
+        return false
+      }
+
+      context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+      return true
+    }
+
+    guard didRender else {
+      throw ColorCubeFeatureLoadingError.failedToCreateImage("CGImage")
+    }
+
+    var floatComponents = [Float](repeating: 0, count: componentCount)
+    rgbaBytes.withUnsafeBufferPointer { input in
+      floatComponents.withUnsafeMutableBufferPointer { output in
+        guard let inputBaseAddress = input.baseAddress,
+              let outputBaseAddress = output.baseAddress
+        else {
+          return
+        }
+
+        vDSP_vfltu8(
+          inputBaseAddress,
+          1,
+          outputBaseAddress,
+          1,
+          vDSP_Length(componentCount)
+        )
+        var divisor = Float(255)
+        vDSP_vsdiv(
+          outputBaseAddress,
+          1,
+          &divisor,
+          outputBaseAddress,
+          1,
+          vDSP_Length(componentCount)
+        )
+      }
+    }
+
+    return floatComponents.withUnsafeBufferPointer { Data(buffer: $0) }
+  }
+
+  private static func cubePixelCount(dimension: Int) -> Int? {
+    guard dimension > 1 else {
+      return nil
+    }
+
+    let (square, squareOverflowed) = dimension.multipliedReportingOverflow(by: dimension)
+    let (cube, cubeOverflowed) = square.multipliedReportingOverflow(by: dimension)
+    guard
+      squareOverflowed == false,
+      cubeOverflowed == false,
+      cube <= Int.max / 4
+    else {
+      return nil
+    }
+    return cube
+  }
+}

--- a/Sources/BrightroomParametric/ColorCube/ColorCubeTextFileParser.swift
+++ b/Sources/BrightroomParametric/ColorCube/ColorCubeTextFileParser.swift
@@ -1,0 +1,233 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+
+import Foundation
+
+/// The internal representation produced while parsing a `.cube` text file.
+struct _ParsedColorCube {
+  let title: String?
+  let dimension: Int
+  let cubeData: Data
+}
+
+/// Parses three-dimensional `.cube` text without exposing parser mechanics as
+/// part of BrightroomParametric's public surface.
+struct _ColorCubeTextParser {
+
+  func parse(contentsOf url: URL) throws -> _ParsedColorCube {
+    try parse(String(contentsOf: url, encoding: .utf8))
+  }
+
+  func parse(_ string: String) throws -> _ParsedColorCube {
+    var title: String?
+    var dimension: Int?
+    var domainMin: [Float] = [0, 0, 0]
+    var domainMax: [Float] = [1, 1, 1]
+    var rows: [[Float]] = []
+
+    for (lineIndex, rawLine) in string.components(separatedBy: .newlines).enumerated() {
+      let lineNumber = lineIndex + 1
+      let line = rawLine
+        .components(separatedBy: "#")
+        .first?
+        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+      guard line.isEmpty == false else {
+        continue
+      }
+
+      let tokens = line.split(whereSeparator: \.isWhitespace).map(String.init)
+      guard let keyword = tokens.first else {
+        continue
+      }
+
+      switch keyword.uppercased() {
+      case "TITLE":
+        title = parseTitle(from: line)
+
+      case "LUT_3D_SIZE":
+        let value = tokens.dropFirst().joined(separator: " ")
+        guard tokens.count == 2,
+              let parsedDimension = Int(tokens[1]),
+              Self.cubePixelCount(dimension: parsedDimension) != nil
+        else {
+          throw ColorCubeFeatureLoadingError.invalidLUT3DSize(
+            value,
+            line: lineNumber
+          )
+        }
+        dimension = parsedDimension
+
+      case "LUT_1D_SIZE":
+        throw ColorCubeFeatureLoadingError.unsupportedLUT1DSize(line: lineNumber)
+
+      case "DOMAIN_MIN":
+        domainMin = try parseFloatValues(
+          from: tokens,
+          expectedCount: 3,
+          directive: keyword,
+          line: line,
+          lineNumber: lineNumber
+        )
+
+      case "DOMAIN_MAX":
+        domainMax = try parseFloatValues(
+          from: tokens,
+          expectedCount: 3,
+          directive: keyword,
+          line: line,
+          lineNumber: lineNumber
+        )
+
+      case "LUT_3D_INPUT_RANGE":
+        let range = try parseFloatValues(
+          from: tokens,
+          expectedCount: 2,
+          directive: keyword,
+          line: line,
+          lineNumber: lineNumber
+        )
+        domainMin = [range[0], range[0], range[0]]
+        domainMax = [range[1], range[1], range[1]]
+
+      default:
+        guard Float(keyword) != nil else {
+          throw ColorCubeFeatureLoadingError.invalidDirective(
+            keyword,
+            line: lineNumber
+          )
+        }
+
+        rows.append(
+          try parseFloatValues(
+            from: ["DATA"] + tokens,
+            expectedCount: 3,
+            directive: "DATA",
+            line: line,
+            lineNumber: lineNumber
+          )
+        )
+      }
+    }
+
+    guard let dimension else {
+      throw ColorCubeFeatureLoadingError.missingLUT3DSize
+    }
+
+    guard isDefaultDomain(domainMin: domainMin, domainMax: domainMax) else {
+      throw ColorCubeFeatureLoadingError.unsupportedDomain(
+        domainMin: domainMin,
+        domainMax: domainMax
+      )
+    }
+
+    let expectedRowCount = dimension * dimension * dimension
+    guard rows.count == expectedRowCount else {
+      throw ColorCubeFeatureLoadingError.mismatchedDataCount(
+        expected: expectedRowCount,
+        actual: rows.count
+      )
+    }
+
+    var rgbaValues: [Float] = []
+    rgbaValues.reserveCapacity(expectedRowCount * 4)
+    for row in rows {
+      rgbaValues.append(contentsOf: [row[0], row[1], row[2], 1])
+    }
+
+    return _ParsedColorCube(
+      title: title,
+      dimension: dimension,
+      cubeData: rgbaValues.withUnsafeBufferPointer { Data(buffer: $0) }
+    )
+  }
+
+  private func parseTitle(from line: String) -> String? {
+    let title = String(line.dropFirst("TITLE".count))
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard title.isEmpty == false else {
+      return nil
+    }
+
+    if title.hasPrefix("\""), title.hasSuffix("\""), title.count >= 2 {
+      return String(title.dropFirst().dropLast())
+    }
+    return title
+  }
+
+  private func parseFloatValues(
+    from tokens: [String],
+    expectedCount: Int,
+    directive: String,
+    line: String,
+    lineNumber: Int
+  ) throws -> [Float] {
+    let valueTokens = Array(tokens.dropFirst())
+    guard valueTokens.count == expectedCount else {
+      throw parseError(
+        directive: directive,
+        line: line,
+        lineNumber: lineNumber
+      )
+    }
+
+    let values = valueTokens.compactMap { token -> Float? in
+      guard let value = Float(token), value.isFinite else {
+        return nil
+      }
+      return value
+    }
+
+    guard values.count == expectedCount else {
+      throw parseError(
+        directive: directive,
+        line: line,
+        lineNumber: lineNumber
+      )
+    }
+    return values
+  }
+
+  private func parseError(
+    directive: String,
+    line: String,
+    lineNumber: Int
+  ) -> ColorCubeFeatureLoadingError {
+    if directive.hasPrefix("DOMAIN") || directive == "LUT_3D_INPUT_RANGE" {
+      return .invalidDomain(line, line: lineNumber)
+    }
+    return .invalidDataLine(line, line: lineNumber)
+  }
+
+  private func isDefaultDomain(
+    domainMin: [Float],
+    domainMax: [Float]
+  ) -> Bool {
+    let epsilon = Float(0.000001)
+    return zip(domainMin, [0, 0, 0]).allSatisfy {
+      abs($0 - Float($1)) <= epsilon
+    }
+      && zip(domainMax, [1, 1, 1]).allSatisfy {
+        abs($0 - Float($1)) <= epsilon
+      }
+  }
+
+  private static func cubePixelCount(dimension: Int) -> Int? {
+    guard dimension > 1 else {
+      return nil
+    }
+
+    let (square, squareOverflowed) = dimension.multipliedReportingOverflow(by: dimension)
+    let (cube, cubeOverflowed) = square.multipliedReportingOverflow(by: dimension)
+    guard
+      squareOverflowed == false,
+      cubeOverflowed == false,
+      cube <= Int.max / 4
+    else {
+      return nil
+    }
+    return cube
+  }
+}

--- a/Sources/BrightroomParametric/Debug/FeatureTreeView.swift
+++ b/Sources/BrightroomParametric/Debug/FeatureTreeView.swift
@@ -1,0 +1,654 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if canImport(SwiftUI)
+
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+// MARK: - Display model
+
+/// A read-only, display-oriented snapshot of one node in a feature tree.
+///
+/// `FeatureTreeNode` is a debug projection of the parametric document model: it
+/// flattens a `MainFeature`, `MaskNode`, or nested pipeline into a title, a set
+/// of scalar parameter fields, and child nodes. It carries no rendering or
+/// editing capability — it exists purely so a viewer can present the structure
+/// of an `EditingDocument` without each call site re-implementing the type
+/// switch over the parametric vocabulary.
+public struct FeatureTreeNode: Identifiable, Sendable {
+
+  /// A single scalar parameter shown under a node.
+  public struct Field: Identifiable, Sendable {
+
+    /// A stable identity within a node, derived from the parameter name.
+    public var id: String { name }
+
+    /// The human-readable parameter name.
+    public var name: String
+
+    /// The formatted parameter value.
+    public var value: String
+
+    /// Creates a parameter field.
+    public init(name: String, value: String) {
+      self.name = name
+      self.value = value
+    }
+  }
+
+  /// A stable, tree-position identity used for view diffing.
+  ///
+  /// This is the node's path in the tree (for example `1.0`), not the parametric
+  /// `FeatureID`. Mask combinators such as `union` do not carry a `FeatureID`,
+  /// so a positional path is the only identity guaranteed to be unique.
+  public let id: String
+
+  /// The display title (for example `Exposure`, `Crop`, `Local Adjustment`).
+  public var title: String
+
+  /// The originating Swift type name, kept for debugging.
+  public var typeName: String
+
+  /// A compact one-line summary shown in the collapsed label, if any.
+  public var summary: String?
+
+  /// Whether the underlying feature contributes to rendering.
+  public var isEnabled: Bool
+
+  /// An SF Symbol name used as the node's leading icon.
+  public var symbolName: String
+
+  /// The scalar parameters of this node.
+  public var fields: [Field]
+
+  /// The child nodes evaluated or composed inside this node.
+  public var children: [FeatureTreeNode]
+
+  /// Creates a feature tree node.
+  public init(
+    id: String,
+    title: String,
+    typeName: String,
+    summary: String? = nil,
+    isEnabled: Bool,
+    symbolName: String,
+    fields: [Field] = [],
+    children: [FeatureTreeNode] = []
+  ) {
+    self.id = id
+    self.title = title
+    self.typeName = typeName
+    self.summary = summary
+    self.isEnabled = isEnabled
+    self.symbolName = symbolName
+    self.fields = fields
+    self.children = children
+  }
+}
+
+// MARK: - Descriptor builder
+
+/// Builds `FeatureTreeNode` snapshots from a parametric document.
+///
+/// The builder walks the document with explicit handling for structural
+/// containers (effect pipelines, presets, local adjustments, mask trees) and
+/// falls back to `Mirror` reflection for the scalar parameters of any leaf
+/// feature. New leaf features therefore appear automatically without changes
+/// here; only new structural containers need a dedicated case.
+public enum FeatureTreeDescriptor {
+
+  /// Builds the top-level nodes for a document's main tree.
+  public static func nodes(for document: EditingDocument) -> [FeatureTreeNode] {
+    document.mainTree.features.enumerated().map { index, feature in
+      node(for: feature, path: "\(index)")
+    }
+  }
+
+  // MARK: Main tree
+
+  static func node(for feature: MainFeature, path: String) -> FeatureTreeNode {
+    switch feature {
+    case let .domain(domain):
+      return domainNode(domain, path: path)
+    case let .effect(effect):
+      return effectNode(effect, path: path)
+    case let .localAdjustment(adjustment):
+      return localAdjustmentNode(adjustment, path: path)
+    }
+  }
+
+  static func domainNode(_ domain: any DomainFeatureType, path: String) -> FeatureTreeNode {
+    let typeName = String(describing: type(of: domain))
+    let params = reflectedFields(of: domain)
+    return FeatureTreeNode(
+      id: path,
+      title: humanizeType(typeName),
+      typeName: typeName,
+      summary: summarize(params),
+      isEnabled: domain.isEnabled,
+      symbolName: domain is CropFeature ? "crop" : "skew",
+      fields: params + [idField(domain.id)],
+      children: []
+    )
+  }
+
+  static func effectNode(_ effect: any ImageEffectFeatureType, path: String) -> FeatureTreeNode {
+    if let bundle = effect as? EffectPipelineFeature {
+      return pipelineNode(
+        id: path,
+        title: "Effects",
+        typeName: "EffectPipelineFeature",
+        summary: count(bundle.pipeline.effects.count, "effect"),
+        isEnabled: bundle.isEnabled,
+        symbolName: "slider.horizontal.3",
+        idField: idField(bundle.id),
+        effects: bundle.pipeline.effects,
+        path: path
+      )
+    }
+
+    if let preset = effect as? PresetFeature {
+      let params = [
+        FeatureTreeNode.Field(name: "Name", value: preset.name),
+        FeatureTreeNode.Field(name: "Identifier", value: preset.identifier),
+      ]
+      return pipelineNode(
+        id: path,
+        title: "Preset",
+        typeName: "PresetFeature",
+        summary: preset.name,
+        isEnabled: preset.isEnabled,
+        symbolName: "camera.filters",
+        fields: params + [idField(preset.id)],
+        effects: preset.effects,
+        path: path
+      )
+    }
+
+    let typeName = String(describing: type(of: effect))
+    let params = reflectedFields(of: effect)
+    return FeatureTreeNode(
+      id: path,
+      title: humanizeType(typeName),
+      typeName: typeName,
+      summary: summarize(params),
+      isEnabled: effect.isEnabled,
+      symbolName: symbol(forEffectType: typeName),
+      fields: params + [idField(effect.id)],
+      children: []
+    )
+  }
+
+  static func localAdjustmentNode(
+    _ adjustment: LocalAdjustmentFeature,
+    path: String
+  ) -> FeatureTreeNode {
+    let mask = maskTreeNode(adjustment.maskTree, path: "\(path).mask")
+    let effects = pipelineNode(
+      id: "\(path).effects",
+      title: "Effects",
+      typeName: "EffectPipeline",
+      summary: count(adjustment.effectPipeline.effects.count, "effect"),
+      isEnabled: true,
+      symbolName: "slider.horizontal.3",
+      effects: adjustment.effectPipeline.effects,
+      path: "\(path).effects"
+    )
+    let params = [FeatureTreeNode.Field(name: "Blend Mode", value: adjustment.blendMode.rawValue)]
+    return FeatureTreeNode(
+      id: path,
+      title: "Local Adjustment",
+      typeName: "LocalAdjustmentFeature",
+      summary: adjustment.blendMode.rawValue,
+      isEnabled: adjustment.isEnabled,
+      symbolName: "circle.dashed.inset.filled",
+      fields: params + [idField(adjustment.id)],
+      children: [mask, effects]
+    )
+  }
+
+  // MARK: Mask tree
+
+  static func maskTreeNode(_ tree: MaskTree, path: String) -> FeatureTreeNode {
+    FeatureTreeNode(
+      id: path,
+      title: "Mask",
+      typeName: "MaskTree",
+      isEnabled: true,
+      symbolName: "theatermasks",
+      children: [maskNode(tree.root, path: "\(path).0")]
+    )
+  }
+
+  static func maskNode(_ node: MaskNode, path: String) -> FeatureTreeNode {
+    switch node {
+    case let .brush(brush):
+      let stamps = brush.strokes.reduce(0) { $0 + $1.stamps.count }
+      let fields = [
+        FeatureTreeNode.Field(name: "Strokes", value: "\(brush.strokes.count)"),
+        FeatureTreeNode.Field(name: "Stamps", value: "\(stamps)"),
+      ]
+      return FeatureTreeNode(
+        id: path,
+        title: "Brush",
+        typeName: "BrushMask",
+        summary: count(brush.strokes.count, "stroke"),
+        isEnabled: brush.isEnabled,
+        symbolName: "paintbrush.pointed",
+        fields: fields + [idField(brush.id)]
+      )
+
+    case let .invert(inner):
+      return FeatureTreeNode(
+        id: path,
+        title: "Invert",
+        typeName: "MaskNode.invert",
+        isEnabled: true,
+        symbolName: "circle.lefthalf.filled",
+        children: [maskNode(inner, path: "\(path).0")]
+      )
+
+    case let .feather(feather):
+      let radius = FeatureValueFormatter.number(feather.radius)
+      return FeatureTreeNode(
+        id: path,
+        title: "Feather",
+        typeName: "MaskFeather",
+        summary: "radius \(radius)",
+        isEnabled: feather.isEnabled,
+        symbolName: "drop",
+        fields: [FeatureTreeNode.Field(name: "Radius", value: radius), idField(feather.id)],
+        children: [maskNode(feather.input, path: "\(path).0")]
+      )
+
+    case let .union(nodes):
+      return FeatureTreeNode(
+        id: path,
+        title: "Union",
+        typeName: "MaskNode.union",
+        summary: count(nodes.count, "input"),
+        isEnabled: true,
+        symbolName: "plus.circle",
+        children: nodes.enumerated().map { maskNode($1, path: "\(path).\($0)") }
+      )
+
+    case let .intersect(nodes):
+      return FeatureTreeNode(
+        id: path,
+        title: "Intersect",
+        typeName: "MaskNode.intersect",
+        summary: count(nodes.count, "input"),
+        isEnabled: true,
+        symbolName: "circle.circle",
+        children: nodes.enumerated().map { maskNode($1, path: "\(path).\($0)") }
+      )
+
+    case let .subtract(subtract):
+      return FeatureTreeNode(
+        id: path,
+        title: "Subtract",
+        typeName: "MaskSubtract",
+        isEnabled: subtract.isEnabled,
+        symbolName: "minus.circle",
+        fields: [idField(subtract.id)],
+        children: [
+          labeledMaskChild("Base", subtract.base, path: "\(path).base"),
+          labeledMaskChild("Removing", subtract.removing, path: "\(path).removing"),
+        ]
+      )
+    }
+  }
+
+  // MARK: Helpers
+
+  private static func pipelineNode(
+    id: String,
+    title: String,
+    typeName: String,
+    summary: String?,
+    isEnabled: Bool,
+    symbolName: String,
+    fields: [FeatureTreeNode.Field] = [],
+    idField: FeatureTreeNode.Field? = nil,
+    effects: [any ImageEffectFeatureType],
+    path: String
+  ) -> FeatureTreeNode {
+    var allFields = fields
+    if let idField {
+      allFields.append(idField)
+    }
+    return FeatureTreeNode(
+      id: id,
+      title: title,
+      typeName: typeName,
+      summary: summary,
+      isEnabled: isEnabled,
+      symbolName: symbolName,
+      fields: allFields,
+      children: effects.enumerated().map { effectNode($1, path: "\(path).\($0)") }
+    )
+  }
+
+  private static func labeledMaskChild(
+    _ label: String,
+    _ node: MaskNode,
+    path: String
+  ) -> FeatureTreeNode {
+    var child = maskNode(node, path: path)
+    child.title = "\(label): \(child.title)"
+    return child
+  }
+
+  private static func idField(_ id: FeatureID) -> FeatureTreeNode.Field {
+    .init(name: "ID", value: id.rawValue)
+  }
+
+  /// Reflects the scalar stored properties of a feature, skipping the structural
+  /// `id` / `isEnabled` properties surfaced elsewhere.
+  private static func reflectedFields(
+    of feature: Any,
+    skipping: Set<String> = ["id", "isEnabled"]
+  ) -> [FeatureTreeNode.Field] {
+    Mirror(reflecting: feature).children.compactMap { child in
+      guard let label = child.label, skipping.contains(label) == false else {
+        return nil
+      }
+      return .init(name: humanizeLabel(label), value: FeatureValueFormatter.string(for: child.value))
+    }
+  }
+
+  private static func summarize(_ fields: [FeatureTreeNode.Field], max: Int = 2) -> String? {
+    guard fields.isEmpty == false else {
+      return nil
+    }
+    return fields.prefix(max).map { "\($0.name) \($0.value)" }.joined(separator: " · ")
+  }
+
+  private static func count(_ value: Int, _ noun: String) -> String {
+    "\(value) \(noun)\(value == 1 ? "" : "s")"
+  }
+
+  private static func symbol(forEffectType typeName: String) -> String {
+    switch typeName {
+    case "GaussianBlurFeature": return "drop.fill"
+    case "UnsharpMaskFeature", "SharpenFeature": return "triangle"
+    case "ColorCubeFeature": return "swatchpalette"
+    case "VignetteFeature": return "circle.and.line.horizontal"
+    case "TemperatureFeature": return "thermometer.medium"
+    case "FadeFeature": return "sun.haze"
+    case "HighlightShadowTintFeature": return "paintpalette"
+    default: return "dial.medium"
+    }
+  }
+
+  private static func humanizeType(_ typeName: String) -> String {
+    var name = typeName
+    if name.hasSuffix("Feature") {
+      name.removeLast("Feature".count)
+    }
+    return splitCamelCase(name)
+  }
+
+  private static func humanizeLabel(_ label: String) -> String {
+    let split = splitCamelCase(label)
+    return split.prefix(1).uppercased() + split.dropFirst()
+  }
+
+  private static func splitCamelCase(_ value: String) -> String {
+    var result = ""
+    for (index, character) in value.enumerated() {
+      if character.isUppercase, index != 0 {
+        result.append(" ")
+      }
+      result.append(character)
+    }
+    return result
+  }
+}
+
+// MARK: - Value formatting
+
+private enum FeatureValueFormatter {
+
+  static func string(for value: Any) -> String {
+    let value = unwrap(value)
+    switch value {
+    case let value as Bool:
+      return value ? "true" : "false"
+    case let value as Int:
+      return String(value)
+    case let value as Double:
+      return number(value)
+    case let value as Float:
+      return number(Double(value))
+    case let value as CGFloat:
+      return number(Double(value))
+    case let value as String:
+      return value.isEmpty ? "\"\"" : value
+    case let value as CGRect:
+      return "(\(number(value.minX)), \(number(value.minY)), \(number(value.width)), \(number(value.height)))"
+    case let value as CGPoint:
+      return "(\(number(value.x)), \(number(value.y)))"
+    case let value as CGSize:
+      return "\(number(value.width)) × \(number(value.height))"
+    case let value as Data:
+      return ByteCountFormatter.string(fromByteCount: Int64(value.count), countStyle: .memory)
+    case let value as ParametricRGBAColor:
+      return "rgba(\(number(value.red)), \(number(value.green)), \(number(value.blue)), \(number(value.alpha)))"
+    case let value as QuarterTurn:
+      return "\(value.rawValue)°"
+    case let value as FeatureID:
+      return value.rawValue
+    case let value as LocalAdjustmentBlendMode:
+      return value.rawValue
+    case let value as GaussianBlurRadius:
+      switch value {
+      case let .absolute(radius):
+        return "absolute(\(number(radius)))"
+      case let .editingStackFilterValue(radius):
+        return "value(\(number(radius)))"
+      }
+    default:
+      return String(describing: value)
+    }
+  }
+
+  static func number(_ value: Double) -> String {
+    guard value.isFinite else {
+      return String(describing: value)
+    }
+    if value == value.rounded(), abs(value) < 1e15 {
+      return String(Int(value))
+    }
+    var text = String(format: "%.4f", value)
+    while text.hasSuffix("0") {
+      text.removeLast()
+    }
+    if text.hasSuffix(".") {
+      text.removeLast()
+    }
+    return text
+  }
+
+  private static func unwrap(_ value: Any) -> Any {
+    let mirror = Mirror(reflecting: value)
+    guard mirror.displayStyle == .optional else {
+      return value
+    }
+    return mirror.children.first?.value ?? value
+  }
+}
+
+// MARK: - Views
+
+/// A standalone, `List`-based viewer for a parametric feature tree.
+///
+/// This is a debug component: it presents the structure of an `EditingDocument`
+/// as a hierarchy of `DisclosureGroup`s so the features used to produce a render
+/// can be inspected. To embed the rows inside an existing `List` or `Form`, use
+/// ``FeatureTreeOutline`` instead.
+public struct FeatureTreeView: View {
+
+  private let nodes: [FeatureTreeNode]
+
+  /// Creates a viewer for a parametric document.
+  public init(document: EditingDocument) {
+    self.nodes = FeatureTreeDescriptor.nodes(for: document)
+  }
+
+  /// Creates a viewer for pre-built nodes.
+  public init(nodes: [FeatureTreeNode]) {
+    self.nodes = nodes
+  }
+
+  public var body: some View {
+    List {
+      FeatureTreeOutline(nodes: nodes)
+    }
+  }
+}
+
+/// The recursive rows of a feature tree, suitable for embedding inside a host
+/// `List`, `Form`, or `Section`.
+///
+/// Use this when the feature tree should appear as one section among others (for
+/// example under a rendered-result preview). For a self-contained screen use
+/// ``FeatureTreeView``.
+public struct FeatureTreeOutline: View {
+
+  private let nodes: [FeatureTreeNode]
+
+  /// Creates an outline for a parametric document.
+  public init(document: EditingDocument) {
+    self.nodes = FeatureTreeDescriptor.nodes(for: document)
+  }
+
+  /// Creates an outline for pre-built nodes.
+  public init(nodes: [FeatureTreeNode]) {
+    self.nodes = nodes
+  }
+
+  public var body: some View {
+    ForEach(nodes) { node in
+      FeatureTreeNodeRow(node: node, depth: 0)
+    }
+  }
+}
+
+private struct FeatureTreeNodeRow: View {
+
+  let node: FeatureTreeNode
+  let depth: Int
+
+  @State private var isExpanded: Bool
+
+  init(node: FeatureTreeNode, depth: Int) {
+    self.node = node
+    self.depth = depth
+    // Expand the top level by default; collapse nested structure so deep trees
+    // stay scannable.
+    _isExpanded = State(initialValue: depth == 0)
+  }
+
+  private var hasDetail: Bool {
+    node.fields.isEmpty == false || node.children.isEmpty == false
+  }
+
+  var body: some View {
+    if hasDetail {
+      DisclosureGroup(isExpanded: $isExpanded) {
+        ForEach(node.fields) { field in
+          FeatureTreeFieldRow(field: field)
+        }
+        ForEach(node.children) { child in
+          FeatureTreeNodeRow(node: child, depth: depth + 1)
+        }
+      } label: {
+        FeatureTreeNodeLabel(node: node)
+      }
+    } else {
+      FeatureTreeNodeLabel(node: node)
+    }
+  }
+}
+
+private struct FeatureTreeNodeLabel: View {
+
+  let node: FeatureTreeNode
+
+  var body: some View {
+    HStack(spacing: 10) {
+      Image(systemName: node.symbolName)
+        .font(.callout)
+        .frame(width: 22)
+        .foregroundStyle(node.isEnabled ? Color.accentColor : Color.secondary)
+
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 6) {
+          Text(node.title)
+            .font(.callout.weight(.medium))
+
+          if node.isEnabled == false {
+            Text("disabled")
+              .font(.caption2.weight(.semibold))
+              .padding(.horizontal, 5)
+              .padding(.vertical, 1)
+              .background(Color.secondary.opacity(0.18), in: Capsule())
+              .foregroundStyle(.secondary)
+          }
+        }
+
+        if let summary = node.summary, summary.isEmpty == false {
+          Text(summary)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+        }
+      }
+    }
+    .opacity(node.isEnabled ? 1 : 0.55)
+  }
+}
+
+private struct FeatureTreeFieldRow: View {
+
+  let field: FeatureTreeNode.Field
+
+  var body: some View {
+    HStack(alignment: .firstTextBaseline, spacing: 12) {
+      Text(field.name)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+
+      Spacer(minLength: 12)
+
+      Text(field.value)
+        .font(.caption.monospaced())
+        .foregroundStyle(.primary)
+        .multilineTextAlignment(.trailing)
+        .textSelection(.enabled)
+    }
+  }
+}
+
+#endif

--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -1,0 +1,444 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Compiles a parametric editing document into a Core Image graph.
+///
+/// The compiler returns `CIImage` recipes and does not create intermediate
+/// `CGImage` or `CGContext` values. Callers choose when and how to materialize
+/// the returned image through `CIContext`.
+///
+/// Feature evaluation is native protocol dispatch: effects and domain features
+/// implement `apply(to:context:)` themselves. The compiler owns the document
+/// walk, tree-level validation, local-adjustment compositing, and the
+/// mask-tree renderer.
+public struct FeatureGraphCompiler: Sendable {
+
+  /// Rendering options for the feature graph compiler.
+  public struct Options: Equatable, Sendable {
+
+    /// A Boolean value indicating whether the input image should be translated
+    /// to zero origin before the first feature is evaluated.
+    public var normalizesInputExtent: Bool
+
+    /// Creates compiler options.
+    public init(normalizesInputExtent: Bool = true) {
+      self.normalizesInputExtent = normalizesInputExtent
+    }
+  }
+
+  /// The options used during compilation.
+  public var options: Options
+
+  /// The kernel registry used for custom Core Image operations.
+  public var kernelRegistry: ParametricKernelRegistry
+
+  /// Creates a feature graph compiler.
+  public init(
+    options: Options = .init(),
+    kernelRegistry: ParametricKernelRegistry = .init()
+  ) {
+    self.options = options
+    self.kernelRegistry = kernelRegistry
+  }
+
+  /// Compiles and evaluates a document from an input image.
+  ///
+  /// - Parameters:
+  ///   - input: The source image used as the first graph node.
+  ///   - document: The parametric document to evaluate.
+  /// - Returns: The final image recipe and debug mask outputs.
+  public func makeOutput(
+    from input: CIImage,
+    document: EditingDocument,
+    radiusReferenceExtent: CGRect? = nil
+  ) throws -> FeatureGraphOutput {
+    try validate(document)
+
+    let context = FeatureEvaluationContext(
+      kernelRegistry: kernelRegistry,
+      radiusReferenceExtent: radiusReferenceExtent
+    )
+    var image = options.normalizesInputExtent ? ParametricImageGeometry.removingExtentOffset(input) : input
+    var localAdjustmentMasks: [FeatureID: CIImage] = [:]
+
+    for feature in document.mainTree.features where feature.isEnabled {
+      switch feature {
+      case let .domain(domainFeature):
+        image = try domainFeature.apply(to: image, context: context)
+
+      case let .effect(effect):
+        image = try effect.apply(to: image, context: context)
+
+      case let .localAdjustment(localAdjustment):
+        let output = try apply(localAdjustment, to: image, context: context)
+        image = output.image
+        localAdjustmentMasks[localAdjustment.id] = output.mask
+      }
+    }
+
+    return FeatureGraphOutput(
+      image: image,
+      localAdjustmentMasks: localAdjustmentMasks
+    )
+  }
+
+  /// Renders a mask tree to an alpha image covering the given extent.
+  ///
+  /// Brush stamps are interpreted in Core Image working-space coordinates
+  /// (bottom-left origin, y-up). Callers holding masks authored in a y-down
+  /// display space flip at this boundary.
+  public func renderMask(_ tree: MaskTree, extent: CGRect) throws -> CIImage {
+    try render(tree, extent: extent)
+  }
+}
+
+/// The result of compiling a parametric feature graph.
+public struct FeatureGraphOutput: Sendable {
+
+  /// The final output image recipe.
+  public var image: CIImage
+
+  /// Evaluated local adjustment masks keyed by their owning feature ID.
+  public var localAdjustmentMasks: [FeatureID: CIImage]
+
+  /// Creates compiler output.
+  public init(
+    image: CIImage,
+    localAdjustmentMasks: [FeatureID: CIImage] = [:]
+  ) {
+    self.image = image
+    self.localAdjustmentMasks = localAdjustmentMasks
+  }
+}
+
+/// Errors thrown while compiling a parametric feature graph.
+public enum FeatureGraphCompilerError: Error, Equatable, Sendable {
+
+  /// Two features or mask nodes use the same ID.
+  case duplicateID(FeatureID)
+
+  /// A local adjustment has no enabled effect to apply.
+  case emptyLocalAdjustmentEffectPipeline(FeatureID)
+
+  /// A composite mask operation has no children.
+  case emptyMaskComposite(FeatureID?)
+
+  /// A crop rectangle cannot produce a valid image extent.
+  case invalidCropRect(FeatureID, CGRect)
+
+  /// Core Image returned nil while applying a named filter or kernel.
+  case failedToCreateImage(String)
+
+  /// A color-cube feature contains data that cannot match its dimension.
+  case invalidColorCubeData(FeatureID, expectedByteCount: Int, actualByteCount: Int)
+}
+
+private extension FeatureGraphCompiler {
+
+  func apply(
+    _ localAdjustment: LocalAdjustmentFeature,
+    to base: CIImage,
+    context: FeatureEvaluationContext
+  ) throws -> (image: CIImage, mask: CIImage) {
+    guard localAdjustment.isEnabled else {
+      return (base, CIImage.parametricTransparent(extent: base.extent))
+    }
+
+    let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+    guard enabledEffects.isEmpty == false else {
+      throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+    }
+
+    let adjusted = try enabledEffects.reduce(base) { image, effect in
+      try effect.apply(to: image, context: context)
+    }
+    let mask = try render(localAdjustment.maskTree, extent: base.extent)
+
+    switch localAdjustment.blendMode {
+    case .alpha:
+      let composited = adjusted.applyingFilter(
+        "CIBlendWithAlphaMask",
+        parameters: [
+          kCIInputBackgroundImageKey: base,
+          kCIInputMaskImageKey: mask,
+        ]
+      )
+      .cropped(to: base.extent)
+      return (composited, mask)
+    }
+  }
+
+  func render(_ maskTree: MaskTree, extent: CGRect) throws -> CIImage {
+    try render(maskTree.root, extent: extent)
+      .cropped(to: extent)
+  }
+
+  func render(_ node: MaskNode, extent: CGRect) throws -> CIImage {
+    switch node {
+    case let .brush(mask):
+      return try render(mask, extent: extent)
+
+    case let .invert(input):
+      let inputImage = try render(input, extent: extent)
+      return inputImage.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 0, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: -1),
+          "inputBiasVector": CIVector(x: 1, y: 1, z: 1, w: 1),
+        ]
+      )
+      .cropped(to: extent)
+
+    case let .feather(feather):
+      let inputImage = try render(feather.input, extent: extent)
+      guard feather.isEnabled, feather.radius > 0.0001 else {
+        return inputImage
+      }
+      return inputImage
+        .clamped(to: extent)
+        .applyingFilter(
+          "CIGaussianBlur",
+          parameters: [kCIInputRadiusKey: feather.radius]
+        )
+        .cropped(to: extent)
+
+    case let .union(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      return try nodes.reduce(CIImage.parametricTransparent(extent: extent)) { accumulated, node in
+        let next = try render(node, extent: extent)
+        return try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMax,
+          extent: extent
+        )
+      }
+
+    case let .intersect(nodes):
+      guard let first = nodes.first else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      var accumulated = try render(first, extent: extent)
+      for node in nodes.dropFirst() {
+        let next = try render(node, extent: extent)
+        accumulated = try blendMask(
+          foreground: next,
+          background: accumulated,
+          kernel: .componentMultiply,
+          extent: extent
+        )
+      }
+      return accumulated.cropped(to: extent)
+
+    case let .subtract(subtract):
+      let base = try render(subtract.base, extent: extent)
+      guard subtract.isEnabled else {
+        return base
+      }
+      let removing = try render(subtract.removing, extent: extent)
+      return try kernelRegistry.subtractMask(
+        base: base,
+        removing: removing,
+        extent: extent
+      )
+    }
+  }
+
+  func render(_ mask: BrushMask, extent: CGRect) throws -> CIImage {
+    guard mask.isEnabled else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    // Each stamp compiles to one CIImage layer. `componentMax` is associative
+    // and commutative, so the stamps reduce in any grouping; folding them in a
+    // balanced tree keeps the Core Image graph depth at O(log n) instead of
+    // O(n). A dense brush (small spacing) emits hundreds–thousands of stamps
+    // per stroke, and a linear fold built a chain that deep — slow to compile
+    // and at risk of stack overflow during render. The tree keeps the same
+    // node count and the same result.
+    var stampImages: [CIImage] = []
+    for stroke in mask.strokes {
+      let radius = max(stroke.brush.diameter / 2, 0)
+      for stamp in stroke.stamps {
+        stampImages.append(
+          try kernelRegistry.makeBrushStamp(
+            extent: extent,
+            center: stamp,
+            radius: radius,
+            hardness: stroke.brush.hardness,
+            opacity: stroke.brush.opacity
+          )
+        )
+      }
+    }
+
+    return try reduceComponentMax(stampImages, extent: extent)
+  }
+
+  /// Reduces mask layers with `componentMax` in a balanced tree so the Core
+  /// Image graph depth stays O(log n). `componentMax` is associative and
+  /// commutative and `componentMax(transparent, x) == x`, so the pairwise
+  /// grouping produces the same alpha field as a linear fold over a transparent
+  /// base.
+  private func reduceComponentMax(_ images: [CIImage], extent: CGRect) throws -> CIImage {
+    guard images.isEmpty == false else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    var level = images
+    while level.count > 1 {
+      var next: [CIImage] = []
+      next.reserveCapacity((level.count + 1) / 2)
+      var index = 0
+      while index < level.count {
+        if index + 1 < level.count {
+          next.append(
+            try blendMask(
+              foreground: level[index + 1],
+              background: level[index],
+              kernel: .componentMax,
+              extent: extent
+            )
+          )
+        } else {
+          next.append(level[index])
+        }
+        index += 2
+      }
+      level = next
+    }
+
+    return level[0].cropped(to: extent)
+  }
+
+  func blendMask(
+    foreground: CIImage,
+    background: CIImage,
+    kernel: CIBlendKernel,
+    extent: CGRect
+  ) throws -> CIImage {
+    guard let output = kernel.apply(
+      foreground: foreground,
+      background: background
+    ) else {
+      throw FeatureGraphCompilerError.failedToCreateImage("CIBlendKernel")
+    }
+    return output.cropped(to: extent)
+  }
+}
+
+private extension FeatureGraphCompiler {
+
+  func validate(_ document: EditingDocument) throws {
+    var ids = Set<FeatureID>()
+
+    func insert(_ id: FeatureID) throws {
+      guard ids.insert(id).inserted else {
+        throw FeatureGraphCompilerError.duplicateID(id)
+      }
+    }
+
+    for feature in document.mainTree.features {
+      try insert(feature.id)
+
+      switch feature {
+      case let .domain(domainFeature):
+        try domainFeature.validate()
+
+      case let .effect(effect):
+        try effect.validate()
+        try validateChildren(of: effect, insert: insert)
+
+      case let .localAdjustment(localAdjustment):
+        let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+        guard enabledEffects.isEmpty == false else {
+          throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+        }
+
+        for effect in localAdjustment.effectPipeline.effects {
+          try insert(effect.id)
+          try effect.validate()
+          try validateChildren(of: effect, insert: insert)
+        }
+        try validate(localAdjustment.maskTree.root, insert: insert)
+      }
+    }
+  }
+
+  func validateChildren(
+    of effect: any ImageEffectFeatureType,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    for child in effect.childFeatures {
+      try insert(child.id)
+      if let childEffect = child as? any ImageEffectFeatureType {
+        try childEffect.validate()
+        try validateChildren(of: childEffect, insert: insert)
+      }
+    }
+  }
+
+  func validate(
+    _ node: MaskNode,
+    insert: (FeatureID) throws -> Void
+  ) throws {
+    switch node {
+    case let .brush(mask):
+      try insert(mask.id)
+
+    case let .invert(input):
+      try validate(input, insert: insert)
+
+    case let .feather(feather):
+      try insert(feather.id)
+      try validate(feather.input, insert: insert)
+
+    case let .union(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      for node in nodes {
+        try validate(node, insert: insert)
+      }
+
+    case let .intersect(nodes):
+      guard nodes.isEmpty == false else {
+        throw FeatureGraphCompilerError.emptyMaskComposite(nil)
+      }
+      for node in nodes {
+        try validate(node, insert: insert)
+      }
+
+    case let .subtract(subtract):
+      try insert(subtract.id)
+      try validate(subtract.base, insert: insert)
+      try validate(subtract.removing, insert: insert)
+    }
+  }
+}

--- a/Sources/BrightroomParametric/ParametricDocumentCodec.swift
+++ b/Sources/BrightroomParametric/ParametricDocumentCodec.swift
@@ -1,0 +1,607 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+// The persistence boundary of the parametric document.
+//
+// The runtime document is a Swift-native value tree and is not a text
+// document. Serialization goes through `ParametricDocumentCodec`, which owns
+// a type registry in the `UICollectionView.register(_:forCellWithReuseIdentifier:)`
+// shape: the host registers (type key → params type) pairs; decode resolves
+// keys once and produces typed values directly from the document stream.
+// There is no intermediate JSON representation; an unregistered key on decode
+// is an error, and schema migration is typed decoding of old versions.
+
+/// A serialized identifier for a persistable feature type.
+public struct FeatureTypeKey: Hashable, Codable, Sendable, RawRepresentable,
+  ExpressibleByStringLiteral
+{
+
+  public var rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public init(stringLiteral value: String) {
+    self.rawValue = value
+  }
+}
+
+/// A feature that can be persisted by `ParametricDocumentCodec`.
+///
+/// Conforming types encode their parameters with their own `Codable`
+/// implementation and decode old schema versions by declaring the old shape
+/// as a private `Decodable` struct and converting — migration is typed and
+/// compiler-checked.
+public protocol PersistableFeature: Feature, Codable {
+
+  /// The serialized identifier resolved through the codec's registrations.
+  static var featureTypeKey: FeatureTypeKey { get }
+
+  /// The schema version written by `Codable` encoding.
+  static var schemaVersion: Int { get }
+
+  /// Decodes parameters that were written with the given schema version.
+  static func decodeParameters(from decoder: Decoder, version: Int) throws -> Self
+}
+
+extension PersistableFeature {
+
+  public static var schemaVersion: Int { 1 }
+
+  public static func decodeParameters(from decoder: Decoder, version: Int) throws -> Self {
+    guard version == schemaVersion else {
+      throw ParametricDocumentCodecError.unsupportedSchemaVersion(
+        featureTypeKey,
+        version: version
+      )
+    }
+    return try Self(from: decoder)
+  }
+}
+
+/// Errors thrown by the document codec.
+public enum ParametricDocumentCodecError: Error, Equatable, Sendable {
+
+  /// The document references a feature type key that has not been registered.
+  case unregisteredFeatureType(FeatureTypeKey)
+
+  /// The document stores a schema version the type cannot decode.
+  case unsupportedSchemaVersion(FeatureTypeKey, version: Int)
+
+  /// The runtime document contains a feature that does not conform to
+  /// `PersistableFeature`.
+  case notPersistable(typeName: String)
+
+  /// Coding ran without a codec; use `ParametricDocumentCodec`.
+  case missingRegistry
+
+  /// The document's structural format version is not supported by this
+  /// library version.
+  case unsupportedDocumentFormatVersion(Int)
+}
+
+/// The registered (type key → params type) pairs used at the persistence
+/// boundary. Registration captures capability-typed decode functions so
+/// decoded values come back as the correct existential.
+public struct ParametricFeatureTypeRegistry: Sendable {
+
+  private var imageEffectDecoders:
+    [FeatureTypeKey: @Sendable (Decoder, Int) throws -> any ImageEffectFeatureType] = [:]
+  private var domainDecoders:
+    [FeatureTypeKey: @Sendable (Decoder, Int) throws -> any DomainFeatureType] = [:]
+
+  public init() {}
+
+  /// Registers an image-effect params type for persistence.
+  ///
+  /// Registering the same `featureTypeKey` again replaces the earlier
+  /// registration (last wins), mirroring `UICollectionView.register`.
+  public mutating func register<T: PersistableFeature & ImageEffectFeatureType>(_ type: T.Type) {
+    imageEffectDecoders[T.featureTypeKey] = { decoder, version in
+      try T.decodeParameters(from: decoder, version: version)
+    }
+  }
+
+  /// Registers a domain-feature params type for persistence.
+  public mutating func register<T: PersistableFeature & DomainFeatureType>(_ type: T.Type) {
+    domainDecoders[T.featureTypeKey] = { decoder, version in
+      try T.decodeParameters(from: decoder, version: version)
+    }
+  }
+
+  func containsImageEffect(_ key: FeatureTypeKey) -> Bool {
+    imageEffectDecoders[key] != nil
+  }
+
+  func containsDomainFeature(_ key: FeatureTypeKey) -> Bool {
+    domainDecoders[key] != nil
+  }
+
+  func decodeImageEffect(
+    key: FeatureTypeKey,
+    version: Int,
+    from decoder: Decoder
+  ) throws -> any ImageEffectFeatureType {
+    guard let decode = imageEffectDecoders[key] else {
+      throw ParametricDocumentCodecError.unregisteredFeatureType(key)
+    }
+    return try decode(decoder, version)
+  }
+
+  func decodeDomainFeature(
+    key: FeatureTypeKey,
+    version: Int,
+    from decoder: Decoder
+  ) throws -> any DomainFeatureType {
+    guard let decode = domainDecoders[key] else {
+      throw ParametricDocumentCodecError.unregisteredFeatureType(key)
+    }
+    return try decode(decoder, version)
+  }
+
+  /// The registry containing every Brightroom built-in feature.
+  public static var brightroomDefault: ParametricFeatureTypeRegistry {
+    var registry = ParametricFeatureTypeRegistry()
+    registry.register(CropFeature.self)
+    registry.register(PresetFeature.self)
+    registry.register(EffectPipelineFeature.self)
+    registry.register(ColorCubeFeature.self)
+    registry.register(BrightnessFeature.self)
+    registry.register(ContrastFeature.self)
+    registry.register(SaturationFeature.self)
+    registry.register(ExposureFeature.self)
+    registry.register(HighlightsFeature.self)
+    registry.register(ShadowsFeature.self)
+    registry.register(HighlightShadowTintFeature.self)
+    registry.register(TemperatureFeature.self)
+    registry.register(SharpenFeature.self)
+    registry.register(GaussianBlurFeature.self)
+    registry.register(UnsharpMaskFeature.self)
+    registry.register(VignetteFeature.self)
+    registry.register(FadeFeature.self)
+    return registry
+  }
+}
+
+/// Encodes and decodes parametric documents.
+public struct ParametricDocumentCodec: Sendable {
+
+  /// The registered persistable feature types.
+  public var types: ParametricFeatureTypeRegistry
+
+  /// Creates a codec, starting from the Brightroom built-in registrations.
+  public init(types: ParametricFeatureTypeRegistry = .brightroomDefault) {
+    self.types = types
+  }
+
+  /// Registers an image-effect params type, UICollectionView style.
+  public mutating func register<T: PersistableFeature & ImageEffectFeatureType>(_ type: T.Type) {
+    types.register(type)
+  }
+
+  /// Registers a domain-feature params type, UICollectionView style.
+  public mutating func register<T: PersistableFeature & DomainFeatureType>(_ type: T.Type) {
+    types.register(type)
+  }
+
+  /// Encodes a document.
+  public func encode(_ document: EditingDocument) throws -> Data {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    encoder.userInfo[.parametricFeatureTypes] = types
+    return try encoder.encode(document)
+  }
+
+  /// Decodes a document, resolving every feature to its registered type.
+  public func decode(_ data: Data) throws -> EditingDocument {
+    let decoder = JSONDecoder()
+    decoder.userInfo[.parametricFeatureTypes] = types
+    return try decoder.decode(EditingDocument.self, from: data)
+  }
+}
+
+extension CodingUserInfoKey {
+
+  /// Carries the codec's type registry through Codable coding.
+  public static let parametricFeatureTypes = CodingUserInfoKey(
+    rawValue: "BrightroomParametric.featureTypes"
+  )!
+}
+
+// MARK: - Envelope coding
+
+private enum EnvelopeKeys: String, CodingKey {
+  case type
+  case v
+  case params
+}
+
+private func registry(from decoder: Decoder) throws -> ParametricFeatureTypeRegistry {
+  guard
+    let registry = decoder.userInfo[.parametricFeatureTypes] as? ParametricFeatureTypeRegistry
+  else {
+    throw ParametricDocumentCodecError.missingRegistry
+  }
+  return registry
+}
+
+private func registry(from encoder: Encoder) throws -> ParametricFeatureTypeRegistry {
+  guard
+    let registry = encoder.userInfo[.parametricFeatureTypes] as? ParametricFeatureTypeRegistry
+  else {
+    throw ParametricDocumentCodecError.missingRegistry
+  }
+  return registry
+}
+
+private func encodeEnvelope(
+  _ feature: any Feature,
+  into container: inout KeyedEncodingContainer<EnvelopeKeys>,
+  isRegistered: (FeatureTypeKey) -> Bool
+) throws {
+  guard let persistable = feature as? any PersistableFeature else {
+    throw ParametricDocumentCodecError.notPersistable(
+      typeName: String(describing: type(of: feature))
+    )
+  }
+
+  func write<T: PersistableFeature>(_ value: T) throws {
+    // Fail at save time, not load time: a document the codec writes must be
+    // decodable by the same codec.
+    guard isRegistered(T.featureTypeKey) else {
+      throw ParametricDocumentCodecError.unregisteredFeatureType(T.featureTypeKey)
+    }
+    try container.encode(T.featureTypeKey, forKey: .type)
+    try container.encode(T.schemaVersion, forKey: .v)
+    try value.encode(to: container.superEncoder(forKey: .params))
+  }
+  try write(persistable)
+}
+
+/// Codable box carrying an image effect through an envelope.
+struct ParametricEffectBox: Codable {
+
+  var value: any ImageEffectFeatureType
+
+  init(_ value: any ImageEffectFeatureType) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let types = try registry(from: decoder)
+    let container = try decoder.container(keyedBy: EnvelopeKeys.self)
+    let key = try container.decode(FeatureTypeKey.self, forKey: .type)
+    let version = try container.decode(Int.self, forKey: .v)
+    self.value = try types.decodeImageEffect(
+      key: key,
+      version: version,
+      from: try container.superDecoder(forKey: .params)
+    )
+  }
+
+  func encode(to encoder: Encoder) throws {
+    let types = try registry(from: encoder)
+    var container = encoder.container(keyedBy: EnvelopeKeys.self)
+    try encodeEnvelope(value, into: &container, isRegistered: types.containsImageEffect)
+  }
+}
+
+/// Codable box carrying a domain feature through an envelope.
+struct ParametricDomainBox: Codable {
+
+  var value: any DomainFeatureType
+
+  init(_ value: any DomainFeatureType) {
+    self.value = value
+  }
+
+  init(from decoder: Decoder) throws {
+    let types = try registry(from: decoder)
+    let container = try decoder.container(keyedBy: EnvelopeKeys.self)
+    let key = try container.decode(FeatureTypeKey.self, forKey: .type)
+    let version = try container.decode(Int.self, forKey: .v)
+    self.value = try types.decodeDomainFeature(
+      key: key,
+      version: version,
+      from: try container.superDecoder(forKey: .params)
+    )
+  }
+
+  func encode(to encoder: Encoder) throws {
+    let types = try registry(from: encoder)
+    var container = encoder.container(keyedBy: EnvelopeKeys.self)
+    try encodeEnvelope(value, into: &container, isRegistered: types.containsDomainFeature)
+  }
+}
+
+// MARK: - Document Codable (boundary-only)
+
+extension EditingDocument: Codable {
+
+  /// The serialized format version of the structural spine (document, tree,
+  /// local adjustments, mask vocabulary). Feature parameters carry their own
+  /// per-type versions in their envelopes; this version is the migration hook
+  /// for everything between them.
+  public static let formatVersion = 1
+
+  private enum Keys: String, CodingKey {
+    case formatVersion
+    case mainTree
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    let version = try container.decode(Int.self, forKey: .formatVersion)
+    guard version == Self.formatVersion else {
+      throw ParametricDocumentCodecError.unsupportedDocumentFormatVersion(version)
+    }
+    self.init(mainTree: try container.decode(MainTree.self, forKey: .mainTree))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    try container.encode(Self.formatVersion, forKey: .formatVersion)
+    try container.encode(mainTree, forKey: .mainTree)
+  }
+}
+
+extension MainTree: Codable {
+
+  private enum Keys: String, CodingKey {
+    case features
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    self.init(features: try container.decode([MainFeature].self, forKey: .features))
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    try container.encode(features, forKey: .features)
+  }
+}
+
+extension MainFeature: Codable {
+
+  private enum Keys: String, CodingKey {
+    case kind
+    case feature
+  }
+
+  private enum Kind: String, Codable {
+    case domain
+    case effect
+    case localAdjustment
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    switch try container.decode(Kind.self, forKey: .kind) {
+    case .domain:
+      self = .domain(try container.decode(ParametricDomainBox.self, forKey: .feature).value)
+    case .effect:
+      self = .effect(try container.decode(ParametricEffectBox.self, forKey: .feature).value)
+    case .localAdjustment:
+      self = .localAdjustment(
+        try container.decode(LocalAdjustmentFeature.self, forKey: .feature)
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    switch self {
+    case let .domain(feature):
+      try container.encode(Kind.domain, forKey: .kind)
+      try container.encode(ParametricDomainBox(feature), forKey: .feature)
+    case let .effect(feature):
+      try container.encode(Kind.effect, forKey: .kind)
+      try container.encode(ParametricEffectBox(feature), forKey: .feature)
+    case let .localAdjustment(feature):
+      try container.encode(Kind.localAdjustment, forKey: .kind)
+      try container.encode(feature, forKey: .feature)
+    }
+  }
+}
+
+extension EffectPipeline: Codable {
+
+  private enum Keys: String, CodingKey {
+    case effects
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    self.init(
+      effects: try container.decode([ParametricEffectBox].self, forKey: .effects).map(\.value)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    try container.encode(effects.map(ParametricEffectBox.init), forKey: .effects)
+  }
+}
+
+extension LocalAdjustmentFeature: Codable {
+
+  private enum Keys: String, CodingKey {
+    case id
+    case isEnabled
+    case maskTree
+    case effectPipeline
+    case blendMode
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    self.init(
+      id: try container.decode(FeatureID.self, forKey: .id),
+      isEnabled: try container.decode(Bool.self, forKey: .isEnabled),
+      maskTree: try container.decode(MaskTree.self, forKey: .maskTree),
+      effectPipeline: try container.decode(EffectPipeline.self, forKey: .effectPipeline),
+      blendMode: try container.decode(LocalAdjustmentBlendMode.self, forKey: .blendMode)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(isEnabled, forKey: .isEnabled)
+    try container.encode(maskTree, forKey: .maskTree)
+    try container.encode(effectPipeline, forKey: .effectPipeline)
+    try container.encode(blendMode, forKey: .blendMode)
+  }
+}
+
+extension PresetFeature {
+
+  private enum Keys: String, CodingKey {
+    case id
+    case isEnabled
+    case name
+    case identifier
+    case effects
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: Keys.self)
+    self.init(
+      id: try container.decode(FeatureID.self, forKey: .id),
+      isEnabled: try container.decode(Bool.self, forKey: .isEnabled),
+      name: try container.decode(String.self, forKey: .name),
+      identifier: try container.decode(String.self, forKey: .identifier),
+      effects: try container.decode([ParametricEffectBox].self, forKey: .effects).map(\.value)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: Keys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(isEnabled, forKey: .isEnabled)
+    try container.encode(name, forKey: .name)
+    try container.encode(identifier, forKey: .identifier)
+    try container.encode(effects.map(ParametricEffectBox.init), forKey: .effects)
+  }
+}
+
+// MARK: - Built-in registrations
+
+extension CropFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.domain.crop"
+
+  /// v2 added `rotation` + `straightenRadians`. v1 documents stored only the
+  /// crop rect and decode with no rotation and zero straighten.
+  public static var schemaVersion: Int { 2 }
+
+  private struct V1Parameters: Decodable {
+    var id: FeatureID
+    var isEnabled: Bool
+    var cropRect: CGRect
+  }
+
+  public static func decodeParameters(from decoder: Decoder, version: Int) throws -> CropFeature {
+    switch version {
+    case 2:
+      return try CropFeature(from: decoder)
+    case 1:
+      let v1 = try V1Parameters(from: decoder)
+      return CropFeature(
+        id: v1.id,
+        isEnabled: v1.isEnabled,
+        cropRect: v1.cropRect
+      )
+    default:
+      throw ParametricDocumentCodecError.unsupportedSchemaVersion(
+        featureTypeKey,
+        version: version
+      )
+    }
+  }
+}
+
+extension PresetFeature: PersistableFeature, Codable {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.preset"
+}
+
+extension EffectPipelineFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.pipeline"
+}
+
+extension ColorCubeFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.color-cube"
+}
+
+extension BrightnessFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.brightness"
+}
+
+extension ContrastFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.contrast"
+}
+
+extension SaturationFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.saturation"
+}
+
+extension ExposureFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.exposure"
+}
+
+extension HighlightsFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.highlights"
+}
+
+extension ShadowsFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.shadows"
+}
+
+extension HighlightShadowTintFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.highlight-shadow-tint"
+}
+
+extension TemperatureFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.temperature"
+}
+
+extension SharpenFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.sharpen"
+}
+
+extension GaussianBlurFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.gaussian-blur"
+}
+
+extension UnsharpMaskFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.unsharp-mask"
+}
+
+extension VignetteFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.vignette"
+}
+
+extension FadeFeature: PersistableFeature {
+  public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.fade"
+}

--- a/Sources/BrightroomParametric/ParametricExportRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricExportRenderer.swift
@@ -1,0 +1,474 @@
+//
+// Copyright (c) 2018 Muukii <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import ImageIO
+import SwiftUI
+import UniformTypeIdentifiers
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Materializes a parametric `EditingDocument` from a source `CIImage` into a
+/// concrete result (`Rendered`), either an in-memory bitmap or a file on disk.
+///
+/// This is the export/preview evaluation layer of the parametric stack: the
+/// document (effects, local adjustments, and the crop as a domain feature)
+/// compiles to one lazy `CIImage` recipe through `ParametricImageRenderer`,
+/// which Core Image then evaluates here at the requested quality, resolution,
+/// and output. The source image is expected to be already oriented; callers
+/// holding an unoriented loader should apply orientation before rendering.
+public struct ParametricExportRenderer {
+
+  /// An encoded file format for `Output.file`.
+  public enum ExportFileType: Sendable {
+    /// Lossy JPEG. `quality` is 0...1 (1 = best).
+    case jpeg(quality: CGFloat)
+    /// HEIF (HEIC). `quality` is 0...1 (1 = best).
+    case heif(quality: CGFloat)
+    /// Lossless PNG.
+    case png
+  }
+
+  /// Where a render stores its result.
+  public enum Output: Sendable {
+    /// Render into an in-memory bitmap (a full-resolution `CGImage`). Simple,
+    /// but allocates the whole output buffer (≈ W·H·4 bytes; ~576MB at 12000²).
+    case memory
+    /// Stream the render straight to a file via Core Image's tiled writer — no
+    /// full-resolution `CGImage`, peak memory bounded to ~a tile plus encoder
+    /// state. The right choice for very large images.
+    case file(url: URL, fileType: ExportFileType)
+  }
+
+  public struct Options: Sendable {
+
+    public var resolution: Resolution
+    public var workingFormat: CIFormat
+
+    /// An colorspace that uses on rendering.
+    /// Result image would use this colorspace.
+    /// Nil means letting the renderer use the intrinsic colorspace of the working image.
+    public var workingColorSpace: CGColorSpace?
+
+    /// Where the result is stored (in-memory bitmap or a file on disk).
+    public var output: Output
+
+    ///
+    /// - Parameters:
+    ///   - resolution:
+    ///   - workingFormat:
+    ///   - workingColorSpace:
+    ///   - output: In-memory bitmap (`.memory`, default) or a tiled write to a
+    ///     file (`.file`). Either way the result is returned as a `Rendered`.
+    public init(
+      resolution: Resolution = .full,
+      workingFormat: CIFormat = .BGRA8,
+      workingColorSpace: CGColorSpace? = nil,
+      output: Output = .memory
+    ) {
+      self.resolution = resolution
+      self.workingFormat = workingFormat
+      self.workingColorSpace = workingColorSpace
+      self.output = output
+    }
+
+  }
+
+  public enum RenderingError: Swift.Error {
+    /// A file-backed render could not be decoded back into a `CGImage`.
+    case failedToDecodeRenderedFile(URL)
+  }
+
+  /**
+   A result of rendering.
+
+   `Rendered` hides whether the result lives in memory or on disk: the same type
+   is returned for `Output.memory` and `Output.file`. Ask it for whatever you
+   need (`cgImage`, `uiImage`, `fileURL`, `thumbnail`) and it resolves the
+   backing for you.
+   */
+  public struct Rendered: Sendable {
+
+    public enum DataType: Sendable {
+      case jpeg(quality: CGFloat)
+      case png
+    }
+
+    enum Storage: Sendable {
+      case memory(CGImage)
+      case file(URL)
+    }
+
+    /// An Options instance that used in redering.
+    public let options: Options
+
+    private let storage: Storage
+
+    init(cgImage: CGImage, options: Options) {
+      self.storage = .memory(cgImage)
+      self.options = options
+    }
+
+    init(fileURL: URL, options: Options) {
+      self.storage = .file(fileURL)
+      self.options = options
+    }
+
+    /// The on-disk location when the render targeted `Output.file`; `nil` for an
+    /// in-memory render.
+    public var fileURL: URL? {
+      if case .file(let url) = storage { return url }
+      return nil
+    }
+
+    /// The result as a `CGImage`, orientation fixed and tagged with the working
+    /// color space. An in-memory render returns immediately; a file-backed
+    /// render decodes the file (which loads the full image into memory — avoid
+    /// it on the large exports `Output.file` exists to keep bounded).
+    public var cgImage: CGImage {
+      get throws {
+        switch storage {
+        case .memory(let image):
+          return image
+        case .file(let url):
+          guard
+            let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+          else {
+            throw RenderingError.failedToDecodeRenderedFile(url)
+          }
+          return image
+        }
+      }
+    }
+
+    #if canImport(UIKit)
+    public var uiImage: UIImage {
+      get throws {
+        UIImage(cgImage: try cgImage, scale: 1, orientation: .up)
+          .withRenderingMode(.alwaysOriginal)
+      }
+    }
+    #endif
+
+    public var swiftUIImage: SwiftUI.Image {
+      get throws {
+        .init(decorative: try cgImage, scale: 1, orientation: .up)
+      }
+    }
+
+    /// A downsampled decode of the result, capped to `maxPixelSize` on the long
+    /// side — preview a large export WITHOUT the full-resolution decode spike.
+    /// A file result decodes a thumbnail via Image I/O (bounded memory); an
+    /// in-memory result returns the already-resident image unchanged.
+    public func thumbnail(maxPixelSize: CGFloat) throws -> CGImage {
+      switch storage {
+      case .memory(let image):
+        return image
+      case .file(let url):
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+          throw RenderingError.failedToDecodeRenderedFile(url)
+        }
+        let options: [CFString: Any] = [
+          kCGImageSourceCreateThumbnailFromImageAlways: true,
+          kCGImageSourceCreateThumbnailWithTransform: true,
+          kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+          kCGImageSourceShouldCacheImmediately: true,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+          throw RenderingError.failedToDecodeRenderedFile(url)
+        }
+        return image
+      }
+    }
+
+    /**
+     Makes a data of the image that optimized for sharing.
+
+     Since the rendered image is working on DisplayP3 profile, that data might display wrong color on other platform devices.
+     To avoid those issues, use this method to create data to send instead of creating data from `cgImageDisplayP3`.
+     */
+    public func makeOptimizedForSharingData(dataType: DataType) throws -> Data {
+      let image = try cgImage
+      let data = NSMutableData()
+
+      let utType: UTType
+      var properties: [CFString: Any] = [kCGImageDestinationOptimizeColorForSharing: true]
+      switch dataType {
+      case .jpeg(let quality):
+        utType = .jpeg
+        properties[kCGImageDestinationLossyCompressionQuality] = quality
+      case .png:
+        utType = .png
+      }
+
+      guard
+        let destination = CGImageDestinationCreateWithData(
+          data,
+          utType.identifier as CFString,
+          1,
+          nil
+        )
+      else {
+        return data as Data
+      }
+      CGImageDestinationAddImage(destination, image, properties as CFDictionary)
+      CGImageDestinationFinalize(destination)
+      return data as Data
+    }
+
+  }
+
+  public enum RenderingDevice: Sendable {
+    /// GPU rendering, falling back to software rendering when the image
+    /// exceeds the GPU context's maximum input or output size.
+    case automatic
+    /// CPU-based rendering (`.useSoftwareRenderer`).
+    case software
+    /// GPU rendering with no size-limit fallback.
+    case gpu
+  }
+
+  public enum Resolution: Sendable {
+    case full
+    case resize(maxPixelSize: CGFloat)
+  }
+
+  /// The renderer that compiles the document into a lazy `CIImage` recipe.
+  public var imageRenderer: ParametricImageRenderer
+
+  public init(imageRenderer: ParametricImageRenderer = .init()) {
+    self.imageRenderer = imageRenderer
+  }
+
+  /**
+   Renders a parametric document from an already-oriented source image.
+
+   Single rendering path: the document (effects, local adjustments, and the crop
+   as a domain feature) compiles to one `CIImage` recipe through
+   `ParametricImageRenderer`, which Core Image evaluates. An unedited image or a
+   pure crop is just an identity/crop-only document on the same path.
+
+   The result is returned as a `Rendered`, which hides whether it is backed by an
+   in-memory bitmap or a file — controlled by `options.output`:
+
+   - `.memory` materializes a full-resolution `CGImage` (`createCGImage`).
+   - `.file` streams the render to disk through Core Image's tiled writer (no
+     full-resolution `CGImage`; bounded peak memory) — use it for large images.
+
+   This call is synchronous; callers that need to stay off an actor should hop
+   to their own queue first.
+   */
+  public func render(
+    source: CIImage,
+    document: EditingDocument,
+    options: Options = .init(),
+    device: RenderingDevice = .automatic
+  ) throws -> Rendered {
+
+    let colorSpace = options.workingColorSpace ?? source.colorSpace
+
+    // Always process through a half-float WORKING buffer so wide-gamut and
+    // out-of-range (>1 / <0) values survive the multi-filter chain — an 8-bit
+    // working format would clamp/band them mid-chain. This is the processing
+    // precision only; it is independent of the OUTPUT format below, which stays
+    // `options.workingFormat` (the caller's delivery format — 8-bit Display-P3
+    // is fine for SDR; bumping the output to float is a per-call delivery choice).
+    let ciContext = Self.makeCIContext(
+      workingFormat: .RGBAh,
+      device: device,
+      imageExtent: source.extent
+    )
+
+    let outputCIImage = try imageRenderer.makeImage(
+      from: source,
+      document: document
+    )
+
+    // `Resolution.resize` is a Core Image scale on the recipe, so the downscale
+    // is part of the same (tiled) evaluation for both outputs.
+    let image = Self.scaled(outputCIImage, for: options.resolution)
+
+    switch options.output {
+    case .memory:
+      /// To keep wide-color(DisplayP3), use createCGImage instead drawing with CIContext
+      let cgImage = ciContext.createCGImage(
+        image,
+        from: image.extent,
+        format: options.workingFormat,
+        colorSpace: colorSpace,
+        deferred: false
+      )!
+      return .init(cgImage: cgImage, options: options)
+
+    case let .file(url, fileType):
+      // Hand the recipe straight to Core Image's tiled writer — no
+      // full-resolution `CGImage`, no `CGImageDestination`. Peak memory is
+      // bounded to ~a tile plus the encoder state.
+      try Self.write(
+        image,
+        to: url,
+        fileType: fileType,
+        context: ciContext,
+        // The write APIs require a concrete color space; fall back to sRGB when
+        // the source has none (mirrors `createCGImage(colorSpace: nil)`).
+        colorSpace: colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB)!
+      )
+      return .init(fileURL: url, options: options)
+    }
+  }
+
+  private static func write(
+    _ image: CIImage,
+    to url: URL,
+    fileType: ExportFileType,
+    context: CIContext,
+    colorSpace: CGColorSpace
+  ) throws {
+    // Bounded-memory write: render the recipe strip-by-strip into a disk-backed
+    // (mmap'd) buffer and encode lazily, instead of `write{JPEG,HEIF}Representation`
+    // which renders the full bitmap into RAM first. See CIImageStreamingFileWriter.
+    try CIImageStreamingFileWriter.write(
+      image,
+      to: url,
+      fileType: fileType,
+      context: context,
+      colorSpace: colorSpace
+    )
+  }
+
+  /// Applies `Resolution.resize` as a Core Image Lanczos scale so the downscale
+  /// is part of the tiled recipe (the `CIContext` already has
+  /// `.highQualityDownsample`). `.full` returns the image unchanged.
+  private static func scaled(_ image: CIImage, for resolution: Resolution) -> CIImage {
+    switch resolution {
+    case .full:
+      return image
+    case .resize(let maxPixelSize):
+      let extent = image.extent
+      let longest = max(extent.width, extent.height)
+      guard longest > maxPixelSize, longest > 0 else {
+        return image
+      }
+      let scale = maxPixelSize / longest
+      let scaled = image
+        .applyingFilter(
+          "CILanczosScaleTransform",
+          parameters: [kCIInputScaleKey: scale, kCIInputAspectRatioKey: 1.0]
+        )
+      // Lanczos can grow the extent by sub-pixels (filter support); crop back to
+      // the integer target so the encoded file has exact dimensions. The
+      // parametric output is zero-origin.
+      let targetSize = CGSize(
+        width: (extent.width * scale).rounded(),
+        height: (extent.height * scale).rounded()
+      )
+      return scaled.cropped(to: CGRect(origin: .zero, size: targetSize))
+    }
+  }
+
+  private struct CIContextCacheKey: Hashable {
+    let workingFormatRawValue: Int32
+    let useSoftwareRenderer: Bool
+  }
+
+  private static let ciContextCacheLock = NSLock()
+  // Guarded by ciContextCacheLock; the lock makes access race-free, so opt out
+  // of the Swift 6 global-mutable-state check rather than re-isolating.
+  private nonisolated(unsafe) static var ciContextCache: [CIContextCacheKey: CIContext] = [:]
+
+  /// Extended-linear, wide-gamut (Display-P3 primaries) CIContext WORKING space.
+  /// Paired with the half-float working format, this extended space lets
+  /// out-of-sRGB / out-of-range values survive the filter chain, so edited
+  /// wide-gamut sources (Display-P3, Adobe RGB, ...) export faithfully instead
+  /// of being gamut-clipped into the default sRGB-primary working space. It
+  /// matches the editing canvas working space so canvas and export agree.
+  /// (Distinct from `Options.workingColorSpace`, which is the OUTPUT tag.)
+  private static let processingColorSpace =
+    CGColorSpace(name: CGColorSpace.extendedLinearDisplayP3) ?? CGColorSpaceCreateDeviceRGB()
+
+  /// CIContext creation costs tens to hundreds of milliseconds; CIContext is
+  /// thread-safe, so contexts are shared across renders keyed by the options
+  /// that affect their output.
+  private static func sharedCIContext(
+    workingFormat: CIFormat,
+    useSoftwareRenderer: Bool
+  ) -> CIContext {
+    let key = CIContextCacheKey(
+      workingFormatRawValue: workingFormat.rawValue,
+      useSoftwareRenderer: useSoftwareRenderer
+    )
+
+    ciContextCacheLock.lock()
+    defer { ciContextCacheLock.unlock() }
+
+    if let cached = ciContextCache[key] {
+      return cached
+    }
+
+    let context = CIContext(
+      options: [
+        .workingFormat: workingFormat,
+        .workingColorSpace: processingColorSpace,
+        .highQualityDownsample: true,
+        .useSoftwareRenderer: useSoftwareRenderer,
+        .cacheIntermediates: false
+      ]
+    )
+    ciContextCache[key] = context
+    return context
+  }
+
+  private static func makeCIContext(
+    workingFormat: CIFormat,
+    device: RenderingDevice,
+    imageExtent: CGRect
+  ) -> CIContext {
+
+    switch device {
+    case .software:
+      return sharedCIContext(workingFormat: workingFormat, useSoftwareRenderer: true)
+    case .gpu:
+      return sharedCIContext(workingFormat: workingFormat, useSoftwareRenderer: false)
+    case .automatic:
+      let gpuContext = sharedCIContext(workingFormat: workingFormat, useSoftwareRenderer: false)
+
+      #if canImport(UIKit)
+      // GPU contexts are bounded by Metal texture size limits (typically 8192–16384px).
+      // The input/output max-size queries are unavailable on native macOS.
+      let inputLimit = gpuContext.inputImageMaximumSize()
+      let outputLimit = gpuContext.outputImageMaximumSize()
+
+      if imageExtent.width <= min(inputLimit.width, outputLimit.width),
+         imageExtent.height <= min(inputLimit.height, outputLimit.height)
+      {
+        return gpuContext
+      }
+
+      return sharedCIContext(workingFormat: workingFormat, useSoftwareRenderer: true)
+      #else
+      return gpuContext
+      #endif
+    }
+  }
+}

--- a/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Values available to features while they evaluate.
+///
+/// The context deliberately carries no document state — a feature sees only
+/// its input image and shared facilities. This keeps evaluation a pure
+/// function of (parameters, input).
+public struct FeatureEvaluationContext: Sendable {
+
+  /// Custom Core Image kernels shared by mask rendering.
+  public let kernelRegistry: ParametricKernelRegistry
+
+  /// The image extent that diagonal-based radii (Gaussian blur, sharpen,
+  /// unsharp mask) resolve against, expressed in the **current render pixel
+  /// space**.
+  ///
+  /// A radius like "value 40" means "diagonal / 50 of the image". The basis
+  /// must be the **source** image, not the cropped/zoomed/intermediate extent
+  /// the effect happens to be applied to — otherwise a tighter crop or a
+  /// zoomed viewport silently changes the blur strength. Render pipelines set
+  /// this to the full source extent scaled to the resolution they are
+  /// rendering at, so the radius stays a fixed fraction of the source in every
+  /// path (export, preview, live viewport).
+  ///
+  /// `nil` falls back to the input image's own extent, which is correct only
+  /// when the input *is* the full source at render scale (true for the export
+  /// and preview-composition paths, where the blur runs pre-crop at source
+  /// resolution).
+  public let radiusReferenceExtent: CGRect?
+
+  /// Creates an evaluation context.
+  public init(
+    kernelRegistry: ParametricKernelRegistry = .init(),
+    radiusReferenceExtent: CGRect? = nil
+  ) {
+    self.kernelRegistry = kernelRegistry
+    self.radiusReferenceExtent = radiusReferenceExtent
+  }
+
+  /// Returns a copy that resolves diagonal-based radii against `extent`
+  /// (the full source extent in the current render pixel space).
+  public func withRadiusReferenceExtent(_ extent: CGRect?) -> Self {
+    .init(kernelRegistry: kernelRegistry, radiusReferenceExtent: extent)
+  }
+}
+
+/// An extent-preserving image effect.
+///
+/// Conforming types are pure parameter values; `apply` is the feature's
+/// evaluation, dispatched natively through the protocol witness — no registry
+/// participates at runtime. Implementations must return an image cropped to
+/// the input extent.
+///
+/// `apply` evaluates unconditionally: `isEnabled` is the CALLER's contract.
+/// The evaluator and composite features (preset, local adjustment pipelines)
+/// filter disabled features before calling `apply`.
+public protocol ImageEffectFeatureType: Feature {
+
+  /// Evaluates the effect over the input image.
+  func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage
+
+  /// Validates the parameters before evaluation.
+  func validate() throws
+
+  /// Nested features evaluated inside this effect, exposed for tree-level
+  /// validation such as duplicate-ID detection.
+  var childFeatures: [any Feature] { get }
+}
+
+extension ImageEffectFeatureType {
+
+  public func validate() throws {}
+
+  public var childFeatures: [any Feature] { [] }
+}
+
+/// A feature that may change the current image domain (extent or coordinate
+/// meaning), such as crop or future geometry correction.
+///
+/// The evaluator treats the returned image's extent as the new current
+/// domain; implementations should reset their output to zero origin.
+public protocol DomainFeatureType: Feature {
+
+  /// Evaluates the domain change over the input image.
+  func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage
+
+  /// Validates the parameters before evaluation.
+  func validate() throws
+}
+
+extension DomainFeatureType {
+
+  public func validate() throws {}
+}
+
+extension EffectPipeline {
+
+  /// Evaluates the enabled effects in order over the input image.
+  ///
+  /// This is the pipeline-level evaluator UIs and renderers use without
+  /// fabricating a whole document.
+  public func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+    try effects
+      .filter(\.isEnabled)
+      .reduce(image) { image, effect in
+        try effect.apply(to: image, context: context)
+      }
+  }
+}
+
+extension Feature {
+
+  /// Compares this feature against another behind an existential.
+  ///
+  /// Method dispatch opens `Self`; differing dynamic types are never equal.
+  public func isEqualFeature(to other: any Feature) -> Bool {
+    guard let other = other as? Self else {
+      return false
+    }
+    return self == other
+  }
+}
+
+/// Compares two features behind existentials.
+public func parametricFeatureIsEqual(_ lhs: any Feature, _ rhs: any Feature) -> Bool {
+  lhs.isEqualFeature(to: rhs)
+}
+
+/// Compares two ordered existential feature arrays.
+public func parametricFeaturesAreEqual(
+  _ lhs: [any Feature],
+  _ rhs: [any Feature]
+) -> Bool {
+  guard lhs.count == rhs.count else {
+    return false
+  }
+  return zip(lhs, rhs).allSatisfy { pair in
+    pair.0.isEqualFeature(to: pair.1)
+  }
+}

--- a/Sources/BrightroomParametric/ParametricFeatureModel.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureModel.swift
@@ -1,0 +1,979 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import Foundation
+
+/// A stable identifier for a parametric editing feature or mask node.
+///
+/// Feature identifiers are stored in documents so debug views, UI selections,
+/// and future references can survive Codable round trips.
+public struct FeatureID: Codable, Equatable, Hashable, Sendable {
+
+  /// The serialized identifier value.
+  public var rawValue: String
+
+  /// Creates an identifier with the provided serialized value.
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  /// Creates a new unique identifier.
+  public init() {
+    self.rawValue = UUID().uuidString
+  }
+}
+
+/// A parametric operation that can appear in an editing document.
+///
+/// Features are pure parameter values. Evaluation behavior is added by
+/// capability protocols (`ImageEffectFeatureType`, `DomainFeatureType`);
+/// persistence is added by `PersistableFeature`. The runtime document is not
+/// Codable by itself — serialization goes through `ParametricDocumentCodec`.
+public protocol Feature: Equatable, Sendable {
+
+  /// The stable identity of this feature.
+  var id: FeatureID { get }
+
+  /// A Boolean value indicating whether the feature contributes to rendering.
+  var isEnabled: Bool { get }
+}
+
+/// A parametric image editing document.
+///
+/// The document intentionally stores edit parameters only. The source image is
+/// supplied to the compiler so the same document can be evaluated for preview,
+/// export, or debugging without baking pixels into the model.
+public struct EditingDocument: Equatable, Sendable {
+
+  /// The ordered main feature tree evaluated from source image to output image.
+  public var mainTree: MainTree
+
+  /// Creates a document with the provided main tree.
+  public init(mainTree: MainTree = .init()) {
+    self.mainTree = mainTree
+  }
+}
+
+/// The main editing sequence for a document.
+///
+/// Main-tree features are evaluated in array order. Domain-changing features
+/// such as crop are allowed here, while local adjustment subtrees are restricted
+/// to extent-preserving operations.
+public struct MainTree: Equatable, Sendable {
+
+  /// The features evaluated in source-to-output order.
+  public var features: [MainFeature]
+
+  /// Creates a main tree with the provided ordered features.
+  public init(features: [MainFeature] = []) {
+    self.features = features
+  }
+}
+
+/// A feature that can appear in the document's main tree.
+///
+/// The effect and domain vocabularies are open: any type conforming to the
+/// capability protocols can appear here, including host-defined features.
+/// Local adjustments are a structural branch owned by the engine.
+public enum MainFeature: Equatable, Sendable {
+
+  /// A feature that may change image extent or coordinate domain.
+  case domain(any DomainFeatureType)
+
+  /// A global, extent-preserving image effect.
+  case effect(any ImageEffectFeatureType)
+
+  /// A local branch that composites an effect pipeline through a mask tree.
+  case localAdjustment(LocalAdjustmentFeature)
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case let (.domain(a), .domain(b)):
+      return parametricFeatureIsEqual(a, b)
+    case let (.effect(a), .effect(b)):
+      return parametricFeatureIsEqual(a, b)
+    case let (.localAdjustment(a), .localAdjustment(b)):
+      return a == b
+    default:
+      return false
+    }
+  }
+}
+
+extension MainFeature: Feature {
+
+  public var id: FeatureID {
+    switch self {
+    case let .domain(feature):
+      feature.id
+    case let .effect(feature):
+      feature.id
+    case let .localAdjustment(feature):
+      feature.id
+    }
+  }
+
+  public var isEnabled: Bool {
+    switch self {
+    case let .domain(feature):
+      feature.isEnabled
+    case let .effect(feature):
+      feature.isEnabled
+    case let .localAdjustment(feature):
+      feature.isEnabled
+    }
+  }
+}
+
+/// A quarter-turn rotation step applied by a crop feature.
+///
+/// Raw values are the signed degrees the engine uses (`EditingCrop.Rotation.angle`),
+/// so the sign convention is identical and host bridges map 1:1. This is a pure
+/// CoreGraphics/Foundation type with no SwiftUI dependency.
+public enum QuarterTurn: Int, Codable, Equatable, Sendable, CaseIterable {
+
+  /// No rotation (0°).
+  case zero = 0
+
+  /// A quarter turn (-90°), matching `EditingCrop.Rotation.angle_90`.
+  case quarterCW = -90
+
+  /// A half turn (-180°).
+  case half = -180
+
+  /// A three-quarter turn (-270°).
+  case quarterCCW = -270
+
+  /// The rotation expressed in radians.
+  public var radians: Double {
+    Double(rawValue) * .pi / 180
+  }
+}
+
+/// A crop in the current main-tree domain.
+///
+/// The crop rectangle is interpreted relative to the image produced by the
+/// previous main-tree feature. A second crop therefore crops the already-cropped
+/// output of the first crop. The crop also carries the quarter-turn rotation and
+/// the free straightening angle, both applied about the crop-rect center, so the
+/// whole crop geometry is expressed as a single parametric feature.
+public struct CropFeature: Feature, Codable {
+
+  /// The stable identity of this crop.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this crop participates in rendering.
+  public var isEnabled: Bool
+
+  /// The rectangle to keep, expressed in the current domain (Core Image
+  /// bottom-left, y-up).
+  public var cropRect: CGRect
+
+  /// The quarter-turn rotation applied about the crop-rect center.
+  public var rotation: QuarterTurn
+
+  /// A free straightening angle in radians, applied about the crop-rect center
+  /// in addition to `rotation`.
+  public var straightenRadians: Double
+
+  /// The combined rotation (quarter turn + straighten) in radians.
+  public var aggregatedRotationRadians: Double {
+    rotation.radians + (straightenRadians.isFinite ? straightenRadians : 0)
+  }
+
+  /// Creates a current-domain crop feature.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    cropRect: CGRect,
+    rotation: QuarterTurn = .zero,
+    straightenRadians: Double = 0
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.cropRect = cropRect
+    self.rotation = rotation
+    self.straightenRadians = straightenRadians
+  }
+}
+
+/// A named group of extent-preserving effects.
+///
+/// This is the parametric equivalent of a filter preset. It stores typed
+/// effect values so the document remains inspectable.
+public struct PresetFeature: Feature {
+
+  /// The stable identity of this preset feature.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this preset participates in rendering.
+  public var isEnabled: Bool
+
+  /// The display name associated with the preset.
+  public var name: String
+
+  /// The stable preset identifier.
+  public var identifier: String
+
+  /// The effects evaluated inside the preset, in order.
+  public var effects: [any ImageEffectFeatureType]
+
+  /// Creates a preset feature.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    name: String,
+    identifier: String,
+    effects: [any ImageEffectFeatureType]
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.name = name
+    self.identifier = identifier
+    self.effects = effects
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    lhs.id == rhs.id
+      && lhs.isEnabled == rhs.isEnabled
+      && lhs.name == rhs.name
+      && lhs.identifier == rhs.identifier
+      && parametricFeaturesAreEqual(lhs.effects, rhs.effects)
+  }
+}
+
+/// A color-cube lookup-table effect.
+///
+/// The feature stores cube data directly so rendering can stay in the Core Image
+/// graph without asking an `ImageSource` or bundle resource to materialize.
+public struct ColorCubeFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The display name associated with the lookup table.
+  public var name: String
+
+  /// The stable lookup-table identifier.
+  public var identifier: String
+
+  /// The opacity used when compositing the color-cube result over its input.
+  public var amount: Double
+
+  /// The color-cube dimension.
+  public var dimension: Int
+
+  /// RGBA float cube data in `CIColorCubeWithColorSpace` layout.
+  public var cubeData: Data
+
+  /// Creates a color-cube effect.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    name: String,
+    identifier: String,
+    amount: Double = 1,
+    dimension: Int,
+    cubeData: Data
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.name = name
+    self.identifier = identifier
+    self.amount = amount
+    self.dimension = dimension
+    self.cubeData = cubeData
+  }
+}
+
+/// A brightness adjustment.
+public struct BrightnessFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The brightness value passed to `CIColorControls`.
+  public var value: Double
+
+  /// Creates a brightness adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A contrast adjustment.
+public struct ContrastFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The contrast offset passed to `CIColorControls` as `1 + value`.
+  public var value: Double
+
+  /// Creates a contrast adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A saturation adjustment.
+public struct SaturationFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The saturation offset passed to `CIColorControls` as `1 + value`.
+  public var value: Double
+
+  /// Creates a saturation adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// An exposure adjustment.
+public struct ExposureFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The exposure value passed to `CIExposureAdjust`.
+  public var value: Double
+
+  /// Creates an exposure adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A highlight recovery adjustment.
+public struct HighlightsFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The highlight recovery value. It is applied as `1 - value`.
+  public var value: Double
+
+  /// Creates a highlight adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A shadow lift adjustment.
+public struct ShadowsFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The shadow amount passed to `CIHighlightShadowAdjust`.
+  public var value: Double
+
+  /// Creates a shadow adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// An RGBA color value stored inside a parametric feature document.
+public struct ParametricRGBAColor: Codable, Equatable, Sendable {
+
+  /// The red component in the Core Image working range.
+  public var red: Double
+
+  /// The green component in the Core Image working range.
+  public var green: Double
+
+  /// The blue component in the Core Image working range.
+  public var blue: Double
+
+  /// The alpha component in the Core Image working range.
+  public var alpha: Double
+
+  /// Creates an RGBA color value.
+  public init(
+    red: Double,
+    green: Double,
+    blue: Double,
+    alpha: Double
+  ) {
+    self.red = red
+    self.green = green
+    self.blue = blue
+    self.alpha = alpha
+  }
+}
+
+/// A highlight/shadow tint effect.
+public struct HighlightShadowTintFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The color composited over highlight regions.
+  public var highlightColor: ParametricRGBAColor
+
+  /// The color composited over shadow regions.
+  public var shadowColor: ParametricRGBAColor
+
+  /// Creates a highlight/shadow tint adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    highlightColor: ParametricRGBAColor,
+    shadowColor: ParametricRGBAColor
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.highlightColor = highlightColor
+    self.shadowColor = shadowColor
+  }
+}
+
+/// A color temperature adjustment.
+public struct TemperatureFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The temperature offset from Brightroom's neutral value.
+  public var value: Double
+
+  /// Creates a temperature adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A luminance sharpen adjustment.
+public struct SharpenFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The sharpness value passed to `CISharpenLuminance`.
+  public var sharpness: Double
+
+  /// The Brightroom filter radius value, resolved against the current extent.
+  public var radius: Double
+
+  /// Creates a sharpen adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    sharpness: Double,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.sharpness = sharpness
+    self.radius = radius
+  }
+}
+
+/// A Gaussian blur radius value.
+public enum GaussianBlurRadius: Codable, Equatable, Sendable {
+
+  /// A Core Image blur radius in image-domain points.
+  case absolute(Double)
+
+  /// A `FilterGaussianBlur.value` slider value, resolved against image extent.
+  case editingStackFilterValue(Double)
+}
+
+/// A Gaussian blur that preserves the input extent.
+public struct GaussianBlurFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The blur radius descriptor.
+  public var radius: GaussianBlurRadius
+
+  /// Creates a Gaussian blur.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.radius = .absolute(radius)
+  }
+
+  /// Creates a Gaussian blur from `FilterGaussianBlur.value`.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.radius = .editingStackFilterValue(value)
+  }
+}
+
+/// An unsharp mask adjustment.
+public struct UnsharpMaskFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The intensity passed to `CIUnsharpMask`.
+  public var intensity: Double
+
+  /// The Brightroom filter radius value, resolved against the current extent.
+  public var radius: Double
+
+  /// Creates an unsharp mask adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    intensity: Double,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.intensity = intensity
+    self.radius = radius
+  }
+}
+
+/// A vignette adjustment.
+public struct VignetteFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The Brightroom vignette value used for both intensity and radius scaling.
+  public var value: Double
+
+  /// Creates a vignette adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    value: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.value = value
+  }
+}
+
+/// A fade adjustment that overlays white.
+public struct FadeFeature: Feature, Codable {
+
+  /// The stable identity of this effect.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this effect participates in rendering.
+  public var isEnabled: Bool
+
+  /// The opacity of the white overlay.
+  public var intensity: Double
+
+  /// Creates a fade adjustment.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    intensity: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.intensity = intensity
+  }
+}
+
+/// An ordered chain of extent-preserving effects.
+public struct EffectPipeline: Equatable, Sendable {
+
+  /// The effects applied from first to last.
+  public var effects: [any ImageEffectFeatureType]
+
+  /// Creates an effect pipeline.
+  public init(effects: [any ImageEffectFeatureType] = []) {
+    self.effects = effects
+  }
+
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    parametricFeaturesAreEqual(lhs.effects, rhs.effects)
+  }
+
+  // MARK: - Typed queries
+
+  /// The first effect of the given type, if present.
+  public func first<T: ImageEffectFeatureType>(of type: T.Type) -> T? {
+    for effect in effects {
+      if let typed = effect as? T {
+        return typed
+      }
+    }
+    return nil
+  }
+
+  /// The index of the first effect of the given type, if present.
+  public func firstIndex<T: ImageEffectFeatureType>(of type: T.Type) -> Int? {
+    effects.firstIndex(where: { $0 is T })
+  }
+
+  /// Replaces the first effect of `T` in place, removes it when `value` is
+  /// nil, or inserts a new value when absent.
+  ///
+  /// Ordering is the caller's decision: `insertionIndex` resolves where a
+  /// NEW effect goes (defaults to appending). An existing effect keeps its
+  /// position.
+  public mutating func set<T: ImageEffectFeatureType>(
+    _ value: T?,
+    insertionIndex: (EffectPipeline) -> Int = { $0.effects.count }
+  ) {
+    if let index = firstIndex(of: T.self) {
+      if let value {
+        effects[index] = value
+      } else {
+        effects.remove(at: index)
+      }
+    } else if let value {
+      let index = min(max(insertionIndex(self), 0), effects.count)
+      effects.insert(value, at: index)
+    }
+  }
+
+  /// Whether the pipeline contains no effects.
+  public var isEmpty: Bool {
+    effects.isEmpty
+  }
+}
+
+/// A main-tree effect node that bundles an ordered `EffectPipeline`.
+///
+/// This is the document representation of the editing stack's global-effects
+/// node: it keeps the `EffectPipeline` editing vocabulary as a single,
+/// identity-stable feature, while the compiler flattens it through
+/// `childFeatures` exactly like `PresetFeature`.
+public struct EffectPipelineFeature: Feature, Codable {
+
+  /// The stable identity of this effect node.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this node participates in rendering.
+  public var isEnabled: Bool
+
+  /// The ordered effects applied when this node evaluates.
+  public var pipeline: EffectPipeline
+
+  /// Creates an effect-pipeline feature.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    pipeline: EffectPipeline
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.pipeline = pipeline
+  }
+}
+
+/// A local adjustment branch.
+///
+/// The branch evaluates an effect pipeline from the current main image, evaluates
+/// a mask tree in the same current domain, and composites the adjusted image
+/// back over the base image without changing extent.
+public struct LocalAdjustmentFeature: Feature {
+
+  /// The stable identity of this local adjustment.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this local adjustment participates in rendering.
+  public var isEnabled: Bool
+
+  /// The mask tree that produces the alpha used for compositing.
+  public var maskTree: MaskTree
+
+  /// The extent-preserving effects applied inside the local branch.
+  public var effectPipeline: EffectPipeline
+
+  /// The blend rule used to composite the adjusted branch over the base image.
+  public var blendMode: LocalAdjustmentBlendMode
+
+  /// Creates a local adjustment branch.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    maskTree: MaskTree,
+    effectPipeline: EffectPipeline,
+    blendMode: LocalAdjustmentBlendMode = .alpha
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.maskTree = maskTree
+    self.effectPipeline = effectPipeline
+    self.blendMode = blendMode
+  }
+}
+
+/// A blend rule for local adjustment output.
+public enum LocalAdjustmentBlendMode: String, Codable, Equatable, Sendable {
+
+  /// Uses the mask alpha to blend adjusted output over the base image.
+  case alpha
+}
+
+/// A mask graph that produces alpha in the current feature domain.
+public struct MaskTree: Codable, Equatable, Sendable {
+
+  /// The root mask node.
+  public var root: MaskNode
+
+  /// Creates a mask tree.
+  public init(root: MaskNode) {
+    self.root = root
+  }
+}
+
+/// A node in an alpha-only mask tree.
+public indirect enum MaskNode: Codable, Equatable, Sendable {
+
+  /// Produces alpha from brush strokes.
+  case brush(BrushMask)
+
+  /// Inverts the input alpha.
+  case invert(MaskNode)
+
+  /// Blurs the input alpha while preserving extent.
+  case feather(MaskFeather)
+
+  /// Combines child masks using alpha union.
+  case union([MaskNode])
+
+  /// Combines child masks using alpha intersection.
+  case intersect([MaskNode])
+
+  /// Removes one mask from another.
+  case subtract(MaskSubtract)
+}
+
+/// A brush-authored mask.
+public struct BrushMask: Feature, Codable {
+
+  /// The stable identity of this mask leaf.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this mask leaf contributes alpha.
+  public var isEnabled: Bool
+
+  /// The brush strokes authored in the current feature domain.
+  public var strokes: [BrushMaskStroke]
+
+  /// Creates a brush-authored mask.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    strokes: [BrushMaskStroke] = []
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.strokes = strokes
+  }
+}
+
+/// A continuous brush stroke represented by sampled stamp centers.
+public struct BrushMaskStroke: Codable, Equatable, Sendable {
+
+  /// The stamp centers in current feature-domain coordinates.
+  public var stamps: [CGPoint]
+
+  /// The brush used to render each stamp.
+  public var brush: BrushMaskBrush
+
+  /// Creates a brush stroke.
+  public init(
+    stamps: [CGPoint],
+    brush: BrushMaskBrush
+  ) {
+    self.stamps = stamps
+    self.brush = brush
+  }
+}
+
+/// Brush parameters for a mask stroke.
+public struct BrushMaskBrush: Codable, Equatable, Sendable {
+
+  /// The brush diameter in current feature-domain units.
+  public var diameter: Double
+
+  /// The hard inner alpha region, from `0` for soft to `1` for hard.
+  public var hardness: Double
+
+  /// The stamp opacity, from `0` to `1`.
+  public var opacity: Double
+
+  /// Creates brush parameters.
+  public init(
+    diameter: Double,
+    hardness: Double,
+    opacity: Double
+  ) {
+    self.diameter = diameter
+    self.hardness = hardness
+    self.opacity = opacity
+  }
+}
+
+/// A mask feather operation.
+public struct MaskFeather: Codable, Equatable, Sendable {
+
+  /// The stable identity of this operation.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this operation participates in rendering.
+  public var isEnabled: Bool
+
+  /// The input mask node to feather.
+  public var input: MaskNode
+
+  /// The blur radius used to feather alpha.
+  public var radius: Double
+
+  /// Creates a feather operation.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    input: MaskNode,
+    radius: Double
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.input = input
+    self.radius = radius
+  }
+}
+
+/// A mask subtraction operation.
+public struct MaskSubtract: Codable, Equatable, Sendable {
+
+  /// The stable identity of this operation.
+  public var id: FeatureID
+
+  /// A Boolean value indicating whether this operation participates in rendering.
+  public var isEnabled: Bool
+
+  /// The mask to subtract from.
+  public var base: MaskNode
+
+  /// The mask removed from the base alpha.
+  public var removing: MaskNode
+
+  /// Creates a mask subtraction operation.
+  public init(
+    id: FeatureID = .init(),
+    isEnabled: Bool = true,
+    base: MaskNode,
+    removing: MaskNode
+  ) {
+    self.id = id
+    self.isEnabled = isEnabled
+    self.base = base
+    self.removing = removing
+  }
+}

--- a/Sources/BrightroomParametric/ParametricFilterSupport.swift
+++ b/Sources/BrightroomParametric/ParametricFilterSupport.swift
@@ -1,0 +1,143 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreGraphics
+import CoreImage
+import Foundation
+
+/// Shared constants that mirror Brightroom's legacy filter slider ranges.
+///
+/// The parametric renderer keeps these values local so the rendering graph can
+/// be compiled by a macOS app without importing the UIKit-backed legacy filter
+/// types.
+enum ParametricFilterConstants {
+
+  /// The maximum legacy slider value for Gaussian blur.
+  static let gaussianBlurSliderMax = 100.0
+
+  /// The maximum legacy slider value for unsharp-mask radius.
+  static let unsharpMaskRadiusSliderMax = 1.0
+
+  /// The maximum legacy slider value for vignette.
+  static let vignetteSliderMax = 2.0
+}
+
+/// Converts Brightroom-style normalized radius values into image-domain radii.
+enum ParametricRadiusCalculator {
+
+  /// Resolves a slider value against the diagonal length of the current image.
+  static func radius(
+    value: Double,
+    max: Double,
+    imageExtent: CGRect
+  ) -> Double {
+    let base = Double(sqrt(pow(imageExtent.width, 2) + pow(imageExtent.height, 2)))
+    let coefficient = base / 20
+    return coefficient * value / max
+  }
+}
+
+/// Applies a vignette centered in the image's current domain.
+///
+/// `CIVignette` accepts a scalar radius and does not expose the effect center,
+/// which makes repeated crop operations hard to reason about. The parametric
+/// renderer uses `CIVignetteEffect` so the vignette is explicitly evaluated
+/// against the current feature output extent.
+enum ParametricVignetteRenderer {
+
+  /// Applies a vignette to the supplied image while preserving its extent.
+  static func apply(
+    value: Double,
+    to image: CIImage
+  ) -> CIImage {
+    guard abs(value) > 0.0001 else {
+      return image
+    }
+
+    let extent = image.extent
+    let radius = max(extent.width, extent.height) * 0.5
+    return image.applyingFilter(
+      "CIVignetteEffect",
+      parameters: [
+        kCIInputCenterKey: CIVector(x: extent.midX, y: extent.midY),
+        kCIInputRadiusKey: radius,
+        kCIInputIntensityKey: value,
+        "inputFalloff": 0.5,
+      ]
+    )
+    .cropped(to: extent)
+  }
+}
+
+/// Geometry helpers kept inside the Parametric layer so the renderer can be
+/// compiled without BrightroomEngine's UIKit-backed support files.
+enum ParametricImageGeometry {
+
+  /// Translates the image so its extent starts at zero while preserving pixels.
+  static func removingExtentOffset(_ image: CIImage) -> CIImage {
+    image.transformed(
+      by: .init(
+        translationX: -image.extent.origin.x,
+        y: -image.extent.origin.y
+      )
+    )
+  }
+}
+
+/// Creates Core Image color-cube filters from serialized cube data.
+enum ParametricColorCubeHelper {
+
+  /// Creates a `CIColorCubeWithColorSpace` filter for a stored RGBA float cube.
+  static func makeColorCubeFilter(
+    cubeData: Data,
+    dimension: Int,
+    cacheKey: String?
+  ) -> CIFilter {
+    if let cacheKey,
+       let cached = parametricColorCubeFilterCache.object(forKey: cacheKey as NSString)
+    {
+      return cached.copy() as! CIFilter
+    }
+
+    let expectedByteCount = dimension * dimension * dimension * 4 * MemoryLayout<Float>.size
+    precondition(
+      cubeData.count == expectedByteCount,
+      "Cube data byte count must be \(expectedByteCount), but got \(cubeData.count)."
+    )
+
+    let filter = CIFilter(
+      name: "CIColorCubeWithColorSpace",
+      parameters: [
+        "inputCubeDimension": dimension,
+        "inputCubeData": cubeData,
+        "inputColorSpace": CGColorSpaceCreateDeviceRGB(),
+      ]
+    )!
+
+    if let cacheKey {
+      parametricColorCubeFilterCache.setObject(filter, forKey: cacheKey as NSString)
+    }
+
+    return filter
+  }
+}
+
+nonisolated(unsafe) private let parametricColorCubeFilterCache = NSCache<NSString, CIFilter>()

--- a/Sources/BrightroomParametric/ParametricImageRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricImageRenderer.swift
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Renders parametric feature documents for still images.
+///
+/// `ParametricImageRenderer` is the public rendering facade for image inputs.
+/// It delegates graph construction to `FeatureGraphCompiler` and returns lazy
+/// Core Image recipes; callers decide when to materialize the result with a
+/// `CIContext`.
+public struct ParametricImageRenderer: Sendable {
+
+  /// The compiler used to evaluate feature graphs.
+  public var compiler: FeatureGraphCompiler
+
+  /// Creates an image renderer.
+  public init(compiler: FeatureGraphCompiler = .init()) {
+    self.compiler = compiler
+  }
+
+  /// Evaluates an editing document from a source image.
+  ///
+  /// `radiusReferenceExtent` is the full source extent in the current render
+  /// pixel space; pass it from paths that evaluate on a cropped/zoomed
+  /// intermediate so diagonal-based radii stay a fixed fraction of the source.
+  /// `nil` (the default) is correct when `sourceImage` is the full source at
+  /// render scale (export, preview composition).
+  public func makeOutput(
+    from sourceImage: CIImage,
+    document: EditingDocument,
+    radiusReferenceExtent: CGRect? = nil
+  ) throws -> FeatureGraphOutput {
+    try compiler.makeOutput(
+      from: sourceImage,
+      document: document,
+      radiusReferenceExtent: radiusReferenceExtent
+    )
+  }
+
+  /// Returns only the final image recipe.
+  public func makeImage(
+    from sourceImage: CIImage,
+    document: EditingDocument,
+    radiusReferenceExtent: CGRect? = nil
+  ) throws -> CIImage {
+    try makeOutput(
+      from: sourceImage,
+      document: document,
+      radiusReferenceExtent: radiusReferenceExtent
+    )
+    .image
+  }
+}

--- a/Sources/BrightroomParametric/ParametricKernelRegistry.swift
+++ b/Sources/BrightroomParametric/ParametricKernelRegistry.swift
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+
+/// Provides cached kernels used by the parametric Core Image compiler.
+///
+/// Documents store semantic feature data only. This registry is renderer
+/// infrastructure and all custom operations are represented as Metal-backed
+/// Core Image kernels loaded from BrightroomParametric's compiled Metal library.
+public struct ParametricKernelRegistry: Sendable {
+
+  /// Creates a registry for Metal-backed parametric kernels.
+  public init() {}
+
+  func makeBrushStamp(
+    extent: CGRect,
+    center: CGPoint,
+    radius: Double,
+    hardness: Double,
+    opacity: Double
+  ) throws -> CIImage {
+    guard radius > 0, opacity > 0 else {
+      return CIImage.parametricTransparent(extent: extent)
+    }
+
+    let kernel = try ParametricMetalKernelStore.colorKernel(named: "brushStamp")
+    guard let image = kernel.apply(
+      extent: extent,
+      arguments: [
+        CIVector(x: center.x, y: center.y),
+        radius,
+        hardness,
+        opacity,
+      ]
+    ) else {
+      throw ParametricKernelRegistryError.failedToApplyKernel("brushStamp")
+    }
+    return image.cropped(to: extent)
+  }
+
+  func subtractMask(
+    base: CIImage,
+    removing: CIImage,
+    extent: CGRect
+  ) throws -> CIImage {
+    let kernel = try ParametricMetalKernelStore.colorKernel(named: "maskSubtract")
+    guard let image = kernel.apply(
+      extent: extent,
+      arguments: [removing, base]
+    ) else {
+      throw ParametricKernelRegistryError.failedToApplyKernel("maskSubtract")
+    }
+    return image.cropped(to: extent)
+  }
+}
+
+/// Errors thrown while preparing or applying parametric custom kernels.
+public enum ParametricKernelRegistryError: Error, Equatable, Sendable {
+
+  /// A named kernel was not present in the loaded kernel cache.
+  case missingKernel(String)
+
+  /// Core Image returned nil while applying a named kernel.
+  case failedToApplyKernel(String)
+
+  /// A named Core Image kernel could not be loaded from the compiled metallib.
+  case failedToLoadKernel(String, String)
+
+  /// The bundled compiled Metal library is missing or unreadable.
+  case missingKernelLibraryResource(String)
+}
+
+private enum ParametricMetalKernelStore {
+
+  /// Loads the bundled compiled Metal library for the parametric kernels.
+  ///
+  /// `ParametricKernels.metal` is build-compiled into `default.metallib`, then
+  /// loaded by function name through `CIColorKernel(functionName:fromMetalLibraryData:)`.
+  private static let kernelNames = ["brushStamp", "maskSubtract"]
+
+  static func colorKernel(named name: String) throws -> CIColorKernel {
+    switch loadedKernels {
+    case let .success(kernels):
+      guard let kernel = kernels[name] else {
+        throw ParametricKernelRegistryError.missingKernel(name)
+      }
+      return kernel
+    case let .failure(error):
+      throw error
+    }
+  }
+
+  private static let loadedKernels: Result<[String: CIColorKernel], ParametricKernelRegistryError> = {
+    do {
+      let kernels = try loadCompiledKernels()
+      return .success(kernels)
+    } catch let error as BrushStampMetalLibraryError {
+      return .failure(.missingKernelLibraryResource(String(describing: error)))
+    } catch let error as ParametricKernelRegistryError {
+      return .failure(error)
+    } catch {
+      return .failure(.missingKernelLibraryResource(String(describing: error)))
+    }
+  }()
+
+  private static func loadCompiledKernels() throws -> [String: CIColorKernel] {
+    let data = try BrushStampMetalLibrary.data()
+    var result: [String: CIColorKernel] = [:]
+    for name in kernelNames {
+      do {
+        result[name] = try CIColorKernel(functionName: name, fromMetalLibraryData: data)
+      } catch {
+        throw ParametricKernelRegistryError.failedToLoadKernel(name, String(describing: error))
+      }
+    }
+    return result
+  }
+}
+
+extension CIImage {
+
+  static func parametricTransparent(extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0)).cropped(to: extent)
+  }
+
+  static func parametricOpaqueWhite(extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: 1, green: 1, blue: 1, alpha: 1)).cropped(to: extent)
+  }
+}

--- a/Sources/BrightroomParametric/ParametricKernels.metal
+++ b/Sources/BrightroomParametric/ParametricKernels.metal
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Core Image kernels used by the parametric feature graph compiler.
+//
+// This file is build-compiled into the package target's `default.metallib` and
+// loaded with `CIColorKernel(functionName:fromMetalLibraryData:)`.
+//
+// This `brushStamp` kernel is one of the brush-mask rasterizers; the live
+// in-flight-stroke render shader (`BrushMaskRenderShader.metal`) is the other.
+// Both share ONE falloff from `BrushStampFalloff.metalh`, so preview/live and
+// committed/export masks cannot drift.
+
+#include <CoreImage/CoreImage.h>
+#include "BrushStampFalloff.metalh"
+
+extern "C" { namespace coreimage {
+  [[ stitchable ]] float4 brushStamp(
+    float2 center,
+    float radius,
+    float hardness,
+    float opacity,
+    destination dest
+  ) {
+    if (radius <= 0.0) {
+      return float4(0.0);
+    }
+
+    float normalizedDistance = length(dest.coord() - center) / radius;
+    float alpha = brushStampAlpha(normalizedDistance, hardness, opacity);
+    return float4(alpha, alpha, alpha, alpha);
+  }
+
+  [[ stitchable ]] float4 maskSubtract(sample_t removing, sample_t base) {
+    float alpha = max(base.a - removing.a, 0.0);
+    return float4(alpha, alpha, alpha, alpha);
+  }
+}}

--- a/Sources/BrightroomParametric/ParametricVideoRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricVideoRenderer.swift
@@ -1,0 +1,226 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import AVFoundation
+import CoreImage
+import Foundation
+
+/// Renders parametric feature documents for video assets.
+///
+/// `ParametricVideoRenderer` keeps video processing in the Core Image domain. It
+/// does not decode, encode, or export movies by itself; callers pass the
+/// returned `AVMutableVideoComposition` to `AVPlayerItem` or
+/// `AVAssetExportSession`.
+public struct ParametricVideoRenderer: Sendable {
+
+  /// How the video composition should choose its render canvas.
+  public enum RenderSizeMode: Equatable, Sendable {
+
+    /// Preserve AVFoundation's source render size.
+    case source
+
+    /// Resolve the render size by applying the document to a synthetic frame
+    /// with the source render size.
+    case featureOutput
+
+    /// Use an explicitly supplied render size.
+    case custom(CGSize)
+  }
+
+  /// The image renderer used to evaluate the feature graph for each frame.
+  public var imageRenderer: ParametricImageRenderer
+
+  /// Creates a video renderer.
+  public init(imageRenderer: ParametricImageRenderer = .init()) {
+    self.imageRenderer = imageRenderer
+  }
+
+  /// Creates a video renderer using a specific feature graph compiler.
+  public init(compiler: FeatureGraphCompiler) {
+    self.imageRenderer = ParametricImageRenderer(compiler: compiler)
+  }
+
+  /// Applies a feature document to a single video frame.
+  ///
+  /// - Parameters:
+  ///   - sourceImage: The frame image supplied by AVFoundation.
+  ///   - document: The feature document to evaluate.
+  ///   - renderExtent: The optional output canvas. When specified, the feature
+  ///     output is placed at the canvas origin and cropped/expanded to that
+  ///     extent using a transparent Core Image background.
+  /// - Returns: A Core Image recipe for the filtered frame.
+  public func makeFrameImage(
+    from sourceImage: CIImage,
+    document: EditingDocument,
+    renderExtent: CGRect? = nil
+  ) throws -> CIImage {
+    let output = try imageRenderer.makeImage(
+      from: sourceImage,
+      document: document
+    )
+
+    guard let renderExtent else {
+      return output
+    }
+
+    return output.parametricPlaced(in: renderExtent)
+  }
+
+  /// Resolves the render size for a video composition.
+  ///
+  /// `featureOutput` performs a dry run with a transparent frame so domain
+  /// features such as crop can decide the final canvas size without decoding a
+  /// real video frame.
+  public func resolveRenderSize(
+    sourceRenderSize: CGSize,
+    document: EditingDocument,
+    mode: RenderSizeMode
+  ) throws -> CGSize {
+    guard sourceRenderSize.isParametricVideoValidRenderSize else {
+      throw ParametricVideoRendererError.invalidSourceRenderSize(sourceRenderSize)
+    }
+
+    switch mode {
+    case .source:
+      return sourceRenderSize
+
+    case let .custom(renderSize):
+      guard renderSize.isParametricVideoValidRenderSize else {
+        throw ParametricVideoRendererError.invalidRenderSize(renderSize)
+      }
+      return renderSize
+
+    case .featureOutput:
+      let sourceExtent = CGRect(origin: .zero, size: sourceRenderSize)
+      let dryRunInput = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+        .cropped(to: sourceExtent)
+      let output = try imageRenderer.makeOutput(
+        from: dryRunInput,
+        document: document
+      )
+      .image
+      let renderSize = output.extent.size
+      guard renderSize.isParametricVideoValidRenderSize else {
+        throw ParametricVideoRendererError.invalidRenderSize(renderSize)
+      }
+      return renderSize
+    }
+  }
+
+  /// Creates a Core Image backed video composition that applies the document to
+  /// every frame.
+  ///
+  /// The returned composition can be assigned to `AVPlayerItem.videoComposition`
+  /// or `AVAssetExportSession.videoComposition`.
+  public func makeVideoComposition(
+    for asset: AVAsset,
+    document: EditingDocument,
+    renderSizeMode: RenderSizeMode = .featureOutput,
+    ciContext: CIContext? = nil
+  ) throws -> AVMutableVideoComposition {
+    let sizingComposition = AVMutableVideoComposition(asset: asset) { request in
+      request.finish(with: request.sourceImage, context: nil)
+    }
+    let sourceRenderSize = ParametricVideoRenderer.sourceRenderSize(
+      for: asset,
+      sizingComposition: sizingComposition
+    )
+    let renderSize = try resolveRenderSize(
+      sourceRenderSize: sourceRenderSize,
+      document: document,
+      mode: renderSizeMode
+    )
+    let renderExtent = CGRect(origin: .zero, size: renderSize)
+    let imageRenderer = imageRenderer
+
+    let composition = AVMutableVideoComposition(asset: asset) { request in
+      do {
+        let output = try ParametricVideoRenderer(imageRenderer: imageRenderer).makeFrameImage(
+          from: request.sourceImage,
+          document: document,
+          renderExtent: renderExtent
+        )
+        request.finish(with: output, context: ciContext)
+      } catch {
+        request.finish(with: error)
+      }
+    }
+    composition.renderSize = renderSize
+    guard composition.renderSize.isParametricVideoValidRenderSize else {
+      throw ParametricVideoRendererError.invalidRenderSize(composition.renderSize)
+    }
+    return composition
+  }
+
+  private static func sourceRenderSize(
+    for asset: AVAsset,
+    sizingComposition: AVMutableVideoComposition
+  ) -> CGSize {
+    if sizingComposition.renderSize.isParametricVideoValidRenderSize {
+      return sizingComposition.renderSize
+    }
+
+    if let composition = asset as? AVComposition,
+       composition.naturalSize.isParametricVideoValidRenderSize
+    {
+      return composition.naturalSize
+    }
+
+    return sizingComposition.renderSize
+  }
+}
+
+/// Errors thrown while preparing parametric video rendering.
+public enum ParametricVideoRendererError: Error, Equatable, Sendable {
+
+  /// AVFoundation could not provide a usable source render size.
+  case invalidSourceRenderSize(CGSize)
+
+  /// The requested or resolved output render size is invalid.
+  case invalidRenderSize(CGSize)
+}
+
+private extension CIImage {
+
+  func parametricPlaced(in renderExtent: CGRect) -> CIImage {
+    let placed = transformed(
+      by: CGAffineTransform(
+        translationX: renderExtent.minX - extent.minX,
+        y: renderExtent.minY - extent.minY
+      )
+    )
+    let background = CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+      .cropped(to: renderExtent)
+    return placed
+      .composited(over: background)
+      .cropped(to: renderExtent)
+  }
+}
+
+private extension CGSize {
+
+  var isParametricVideoValidRenderSize: Bool {
+    width.isFinite
+      && height.isFinite
+      && width > 0
+      && height > 0
+  }
+}

--- a/Tests/BrightroomParametricTests/BlurRadiusReferenceExtentTests.swift
+++ b/Tests/BrightroomParametricTests/BlurRadiusReferenceExtentTests.swift
@@ -1,0 +1,134 @@
+import CoreImage
+import Foundation
+import Testing
+import UIKit
+
+@testable import BrightroomParametric
+
+/// Pins the source-extent invariant for diagonal-based radii: a value-form
+/// Gaussian blur resolves its radius against the context's source reference
+/// extent, NOT the (possibly cropped or zoomed) extent of the image it happens
+/// to be applied to.
+///
+/// This is what keeps the masked blur a fixed fraction of the source across
+/// crop changes and viewport zoom, so the CropView preview matches the
+/// exported result. Before the fix, the live viewport re-resolved `value=40`
+/// against the zoomed drawable extent, so zooming changed the visible blur.
+struct BlurRadiusReferenceExtentTests {
+
+  private static let context = CIContext()
+
+  /// `value=40` with a source reference resolves to `diagonal(reference)/50`,
+  /// independent of the small input image it is applied to.
+  @Test func `value blur resolves radius against reference extent`() throws {
+    // An 80×80 input that, in the viewport, is a zoomed slice of a larger
+    // 800×800 source.
+    let input = Self.stepEdge(side: 80)
+    let sourceReference = CGRect(x: 0, y: 0, width: 800, height: 800)
+
+    let viaValue = try GaussianBlurFeature(value: 40).apply(
+      to: input,
+      context: FeatureEvaluationContext(radiusReferenceExtent: sourceReference)
+    )
+
+    // The equivalent absolute radius (diagonal/50) applied to the same input.
+    let referenceRadius = hypot(800.0, 800.0) / 50.0
+    let viaAbsolute = try GaussianBlurFeature(radius: referenceRadius).apply(
+      to: input,
+      context: FeatureEvaluationContext()
+    )
+    #expect(
+      Self.areNearlyEqual(viaValue, viaAbsolute, extent: input.extent, tolerance: 3),
+      "value blur must resolve its radius from the reference extent"
+    )
+
+    // The bug it prevents: resolving against the input's own (small) extent
+    // gives a ~10× smaller radius and a visibly sharper edge.
+    let inputExtentRadius = hypot(80.0, 80.0) / 50.0
+    let viaInputExtent = try GaussianBlurFeature(radius: inputExtentRadius).apply(
+      to: input,
+      context: FeatureEvaluationContext()
+    )
+    #expect(
+      !Self.areNearlyEqual(viaValue, viaInputExtent, extent: input.extent, tolerance: 3),
+      "value blur must NOT resolve its radius from the input extent"
+    )
+  }
+
+  /// With `radiusReferenceExtent` nil, the radius falls back to the input
+  /// extent — the contract the export and preview-composition paths rely on,
+  /// where the input IS the full source at render scale.
+  @Test func `nil reference falls back to input extent`() throws {
+    let input = Self.stepEdge(side: 200)
+    let viaNil = try GaussianBlurFeature(value: 40).apply(
+      to: input,
+      context: FeatureEvaluationContext()
+    )
+    let viaInputExtent = try GaussianBlurFeature(radius: hypot(200.0, 200.0) / 50.0).apply(
+      to: input,
+      context: FeatureEvaluationContext()
+    )
+    #expect(
+      Self.areNearlyEqual(viaNil, viaInputExtent, extent: input.extent, tolerance: 3),
+      "nil reference must fall back to the input extent"
+    )
+  }
+
+  // MARK: - Helpers
+
+  /// A vertical black/white step edge, so a Gaussian blur spreads measurably
+  /// across the boundary.
+  private static func stepEdge(side: Int) -> CIImage {
+    let size = CGSize(width: side, height: side)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    format.opaque = true
+    let cg = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+      UIColor.white.setFill()
+      UIRectFill(CGRect(x: 0, y: 0, width: size.width / 2, height: size.height))
+      UIColor.black.setFill()
+      UIRectFill(CGRect(x: size.width / 2, y: 0, width: size.width / 2, height: size.height))
+    }.cgImage!
+    return CIImage(cgImage: cg)
+  }
+
+  private static func areNearlyEqual(
+    _ lhs: CIImage,
+    _ rhs: CIImage,
+    extent: CGRect,
+    tolerance: Int
+  ) -> Bool {
+    guard
+      let l = context.createCGImage(lhs, from: extent),
+      let r = context.createCGImage(rhs, from: extent)
+    else {
+      return false
+    }
+    let lp = pixels(of: l)
+    let rp = pixels(of: r)
+    guard lp.count == rp.count else { return false }
+    var maxDiff = 0
+    for i in stride(from: 0, to: lp.count, by: 997) { // sparse sample
+      maxDiff = max(maxDiff, abs(Int(lp[i]) - Int(rp[i])))
+    }
+    return maxDiff <= tolerance
+  }
+
+  private static func pixels(of image: CGImage) -> [UInt8] {
+    let width = image.width
+    let height = image.height
+    var data = [UInt8](repeating: 0, count: width * height * 4)
+    let ctx = CGContext(
+      data: &data,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        | CGBitmapInfo.byteOrder32Big.rawValue
+    )!
+    ctx.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return data
+  }
+}

--- a/Tests/BrightroomParametricTests/BrushStampFalloffTests.swift
+++ b/Tests/BrightroomParametricTests/BrushStampFalloffTests.swift
@@ -1,0 +1,150 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import CoreImage
+import Foundation
+import Testing
+
+@testable import BrightroomParametric
+
+/// Pins the canonical brush-stamp falloff produced by the parametric CIKernel
+/// rasterizer (`FeatureGraphCompiler.renderMask`, the export/preview path).
+///
+/// The falloff is `BrushStampFalloff.metalh`'s `brushStampAlpha`:
+/// `alpha = (normalizedDistance > 1) ? 0
+///        : (hardness < 0.999 ? 1 - smoothstep(clamp(hardness,0,0.998), 1, d) : 1)
+///          * clamp(opacity, 0, 1)`
+/// where `normalizedDistance = distance / radius` and `radius = diameter / 2`.
+///
+/// The kernel returns `float4(a, a, a, a)`, so alpha == red == any channel; the
+/// tests read the red channel. A single stamp is rendered centered so the y-up
+/// (Core Image working space) vs y-down (CGImage) origin distinction is
+/// symmetric and does not affect the asserted points.
+struct BrushStampFalloffTests {
+
+  private static let context = CIContext()
+
+  private static let extentSize = 64
+  private static let center = CGPoint(x: 32, y: 32)
+  private static let diameter: Double = 40  // radius 20
+
+  // MARK: - Canonical shape (soft brush so the falloff is observable)
+
+  /// Center alpha must reach `opacity * 255` (within an 8-bit / AA tolerance),
+  /// a point clearly outside the radius must be ~0, and a mid-radius point must
+  /// fall strictly between the two — i.e. the falloff is monotonic-ish.
+  @Test func `Center full outside zero mid radius between`() throws {
+    let opacity: Double = 1
+    let image = try Self.renderSingleStamp(hardness: 0, opacity: opacity)
+
+    // Center: full opacity.
+    let centerValue = Self.red(in: image, x: 32, y: 32)
+    #expect(abs(Int(centerValue) - Int(opacity * 255)) <= 6, "center should be ~opacity*255")
+
+    // Clearly outside the radius (distance 28 > radius 20): zero.
+    let outsideValue = Self.red(in: image, x: 60, y: 32)
+    #expect(Int(outsideValue) <= 4, "pixel outside the radius should be ~0")
+
+    // Mid-radius (distance 10, normalizedDistance 0.5): strictly between.
+    let midValue = Self.red(in: image, x: 42, y: 32)
+    #expect(Int(midValue) > Int(outsideValue), "mid-radius should exceed the outside value")
+    #expect(Int(midValue) < Int(centerValue), "mid-radius should be below the center value")
+  }
+
+  /// The falloff is monotonically non-increasing as distance grows along a ray
+  /// from the stamp center.
+  @Test func `Falloff is monotonic along ray`() throws {
+    let image = try Self.renderSingleStamp(hardness: 0, opacity: 1)
+
+    // Sample x from the center outward; alpha must never increase.
+    var previous = 256
+    for x in stride(from: 32, through: 56, by: 2) {
+      let value = Int(Self.red(in: image, x: x, y: 32))
+      #expect(value <= previous + 2, "falloff increased at x=\(x): \(value) > \(previous)")
+      previous = value
+    }
+  }
+
+  // MARK: - Hardness controls edge sharpness
+
+  /// At a near-edge point, hardness 1.0 (hard) keeps full alpha while hardness
+  /// 0.0 (soft) has already faded — so the hard edge is sharper.
+  @Test func `Hard edge is sharper than soft edge`() throws {
+    let hard = try Self.renderSingleStamp(hardness: 1, opacity: 1)
+    let soft = try Self.renderSingleStamp(hardness: 0, opacity: 1)
+
+    // Near-edge point: distance 17 from center -> normalizedDistance 0.85.
+    let nearEdge = (x: 49, y: 32)
+
+    let hardValue = Int(Self.red(in: hard, x: nearEdge.x, y: nearEdge.y))
+    let softValue = Int(Self.red(in: soft, x: nearEdge.x, y: nearEdge.y))
+
+    // Hard brush holds full alpha right up to the radius edge.
+    #expect(hardValue > 240, "hard near-edge should remain ~full alpha")
+    // Soft brush has faded substantially by the same point.
+    #expect(softValue < hardValue - 40, "soft near-edge should be clearly weaker than hard")
+  }
+
+  // MARK: - Rendering
+
+  private static func renderSingleStamp(hardness: Double, opacity: Double) throws -> CGImage {
+    let extent = CGRect(x: 0, y: 0, width: extentSize, height: extentSize)
+    let maskTree = MaskTree(
+      root: .brush(
+        BrushMask(
+          strokes: [
+            BrushMaskStroke(
+              stamps: [center],
+              brush: BrushMaskBrush(diameter: diameter, hardness: hardness, opacity: opacity)
+            )
+          ]
+        )
+      )
+    )
+
+    let ciImage = try FeatureGraphCompiler().renderMask(maskTree, extent: extent)
+    return try #require(context.createCGImage(ciImage, from: extent))
+  }
+
+  /// Reads the red channel at the given pixel. The brush kernel writes
+  /// `float4(a, a, a, a)`, so red equals the mask alpha.
+  private static func red(in image: CGImage, x: Int, y: Int) -> UInt8 {
+    let width = image.width
+    let height = image.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let context = CGContext(
+      data: &pixels,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: CGColorSpaceCreateDeviceRGB(),
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        | CGBitmapInfo.byteOrder32Big.rawValue
+    )!
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    let clampedX = min(max(x, 0), width - 1)
+    let clampedY = min(max(y, 0), height - 1)
+    let offset = (clampedY * width + clampedX) * 4
+    return pixels[offset]
+  }
+}

--- a/Tests/BrightroomParametricTests/ColorCubeFeatureLoadingTests.swift
+++ b/Tests/BrightroomParametricTests/ColorCubeFeatureLoadingTests.swift
@@ -1,0 +1,199 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+import UniformTypeIdentifiers
+
+@testable import BrightroomParametric
+
+struct ColorCubeFeatureLoadingTests {
+
+  @Test func `Color cube feature loads cube files directly`() throws {
+    let directory = try Self.makeTemporaryDirectory()
+    defer {
+      try? FileManager.default.removeItem(at: directory)
+    }
+
+    let url = directory.appendingPathComponent("Identity.cube")
+    try Self.identityCube(size: 2, title: "Identity 2").write(
+      to: url,
+      atomically: true,
+      encoding: .utf8
+    )
+
+    let feature = try ColorCubeFeature(
+      contentsOfCubeFile: url,
+      id: FeatureID(rawValue: "test.identity"),
+      amount: 0.75
+    )
+
+    #expect(feature.id == FeatureID(rawValue: "test.identity"))
+    #expect(feature.name == "Identity 2")
+    #expect(feature.identifier == "Identity.cube")
+    #expect(feature.amount == 0.75)
+    #expect(feature.dimension == 2)
+    #expect(feature.cubeData.count == 2 * 2 * 2 * 4 * MemoryLayout<Float>.size)
+  }
+
+  @Test func `Color cube feature normalizes image LUT data`() throws {
+    let image = try Self.makeCubeImage()
+    let feature = try ColorCubeFeature(
+      cubeImage: image,
+      name: "Image LUT",
+      identifier: "image-lut"
+    )
+
+    #expect(feature.dimension == 4)
+    #expect(feature.cubeData.count == 4 * 4 * 4 * 4 * MemoryLayout<Float>.size)
+
+    let values = feature.cubeData.withUnsafeBytes {
+      Array($0.bindMemory(to: Float.self))
+    }
+    #expect(abs(values[0] - 64 / 255) < 0.0001)
+    #expect(abs(values[1] - 128 / 255) < 0.0001)
+    #expect(abs(values[2] - 192 / 255) < 0.0001)
+    #expect(abs(values[3] - 1) < 0.0001)
+  }
+
+  @Test func `Color cube feature loads PNG and JPEG LUT images`() throws {
+    let directory = try Self.makeTemporaryDirectory()
+    defer {
+      try? FileManager.default.removeItem(at: directory)
+    }
+
+    let image = try Self.makeCubeImage()
+    let formats = [
+      (fileExtension: "png", type: UTType.png),
+      (fileExtension: "jpg", type: UTType.jpeg),
+    ]
+
+    for format in formats {
+      let url = directory
+        .appendingPathComponent("ImageLUT")
+        .appendingPathExtension(format.fileExtension)
+      try Self.write(image, to: url, type: format.type)
+
+      let feature = try ColorCubeFeature(cubeImageAt: url)
+
+      #expect(feature.name == "ImageLUT")
+      #expect(feature.identifier == url.lastPathComponent)
+      #expect(feature.dimension == 4)
+      #expect(feature.cubeData.count == 4 * 4 * 4 * 4 * MemoryLayout<Float>.size)
+    }
+  }
+
+  @Test func `Color cube feature rejects dimensions that overflow storage`() throws {
+    let directory = try Self.makeTemporaryDirectory()
+    defer {
+      try? FileManager.default.removeItem(at: directory)
+    }
+
+    let cubeURL = directory.appendingPathComponent("Overflow.cube")
+    try "LUT_3D_SIZE \(Int.max)".write(
+      to: cubeURL,
+      atomically: true,
+      encoding: .utf8
+    )
+
+    #expect(
+      throws: ColorCubeFeatureLoadingError.invalidLUT3DSize(
+        String(Int.max),
+        line: 1
+      )
+    ) {
+      try ColorCubeFeature(contentsOfCubeFile: cubeURL)
+    }
+
+    let image = try Self.makeCubeImage()
+    #expect(
+      throws: ColorCubeFeatureLoadingError.unableToInferCubeDimension(
+        width: image.width,
+        height: image.height
+      )
+    ) {
+      try ColorCubeFeature(
+        cubeImage: image,
+        name: "Overflow",
+        identifier: "overflow",
+        dimension: Int.max
+      )
+    }
+  }
+
+  private static func makeTemporaryDirectory() throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(
+      at: directory,
+      withIntermediateDirectories: true
+    )
+    return directory
+  }
+
+  private static func makeCubeImage() throws -> CGImage {
+    let width = 8
+    let height = 8
+    let pixel = [UInt8](arrayLiteral: 64, 128, 192, 255)
+    let pixelData = Data((0..<(width * height)).flatMap { _ in pixel })
+    let provider = try #require(CGDataProvider(data: pixelData as CFData))
+    return try #require(
+      CGImage(
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bitsPerPixel: 32,
+        bytesPerRow: width * 4,
+        space: CGColorSpaceCreateDeviceRGB(),
+        bitmapInfo: CGBitmapInfo(
+          rawValue:
+            CGImageAlphaInfo.premultipliedLast.rawValue
+            | CGBitmapInfo.byteOrder32Big.rawValue
+        ),
+        provider: provider,
+        decode: nil,
+        shouldInterpolate: false,
+        intent: .defaultIntent
+      )
+    )
+  }
+
+  private static func write(
+    _ image: CGImage,
+    to url: URL,
+    type: UTType
+  ) throws {
+    let destination = try #require(
+      CGImageDestinationCreateWithURL(url as CFURL, type.identifier as CFString, 1, nil)
+    )
+    CGImageDestinationAddImage(destination, image, nil)
+    #expect(CGImageDestinationFinalize(destination))
+  }
+
+  private static func identityCube(size: Int, title: String) -> String {
+    let divisor = Float(size - 1)
+    var lines = [
+      "# comment",
+      "TITLE \"\(title)\"",
+      "LUT_3D_SIZE \(size)",
+      "DOMAIN_MIN 0.0 0.0 0.0",
+      "DOMAIN_MAX 1.0 1.0 1.0",
+    ]
+
+    for blueIndex in 0..<size {
+      for greenIndex in 0..<size {
+        for redIndex in 0..<size {
+          let red = Float(redIndex) / divisor
+          let green = Float(greenIndex) / divisor
+          let blue = Float(blueIndex) / divisor
+          lines.append("\(red) \(green) \(blue)")
+        }
+      }
+    }
+
+    return lines.joined(separator: "\n")
+  }
+}

--- a/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
+++ b/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
@@ -1,0 +1,1194 @@
+import AVFoundation
+import CoreImage
+import Foundation
+import Testing
+
+@testable import BrightroomParametric
+
+struct ParametricFeatureTreeTests {
+
+  @Test func documentCodableRoundTrip() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "crop-a"),
+              cropRect: CGRect(x: 4, y: 5, width: 30, height: 20)
+            )
+          ),
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "local-a"),
+              maskTree: MaskTree(
+                root: .feather(
+                  MaskFeather(
+                    id: FeatureID(rawValue: "feather-a"),
+                    input: .brush(
+                      BrushMask(
+                        id: FeatureID(rawValue: "mask-a"),
+                        strokes: [
+                          BrushMaskStroke(
+                            stamps: [CGPoint(x: 10, y: 8)],
+                            brush: BrushMaskBrush(diameter: 12, hardness: 0.5, opacity: 0.75)
+                          ),
+                        ]
+                      )
+                    ),
+                    radius: 2
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  BrightnessFeature(id: FeatureID(rawValue: "brightness-a"), value: 0.1),
+                  GaussianBlurFeature(id: FeatureID(rawValue: "blur-a"), radius: 3),
+                ]
+              )
+            )
+          ),
+          .effect(
+            ExposureFeature(id: FeatureID(rawValue: "exposure-a"), value: 0.25)
+          ),
+          .effect(ContrastFeature(id: FeatureID(rawValue: "contrast-a"), value: 0.08)),
+          .effect(SaturationFeature(id: FeatureID(rawValue: "saturation-a"), value: 0.12)),
+          .effect(HighlightsFeature(id: FeatureID(rawValue: "highlights-a"), value: 0.2)),
+          .effect(ShadowsFeature(id: FeatureID(rawValue: "shadows-a"), value: 0.15)),
+          .effect(
+            HighlightShadowTintFeature(
+              id: FeatureID(rawValue: "highlight-shadow-tint-a"),
+              highlightColor: ParametricRGBAColor(red: 1, green: 0.2, blue: 0.1, alpha: 0.05),
+              shadowColor: ParametricRGBAColor(red: 0.1, green: 0.2, blue: 1, alpha: 0.04)
+            )
+          ),
+          .effect(TemperatureFeature(id: FeatureID(rawValue: "temperature-a"), value: 450)),
+          .effect(SharpenFeature(id: FeatureID(rawValue: "sharpen-a"), sharpness: 0.2, radius: 4)),
+          .effect(UnsharpMaskFeature(id: FeatureID(rawValue: "unsharp-a"), intensity: 0.1, radius: 0.25)),
+          .effect(VignetteFeature(id: FeatureID(rawValue: "vignette-a"), value: 0.35)),
+          .effect(FadeFeature(id: FeatureID(rawValue: "fade-a"), intensity: 0.05)),
+        ]
+      )
+    )
+
+    let codec = ParametricDocumentCodec()
+    let data = try codec.encode(document)
+    let decoded = try codec.decode(data)
+
+    #expect(decoded == document)
+  }
+
+  @Test func codecRoundTripMatchesOriginalDocumentRendering() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "node-crop"),
+              cropRect: CGRect(x: 4, y: 3, width: 36, height: 24)
+            )
+          ),
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "node-local"),
+              maskTree: MaskTree(
+                root: .feather(
+                  MaskFeather(
+                    id: FeatureID(rawValue: "node-feather"),
+                    input: .brush(
+                      BrushMask(
+                        id: FeatureID(rawValue: "node-brush"),
+                        strokes: [
+                          BrushMaskStroke(
+                            stamps: [CGPoint(x: 16, y: 12)],
+                            brush: BrushMaskBrush(diameter: 14, hardness: 0.6, opacity: 0.8)
+                          ),
+                        ]
+                      )
+                    ),
+                    radius: 2
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  ExposureFeature(id: FeatureID(rawValue: "node-local-exposure"), value: 0.5),
+                ]
+              )
+            )
+          ),
+          .effect(BrightnessFeature(id: FeatureID(rawValue: "node-brightness"), value: 0.05)),
+        ]
+      )
+    )
+    let codec = ParametricDocumentCodec()
+    let data = try codec.encode(document)
+    let decoded = try codec.decode(data)
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 48, height: 36)
+    )
+
+    let originalOutput = try Self.compiler.makeOutput(from: input, document: document)
+    let decodedOutput = try Self.compiler.makeOutput(from: input, document: decoded)
+
+    #expect(decoded == document)
+    try Self.assertImagesMatch(
+      originalOutput.image,
+      decodedOutput.image,
+      tolerance: 2
+    )
+  }
+
+  @Test func customRegisteredFeatureRendersLikeDefaultFeatures() throws {
+    var codec = ParametricDocumentCodec()
+    codec.register(TestRedBoostFeature.self)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestRedBoostFeature(
+              id: FeatureID(rawValue: "custom-red-boost"),
+              amount: 0.25
+            )
+          ),
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "registry-brightness"),
+              value: 0.02
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 32, height: 24)
+    )
+    let expected = input
+      .applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+          "inputBiasVector": CIVector(x: 0.25, y: 0, z: 0, w: 0),
+        ]
+      )
+      .cropped(to: input.extent)
+      .applyingFilter(
+        "CIColorControls",
+        parameters: ["inputBrightness": 0.02]
+      )
+      .cropped(to: input.extent)
+
+    let data = try codec.encode(document)
+    let decoded = try codec.decode(data)
+    let output = try FeatureGraphCompiler().makeOutput(from: input, document: decoded)
+
+    try Self.assertImagesMatch(
+      expected,
+      output.image,
+      tolerance: 2
+    )
+  }
+
+  @Test func codecRoundTripPreservesDocumentWithCustomRegisteredFeature() throws {
+    var codec = ParametricDocumentCodec()
+    codec.register(TestRedBoostFeature.self)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestRedBoostFeature(
+              id: FeatureID(rawValue: "round-trip-red-boost"),
+              amount: 0.4
+            )
+          ),
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "round-trip-brightness"),
+              value: 0.03
+            )
+          ),
+        ]
+      )
+    )
+
+    let data = try codec.encode(document)
+    let decoded = try codec.decode(data)
+
+    #expect(decoded == document)
+  }
+
+  @Test func decodingUnregisteredFeatureTypeThrows() throws {
+    var registeringCodec = ParametricDocumentCodec()
+    registeringCodec.register(TestRedBoostFeature.self)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestRedBoostFeature(
+              id: FeatureID(rawValue: "unregistered-red-boost"),
+              amount: 0.1
+            )
+          ),
+        ]
+      )
+    )
+    let data = try registeringCodec.encode(document)
+
+    let plainCodec = ParametricDocumentCodec()
+    #expect(
+      throws: ParametricDocumentCodecError.unregisteredFeatureType(TestRedBoostFeature.featureTypeKey)
+    ) {
+      try plainCodec.decode(data)
+    }
+  }
+
+  @Test func encodingUnregisteredFeatureTypeThrowsAtSaveTime() throws {
+    // A codec must refuse to write a document it cannot read back.
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestRedBoostFeature(
+              id: FeatureID(rawValue: "save-time-red-boost"),
+              amount: 0.1
+            )
+          ),
+        ]
+      )
+    )
+
+    let plainCodec = ParametricDocumentCodec()
+    #expect(
+      throws: ParametricDocumentCodecError.unregisteredFeatureType(TestRedBoostFeature.featureTypeKey)
+    ) {
+      try plainCodec.encode(document)
+    }
+  }
+
+  @Test func plainJSONCodingWithoutCodecThrowsMissingRegistry() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(BrightnessFeature(id: FeatureID(rawValue: "plain-brightness"), value: 0.1)),
+        ]
+      )
+    )
+
+    #expect(throws: ParametricDocumentCodecError.missingRegistry) {
+      try JSONEncoder().encode(document)
+    }
+
+    let codec = ParametricDocumentCodec()
+    let data = try codec.encode(document)
+    #expect(throws: ParametricDocumentCodecError.missingRegistry) {
+      try JSONDecoder().decode(EditingDocument.self, from: data)
+    }
+  }
+
+  @Test func schemaVersionMigrationDecodesOldPayload() throws {
+    // Write with the v1 shape under the shared key, then decode with the v2
+    // type whose decodeParameters converts the old payload.
+    var writingCodec = ParametricDocumentCodec()
+    writingCodec.register(TestMigratingFeatureV1.self)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestMigratingFeatureV1(
+              id: FeatureID(rawValue: "migrating-feature"),
+              amount: 0.5
+            )
+          ),
+        ]
+      )
+    )
+    let data = try writingCodec.encode(document)
+
+    var readingCodec = ParametricDocumentCodec()
+    readingCodec.register(TestMigratingFeatureV2.self)
+    let decoded = try readingCodec.decode(data)
+
+    let firstFeature = try #require(decoded.mainTree.features.first)
+    guard case let .effect(effect) = firstFeature else {
+      Issue.record("expected the migrated v2 feature")
+      return
+    }
+    let migrated = try #require(effect as? TestMigratingFeatureV2, "expected the migrated v2 feature")
+    #expect(migrated.id == FeatureID(rawValue: "migrating-feature"))
+    #expect(migrated.strength == 0.5)
+  }
+
+  @Test func unsupportedDocumentFormatVersionThrows() throws {
+    let codec = ParametricDocumentCodec()
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(BrightnessFeature(id: FeatureID(rawValue: "format-brightness"), value: 0.1)),
+        ]
+      )
+    )
+    let data = try codec.encode(document)
+    let mutated = String(decoding: data, as: UTF8.self)
+      .replacingOccurrences(of: "\"formatVersion\":1", with: "\"formatVersion\":99")
+      .data(using: .utf8)!
+
+    #expect(throws: ParametricDocumentCodecError.unsupportedDocumentFormatVersion(99)) {
+      try codec.decode(mutated)
+    }
+  }
+
+  @Test func parametricImageRendererMatchesFeatureGraphCompiler() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "image-renderer-brightness"),
+              value: 0.05
+            )
+          ),
+          .effect(
+            SaturationFeature(
+              id: FeatureID(rawValue: "image-renderer-saturation"),
+              value: 0.12
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 36, height: 24)
+    )
+    let expected = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let output = try ParametricImageRenderer().makeImage(
+      from: input,
+      document: document
+    )
+
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  /// An `EffectPipelineFeature` (the document's bundled global-effects node)
+  /// must render identically to the same effects scattered as individual
+  /// `.effect` main-tree features. This is the contract that lets the editing
+  /// stack store one identity-stable effects node while the compiler flattens
+  /// it through `childFeatures`.
+  @Test func effectPipelineFeatureMatchesScatteredEffects() throws {
+    let brightness = BrightnessFeature(id: FeatureID(rawValue: "pipeline-brightness"), value: 0.05)
+    let saturation = SaturationFeature(id: FeatureID(rawValue: "pipeline-saturation"), value: 0.12)
+
+    let scattered = EditingDocument(
+      mainTree: MainTree(features: [.effect(brightness), .effect(saturation)])
+    )
+    let bundled = EditingDocument(
+      mainTree: MainTree(features: [
+        .effect(
+          EffectPipelineFeature(
+            id: FeatureID(rawValue: "pipeline-node"),
+            pipeline: EffectPipeline(effects: [brightness, saturation])
+          )
+        )
+      ])
+    )
+
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 36, height: 24)
+    )
+    let scatteredOutput = try Self.compiler.makeOutput(from: input, document: scattered).image
+    let bundledOutput = try Self.compiler.makeOutput(from: input, document: bundled).image
+
+    try Self.assertImagesMatch(scatteredOutput, bundledOutput, tolerance: 2)
+  }
+
+  @Test func videoFrameRendererMatchesDocumentRendering() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            ExposureFeature(
+              id: FeatureID(rawValue: "video-exposure"),
+              value: 0.4
+            )
+          ),
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "video-brightness"),
+              value: 0.04
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 44, height: 30)
+    )
+    let expected = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let output = try ParametricVideoRenderer().makeFrameImage(
+      from: input,
+      document: document
+    )
+
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  @Test func videoRendererResolvesCropOutputRenderSize() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "video-crop"),
+              cropRect: CGRect(x: 8, y: 6, width: 24, height: 18)
+            )
+          ),
+        ]
+      )
+    )
+
+    let renderSize = try ParametricVideoRenderer().resolveRenderSize(
+      sourceRenderSize: CGSize(width: 48, height: 36),
+      document: document,
+      mode: .featureOutput
+    )
+
+    #expect(renderSize == CGSize(width: 24, height: 18))
+  }
+
+  @Test func videoRendererCreatesVideoComposition() throws {
+    let assetSize = CGSize(width: 48, height: 36)
+    let asset = try Self.makeTestVideoAsset(size: assetSize)
+    defer {
+      try? FileManager.default.removeItem(at: asset.url)
+    }
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "video-composition-brightness"),
+              value: 0.03
+            )
+          ),
+        ]
+      )
+    )
+
+    let composition = try ParametricVideoRenderer().makeVideoComposition(
+      for: asset,
+      document: document,
+      renderSizeMode: .source
+    )
+
+    #expect(composition.renderSize == assetSize)
+  }
+
+  @Test func videoFrameRendererPlacesOutputInsideRenderExtent() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "video-crop-place"),
+              cropRect: CGRect(x: 8, y: 6, width: 24, height: 18)
+            )
+          ),
+          .effect(
+            BrightnessFeature(
+              id: FeatureID(rawValue: "video-crop-brightness"),
+              value: 0.05
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 48, height: 36)
+    )
+    let renderExtent = CGRect(x: 0, y: 0, width: 48, height: 36)
+    let featureOutput = try Self.compiler.makeOutput(
+      from: input,
+      document: document
+    )
+    .image
+    let expected = featureOutput
+      .composited(
+        over: CIImage(color: CIColor(red: 0, green: 0, blue: 0, alpha: 0))
+          .cropped(to: renderExtent)
+      )
+      .cropped(to: renderExtent)
+    let output = try ParametricVideoRenderer().makeFrameImage(
+      from: input,
+      document: document,
+      renderExtent: renderExtent
+    )
+
+    #expect(output.extent == renderExtent)
+    try Self.assertImagesMatch(
+      expected,
+      output,
+      tolerance: 2
+    )
+  }
+
+  @Test func multipleCropsEvaluateInCurrentDomain() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "crop-a"),
+              cropRect: CGRect(x: 10, y: 10, width: 80, height: 80)
+            )
+          ),
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "crop-b"),
+              cropRect: CGRect(x: 20, y: 20, width: 25, height: 30)
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricTestImage(
+      white: 1,
+      extent: CGRect(x: 0, y: 0, width: 100, height: 100)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    #expect(output.image.extent == CGRect(x: 0, y: 0, width: 25, height: 30))
+  }
+
+  @Test func imageEffectReceivesCurrentExtentAfterCrop() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "extent-probe-crop"),
+              cropRect: CGRect(x: 10, y: 8, width: 40, height: 20)
+            )
+          ),
+          .effect(
+            TestExtentProbeFeature(
+              id: FeatureID(rawValue: "extent-probe-effect")
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 80, height: 60)
+    )
+
+    let output = try FeatureGraphCompiler().makeOutput(from: input, document: document)
+
+    #expect(output.image.extent == CGRect(x: 0, y: 0, width: 40, height: 20))
+    let rendered = try Self.render(output.image)
+    let pixel = Self.rgba(in: rendered, x: 20, y: 10)
+    #expect(abs(Int(pixel.red) - 102) <= 2)
+    #expect(abs(Int(pixel.green) - 51) <= 2)
+  }
+
+  @Test func vignetteUsesCurrentExtentAfterCrop() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .domain(
+            CropFeature(
+              id: FeatureID(rawValue: "vignette-crop"),
+              cropRect: CGRect(x: 10, y: 8, width: 40, height: 20)
+            )
+          ),
+          .effect(
+            VignetteFeature(
+              id: FeatureID(rawValue: "vignette-after-crop"),
+              value: 0.5
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 80, height: 60)
+    )
+    let cropped = input
+      .cropped(to: CGRect(x: 10, y: 8, width: 40, height: 20))
+      .transformed(by: CGAffineTransform(translationX: -10, y: -8))
+    let expected = Self.vignetteEffectImage(value: 0.5, image: cropped)
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+
+    try Self.assertImagesMatch(expected, output.image, tolerance: 2)
+  }
+
+  @Test func localAdjustmentsAndGlobalEffectEvaluateInOrder() throws {
+    let localExposure = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "local-exposure"),
+      maskTree: MaskTree(
+        root: .brush(
+          BrushMask(
+            id: FeatureID(rawValue: "exposure-mask"),
+            strokes: [
+              BrushMaskStroke(
+                stamps: [CGPoint(x: 10, y: 10)],
+                brush: BrushMaskBrush(diameter: 16, hardness: 1, opacity: 1)
+              ),
+            ]
+          )
+        )
+      ),
+      effectPipeline: EffectPipeline(
+        effects: [
+          ExposureFeature(id: FeatureID(rawValue: "local-exposure-effect"), value: 1),
+        ]
+      )
+    )
+    let localBlur = LocalAdjustmentFeature(
+      id: FeatureID(rawValue: "local-blur"),
+      maskTree: MaskTree(
+        root: .brush(
+          BrushMask(
+            id: FeatureID(rawValue: "blur-mask"),
+            strokes: [
+              BrushMaskStroke(
+                stamps: [CGPoint(x: 20, y: 10)],
+                brush: BrushMaskBrush(diameter: 18, hardness: 1, opacity: 1)
+              ),
+            ]
+          )
+        )
+      ),
+      effectPipeline: EffectPipeline(
+        effects: [
+          GaussianBlurFeature(id: FeatureID(rawValue: "blur-effect"), radius: 5),
+        ]
+      )
+    )
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(localExposure),
+          .localAdjustment(localBlur),
+          .effect(BrightnessFeature(id: FeatureID(rawValue: "global-brightness"), value: 0.05)),
+        ]
+      )
+    )
+    let input = CIImage.parametricVerticalStripeImage(
+      extent: CGRect(x: 0, y: 0, width: 40, height: 20),
+      backgroundWhite: 0.15,
+      stripeWhite: 0.9,
+      stripeRect: CGRect(x: 22, y: 0, width: 2, height: 20)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+    let renderedImage = try Self.render(output.image)
+    let localPixel = Self.rgba(in: renderedImage, x: 10, y: 10)
+    let outsidePixel = Self.rgba(in: renderedImage, x: 0, y: 10)
+    let blurredNeighborPixel = Self.rgba(in: renderedImage, x: 19, y: 10)
+    let stripePixel = Self.rgba(in: renderedImage, x: 22, y: 10)
+
+    #expect(localPixel.red > outsidePixel.red)
+    #expect(blurredNeighborPixel.red > outsidePixel.red)
+    #expect(blurredNeighborPixel.red < stripePixel.red)
+  }
+
+  @Test func invertedMaskAppliesOutsideBrush() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "local-invert"),
+              maskTree: MaskTree(
+                root: .invert(
+                  .brush(
+                    BrushMask(
+                      id: FeatureID(rawValue: "center-mask"),
+                      strokes: [
+                        BrushMaskStroke(
+                          stamps: [CGPoint(x: 10, y: 10)],
+                          brush: BrushMaskBrush(diameter: 12, hardness: 1, opacity: 1)
+                        ),
+                      ]
+                    )
+                  )
+                )
+              ),
+              effectPipeline: EffectPipeline(
+                effects: [
+                  ExposureFeature(id: FeatureID(rawValue: "invert-exposure"), value: 1),
+                ]
+              )
+            )
+          ),
+        ]
+      )
+    )
+    let input = CIImage.parametricTestImage(
+      white: 0.2,
+      extent: CGRect(x: 0, y: 0, width: 20, height: 20)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: document)
+    let renderedImage = try Self.render(output.image)
+    let center = Self.rgba(in: renderedImage, x: 10, y: 10)
+    let corner = Self.rgba(in: renderedImage, x: 1, y: 1)
+
+    #expect(corner.red > center.red)
+  }
+
+  @Test func duplicateIDsThrowValidationError() throws {
+    let id = FeatureID(rawValue: "duplicate")
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(BrightnessFeature(id: id, value: 0.1)),
+          .effect(ExposureFeature(id: id, value: 0.1)),
+        ]
+      )
+    )
+
+    #expect(throws: FeatureGraphCompilerError.duplicateID(id)) {
+      try Self.compiler.makeOutput(from: Self.smallInput, document: document)
+    }
+  }
+
+  @Test func emptyLocalAdjustmentPipelineThrowsValidationError() throws {
+    let id = FeatureID(rawValue: "empty-local")
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: id,
+              maskTree: MaskTree(root: .brush(BrushMask(id: FeatureID(rawValue: "mask")))),
+              effectPipeline: EffectPipeline()
+            )
+          ),
+        ]
+      )
+    )
+
+    #expect(throws: FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(id)) {
+      try Self.compiler.makeOutput(from: Self.smallInput, document: document)
+    }
+  }
+
+  @Test func metalKernelRegistryCanCreateBrushStampRecipe() throws {
+    let registry = ParametricKernelRegistry()
+
+    let image = try registry.makeBrushStamp(
+      extent: CGRect(x: 0, y: 0, width: 12, height: 12),
+      center: CGPoint(x: 6, y: 6),
+      radius: 4,
+      hardness: 0.5,
+      opacity: 1
+    )
+
+    #expect(image.extent == CGRect(x: 0, y: 0, width: 12, height: 12))
+  }
+
+  private static let compiler = FeatureGraphCompiler()
+
+  private static let smallInput = CIImage.parametricTestImage(
+    white: 0.5,
+    extent: CGRect(x: 0, y: 0, width: 8, height: 8)
+  )
+
+  private static let context = CIContext()
+
+  private static func render(_ image: CIImage) throws -> CGImage {
+    try #require(Self.context.createCGImage(image, from: image.extent))
+  }
+
+  private static func rgba(in image: CGImage, x: Int, y: Int) -> RGBA {
+    let width = image.width
+    let height = image.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let context = CGContext(
+      data: &pixels,
+      width: width,
+      height: height,
+      bitsPerComponent: 8,
+      bytesPerRow: width * 4,
+      space: colorSpace,
+      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        | CGBitmapInfo.byteOrder32Big.rawValue
+    )!
+
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    let index = (y * width + x) * 4
+    return RGBA(
+      red: pixels[index],
+      green: pixels[index + 1],
+      blue: pixels[index + 2],
+      alpha: pixels[index + 3]
+    )
+  }
+
+  private static func assertImagesMatch(
+    _ lhs: CIImage,
+    _ rhs: CIImage,
+    tolerance: Int,
+    sourceLocation: SourceLocation = SourceLocation(
+      fileID: #fileID,
+      filePath: #filePath,
+      line: #line,
+      column: #column
+    )
+  ) throws {
+    #expect(lhs.extent == rhs.extent, sourceLocation: sourceLocation)
+
+    let lhsImage = try render(lhs)
+    let rhsImage = try render(rhs)
+    #expect(lhsImage.width == rhsImage.width, sourceLocation: sourceLocation)
+    #expect(lhsImage.height == rhsImage.height, sourceLocation: sourceLocation)
+
+    let sampleXs = [4, lhsImage.width / 3, lhsImage.width / 2, max(lhsImage.width - 5, 0)]
+    let sampleYs = [4, lhsImage.height / 3, lhsImage.height / 2, max(lhsImage.height - 5, 0)]
+
+    for y in sampleYs {
+      for x in sampleXs {
+        let lhsPixel = rgba(in: lhsImage, x: x, y: y)
+        let rhsPixel = rgba(in: rhsImage, x: x, y: y)
+        #expect(
+          abs(Int(lhsPixel.red) - Int(rhsPixel.red)) <= tolerance,
+          "red mismatch at \(x),\(y)",
+          sourceLocation: sourceLocation
+        )
+        #expect(
+          abs(Int(lhsPixel.green) - Int(rhsPixel.green)) <= tolerance,
+          "green mismatch at \(x),\(y)",
+          sourceLocation: sourceLocation
+        )
+        #expect(
+          abs(Int(lhsPixel.blue) - Int(rhsPixel.blue)) <= tolerance,
+          "blue mismatch at \(x),\(y)",
+          sourceLocation: sourceLocation
+        )
+        #expect(
+          abs(Int(lhsPixel.alpha) - Int(rhsPixel.alpha)) <= tolerance,
+          "alpha mismatch at \(x),\(y)",
+          sourceLocation: sourceLocation
+        )
+      }
+    }
+  }
+
+  private static func vignetteEffectImage(value: Double, image: CIImage) -> CIImage {
+    let extent = image.extent
+    let radius = max(extent.width, extent.height) * 0.5
+    return image.applyingFilter(
+      "CIVignetteEffect",
+      parameters: [
+        kCIInputCenterKey: CIVector(x: extent.midX, y: extent.midY),
+        kCIInputRadiusKey: radius,
+        kCIInputIntensityKey: value,
+        "inputFalloff": 0.5,
+      ]
+    )
+    .cropped(to: extent)
+  }
+
+  private static func makeTestVideoAsset(size: CGSize) throws -> AVURLAsset {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("brightroom-parametric-\(UUID().uuidString)")
+      .appendingPathExtension("mov")
+    let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+    let input = AVAssetWriterInput(
+      mediaType: .video,
+      outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: Int(size.width),
+        AVVideoHeightKey: Int(size.height),
+      ]
+    )
+    let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+      assetWriterInput: input,
+      sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: Int(size.width),
+        kCVPixelBufferHeightKey as String: Int(size.height),
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ]
+    )
+
+    guard writer.canAdd(input) else {
+      throw TestVideoAssetError.cannotAddInput
+    }
+
+    writer.add(input)
+
+    guard writer.startWriting() else {
+      throw writer.error ?? TestVideoAssetError.cannotStartWriting
+    }
+
+    writer.startSession(atSourceTime: .zero)
+
+    let pixelBuffer = try makeTestPixelBuffer(
+      width: Int(size.width),
+      height: Int(size.height)
+    )
+    while !input.isReadyForMoreMediaData {
+      RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+    }
+
+    guard adaptor.append(pixelBuffer, withPresentationTime: .zero) else {
+      throw writer.error ?? TestVideoAssetError.cannotAppendFrame
+    }
+
+    input.markAsFinished()
+
+    let semaphore = DispatchSemaphore(value: 0)
+    writer.finishWriting {
+      semaphore.signal()
+    }
+    semaphore.wait()
+
+    guard writer.status == .completed else {
+      throw writer.error ?? TestVideoAssetError.cannotFinishWriting(writer.status)
+    }
+
+    return AVURLAsset(url: url)
+  }
+
+  private static func makeTestPixelBuffer(width: Int, height: Int) throws -> CVPixelBuffer {
+    var pixelBuffer: CVPixelBuffer?
+    let result = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_32BGRA,
+      [
+        kCVPixelBufferIOSurfacePropertiesKey as String: [:],
+      ] as CFDictionary,
+      &pixelBuffer
+    )
+
+    guard result == kCVReturnSuccess, let pixelBuffer else {
+      throw TestVideoAssetError.cannotCreatePixelBuffer(result)
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, [])
+    defer {
+      CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+    }
+
+    guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) else {
+      throw TestVideoAssetError.missingPixelBufferBaseAddress
+    }
+
+    let bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer)
+
+    for y in 0..<height {
+      let row = baseAddress
+        .advanced(by: y * bytesPerRow)
+        .assumingMemoryBound(to: UInt8.self)
+
+      for x in 0..<width {
+        let offset = x * 4
+        row[offset] = UInt8(80 + (x % 24))
+        row[offset + 1] = UInt8(100 + (y % 32))
+        row[offset + 2] = UInt8(160)
+        row[offset + 3] = UInt8(255)
+      }
+    }
+
+    return pixelBuffer
+  }
+
+  private struct RGBA: Equatable {
+    var red: UInt8
+    var green: UInt8
+    var blue: UInt8
+    var alpha: UInt8
+  }
+
+  private struct TestRedBoostFeature: ImageEffectFeatureType, PersistableFeature {
+
+    static let featureTypeKey: FeatureTypeKey = "test.red-boost"
+
+    var id: FeatureID = .init()
+    var isEnabled: Bool = true
+    var amount: Double
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      image.applyingFilter(
+        "CIColorMatrix",
+        parameters: [
+          "inputRVector": CIVector(x: 1, y: 0, z: 0, w: 0),
+          "inputGVector": CIVector(x: 0, y: 1, z: 0, w: 0),
+          "inputBVector": CIVector(x: 0, y: 0, z: 1, w: 0),
+          "inputAVector": CIVector(x: 0, y: 0, z: 0, w: 1),
+          "inputBiasVector": CIVector(x: CGFloat(amount), y: 0, z: 0, w: 0),
+        ]
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  private struct TestExtentProbeFeature: ImageEffectFeatureType {
+
+    var id: FeatureID = .init()
+    var isEnabled: Bool = true
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      CIImage(
+        color: CIColor(
+          red: min(image.extent.width / 100, 1),
+          green: min(image.extent.height / 100, 1),
+          blue: 0,
+          alpha: 1
+        )
+      )
+      .cropped(to: image.extent)
+    }
+  }
+
+  /// The v1 shape of the migrating test feature: field named `amount`.
+  private struct TestMigratingFeatureV1: ImageEffectFeatureType, PersistableFeature {
+
+    static let featureTypeKey: FeatureTypeKey = "test.migrating"
+
+    var id: FeatureID = .init()
+    var isEnabled: Bool = true
+    var amount: Double
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      image
+    }
+  }
+
+  /// The v2 shape under the same key: field renamed to `strength`, with a
+  /// typed migration from the v1 payload.
+  private struct TestMigratingFeatureV2: ImageEffectFeatureType, PersistableFeature {
+
+    static let featureTypeKey: FeatureTypeKey = "test.migrating"
+    static let schemaVersion = 2
+
+    var id: FeatureID = .init()
+    var isEnabled: Bool = true
+    var strength: Double
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      image
+    }
+
+    static func decodeParameters(from decoder: Decoder, version: Int) throws -> Self {
+      switch version {
+      case 2:
+        return try Self(from: decoder)
+      case 1:
+        struct V1: Decodable {
+          var id: FeatureID
+          var isEnabled: Bool
+          var amount: Double
+        }
+        let old = try V1(from: decoder)
+        return Self(id: old.id, isEnabled: old.isEnabled, strength: old.amount)
+      default:
+        throw ParametricDocumentCodecError.unsupportedSchemaVersion(
+          featureTypeKey,
+          version: version
+        )
+      }
+    }
+  }
+
+  private enum TestVideoAssetError: Error {
+    case cannotAddInput
+    case cannotStartWriting
+    case cannotAppendFrame
+    case cannotFinishWriting(AVAssetWriter.Status)
+    case cannotCreatePixelBuffer(CVReturn)
+    case missingPixelBufferBaseAddress
+  }
+}
+
+private extension CIImage {
+
+  static func parametricTestImage(white: CGFloat, extent: CGRect) -> CIImage {
+    CIImage(color: CIColor(red: white, green: white, blue: white, alpha: 1))
+      .cropped(to: extent)
+  }
+
+  static func parametricVerticalStripeImage(
+    extent: CGRect,
+    backgroundWhite: CGFloat,
+    stripeWhite: CGFloat,
+    stripeRect: CGRect
+  ) -> CIImage {
+    let background = CIImage.parametricTestImage(
+      white: backgroundWhite,
+      extent: extent
+    )
+    let stripe = CIImage.parametricTestImage(white: stripeWhite, extent: stripeRect)
+
+    return stripe.applyingFilter(
+      "CISourceOverCompositing",
+      parameters: [kCIInputBackgroundImageKey: background]
+    )
+    .cropped(to: extent)
+  }
+
+  static func parametricColorPatchImage(extent: CGRect) -> CIImage {
+    let background = CIImage(color: CIColor(red: 0.18, green: 0.32, blue: 0.52, alpha: 1))
+      .cropped(to: extent)
+    let warmPatch = CIImage(color: CIColor(red: 0.86, green: 0.26, blue: 0.18, alpha: 0.82))
+      .cropped(
+        to: CGRect(
+          x: extent.minX + extent.width * 0.18,
+          y: extent.minY,
+          width: extent.width * 0.22,
+          height: extent.height
+        )
+      )
+    let coolPatch = CIImage(color: CIColor(red: 0.16, green: 0.45, blue: 0.92, alpha: 0.78))
+      .cropped(
+        to: CGRect(
+          x: extent.minX + extent.width * 0.56,
+          y: extent.minY,
+          width: extent.width * 0.28,
+          height: extent.height
+        )
+      )
+    let brightPatch = CIImage(color: CIColor(red: 0.95, green: 0.92, blue: 0.76, alpha: 0.65))
+      .cropped(
+        to: CGRect(
+          x: extent.minX,
+          y: extent.minY + extent.height * 0.2,
+          width: extent.width,
+          height: extent.height * 0.3
+        )
+      )
+
+    return [warmPatch, coolPatch, brightPatch].reduce(background) { image, patch in
+      patch.applyingFilter(
+        "CISourceOverCompositing",
+        parameters: [kCIInputBackgroundImageKey: image]
+      )
+    }
+    .cropped(to: extent)
+  }
+}


### PR DESCRIPTION
## Summary

- add `BrightroomParametric` as a dependency-free Swift Package product and target
- bring the committed parametric feature tree, compiler, persistence, image/video renderers, Metal kernels, and debugging surface from the `v5` foundation onto `main`
- add `ColorCubeFeature` loading from `.cube`, PNG, JPEG, and in-memory `CGImage` sources for the BrightroomVideo integration
- add an Engine-independent `BrightroomParametricTests` target and run it in CI

## Scope

This PR intentionally does not make BrightroomEngine or BrightroomUI depend on BrightroomParametric. Existing products therefore keep their current behavior; integration can follow in smaller PRs.

It also excludes the `FeatureGraphValidator`, recursive document-ID reservation, and compiler integration work that was intentionally rolled back from the `v5` checkout.

The package keeps the existing Swift tools 5.9 and iOS 17 settings. It does not claim package-wide macOS support or introduce a Swift 6 migration.

## ColorCube API

The public initializer signatures match the implementation currently consumed by MuApps/BrightroomVideo. This branch additionally guards cube-size arithmetic against overflow and parses `TITLE` as an exact directive. Tests live in the Parametric-only target rather than BrightroomEngineTests.

## Checks

- `xcodebuild -scheme Brightroom-Package -destination 'platform=iOS Simulator,id=9733FFE2-9CB8-4AE6-AA97-92B52DB2BA28' -only-testing:BrightroomParametricTests CODE_SIGNING_ALLOWED=NO test` — 32 tests passed
- `xcodebuild -scheme BrightroomParametric -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` — succeeded
- `swift package dump-package` — succeeded

Local validation used Xcode 26.6 / iOS 26.5; CI remains pinned to Xcode 26.2 / iOS 26.2.