### PR TITLE
Optimize ColorCube text parsing

### DIFF
--- a/Sources/BrightroomParametric/ColorCube/ColorCubeTextFileParser.swift
+++ b/Sources/BrightroomParametric/ColorCube/ColorCubeTextFileParser.swift
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
 //
 
+import Darwin
 import Foundation
 
 /// The internal representation produced while parsing a `.cube` text file.
@@ -9,6 +10,175 @@ struct _ParsedColorCube {
   let title: String?
   let dimension: Int
   let cubeData: Data
+}
+
+/// A trimmed, comment-free line in a color-cube text source.
+private struct _ColorCubeTextLine {
+  let range: Range<Int>
+  let number: Int
+}
+
+/// Provides allocation-free token and numeric access to one UTF-8 source.
+///
+/// The source is valid only while the parser's UTF-8 storage is borrowed.
+private struct _ColorCubeUTF8Source {
+
+  let bytes: UnsafeBufferPointer<UInt8>
+
+  func nextToken(
+    in line: _ColorCubeTextLine,
+    cursor: inout Int
+  ) -> Range<Int>? {
+    while cursor < line.range.upperBound, Self.isWhitespace(bytes[cursor]) {
+      cursor += 1
+    }
+    guard cursor < line.range.upperBound else {
+      return nil
+    }
+
+    let start = cursor
+    while cursor < line.range.upperBound, Self.isWhitespace(bytes[cursor]) == false {
+      cursor += 1
+    }
+    return start..<cursor
+  }
+
+  func string(in range: Range<Int>) -> String {
+    guard let baseAddress = bytes.baseAddress else {
+      return ""
+    }
+    return String(
+      decoding: UnsafeBufferPointer(
+        start: baseAddress.advanced(by: range.lowerBound),
+        count: range.count
+      ),
+      as: UTF8.self
+    )
+  }
+
+  func token(
+    in range: Range<Int>,
+    equalsASCII keyword: StaticString
+  ) -> Bool {
+    keyword.withUTF8Buffer { keywordBytes in
+      guard range.count == keywordBytes.count else {
+        return false
+      }
+      for offset in keywordBytes.indices {
+        guard
+          Self.uppercasedASCII(bytes[range.lowerBound + offset])
+            == Self.uppercasedASCII(keywordBytes[offset])
+        else {
+          return false
+        }
+      }
+      return true
+    }
+  }
+
+  /// Parses one complete token while borrowing the source's trailing NUL byte.
+  func float(in range: Range<Int>) -> Float? {
+    guard let baseAddress = bytes.baseAddress else {
+      return nil
+    }
+
+    let tokenStart = UnsafeRawPointer(
+      baseAddress.advanced(by: range.lowerBound)
+    ).assumingMemoryBound(to: CChar.self)
+    var parsedEnd: UnsafeMutablePointer<CChar>?
+    let value = strtof(tokenStart, &parsedEnd)
+    let expectedEnd = UnsafeMutablePointer(mutating: tokenStart)
+      .advanced(by: range.count)
+    guard parsedEnd == expectedEnd else {
+      return nil
+    }
+    return value
+  }
+
+  static func isWhitespace(_ byte: UInt8) -> Bool {
+    switch byte {
+    case 0x09, 0x0B, 0x0C, 0x0D, 0x20:
+      return true
+    default:
+      return false
+    }
+  }
+
+  private static func uppercasedASCII(_ byte: UInt8) -> UInt8 {
+    guard byte >= 0x61, byte <= 0x7A else {
+      return byte
+    }
+    return byte - 0x20
+  }
+}
+
+/// Iterates logical lines without first splitting the complete source string.
+private struct _ColorCubeTextLineIterator: IteratorProtocol {
+
+  private let source: _ColorCubeUTF8Source
+  private var cursor = 0
+  private var lineNumber = 0
+
+  init(source: _ColorCubeUTF8Source) {
+    self.source = source
+  }
+
+  mutating func next() -> _ColorCubeTextLine? {
+    while cursor < source.bytes.count {
+      lineNumber += 1
+      let lineStart = cursor
+      while
+        cursor < source.bytes.count,
+        source.bytes[cursor] != 0x0A,
+        source.bytes[cursor] != 0x0D
+      {
+        cursor += 1
+      }
+      let lineEnd = cursor
+
+      if cursor < source.bytes.count {
+        let newline = source.bytes[cursor]
+        cursor += 1
+        if
+          newline == 0x0D,
+          cursor < source.bytes.count,
+          source.bytes[cursor] == 0x0A
+        {
+          cursor += 1
+        }
+      }
+
+      var contentEnd = lineStart
+      while contentEnd < lineEnd, source.bytes[contentEnd] != 0x23 {
+        contentEnd += 1
+      }
+
+      var trimmedStart = lineStart
+      while
+        trimmedStart < contentEnd,
+        _ColorCubeUTF8Source.isWhitespace(source.bytes[trimmedStart])
+      {
+        trimmedStart += 1
+      }
+
+      var trimmedEnd = contentEnd
+      while
+        trimmedEnd > trimmedStart,
+        _ColorCubeUTF8Source.isWhitespace(source.bytes[trimmedEnd - 1])
+      {
+        trimmedEnd -= 1
+      }
+
+      guard trimmedStart < trimmedEnd else {
+        continue
+      }
+      return _ColorCubeTextLine(
+        range: trimmedStart..<trimmedEnd,
+        number: lineNumber
+      )
+    }
+    return nil
+  }
 }
 
 /// Parses three-dimensional `.cube` text without exposing parser mechanics as
@@ -20,95 +190,138 @@ struct _ColorCubeTextParser {
   }
 
   func parse(_ string: String) throws -> _ParsedColorCube {
+    var utf8 = Array(string.utf8)
+    // `strtof` may inspect one byte past the final token.
+    utf8.append(0)
+
+    return try utf8.withUnsafeBufferPointer { buffer in
+      guard let baseAddress = buffer.baseAddress else {
+        throw ColorCubeFeatureLoadingError.missingLUT3DSize
+      }
+      let source = _ColorCubeUTF8Source(
+        bytes: UnsafeBufferPointer(
+          start: baseAddress,
+          count: buffer.count - 1
+        )
+      )
+      return try parse(source)
+    }
+  }
+
+  private func parse(_ source: _ColorCubeUTF8Source) throws -> _ParsedColorCube {
     var title: String?
     var dimension: Int?
     var domainMin: [Float] = [0, 0, 0]
     var domainMax: [Float] = [1, 1, 1]
-    var rows: [[Float]] = []
+    var rgbaValues: [Float] = []
+    var lines = _ColorCubeTextLineIterator(source: source)
 
-    for (lineIndex, rawLine) in string.components(separatedBy: .newlines).enumerated() {
-      let lineNumber = lineIndex + 1
-      let line = rawLine
-        .components(separatedBy: "#")
-        .first?
-        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-      guard line.isEmpty == false else {
+    while let line = lines.next() {
+      var cursor = line.range.lowerBound
+      guard let keyword = source.nextToken(in: line, cursor: &cursor) else {
         continue
       }
 
-      let tokens = line.split(whereSeparator: \.isWhitespace).map(String.init)
-      guard let keyword = tokens.first else {
+      if source.token(in: keyword, equalsASCII: "TITLE") {
+        title = parseTitle(
+          from: line,
+          after: keyword,
+          source: source
+        )
         continue
       }
 
-      switch keyword.uppercased() {
-      case "TITLE":
-        title = parseTitle(from: line)
-
-      case "LUT_3D_SIZE":
-        let value = tokens.dropFirst().joined(separator: " ")
-        guard tokens.count == 2,
-              let parsedDimension = Int(tokens[1]),
-              Self.cubePixelCount(dimension: parsedDimension) != nil
+      if source.token(in: keyword, equalsASCII: "LUT_3D_SIZE") {
+        let valueTokens = remainingTokens(
+          in: line,
+          cursor: &cursor,
+          source: source
+        )
+        let value = valueTokens
+          .map(source.string(in:))
+          .joined(separator: " ")
+        guard
+          valueTokens.count == 1,
+          let parsedDimension = Int(source.string(in: valueTokens[0])),
+          let pixelCount = Self.cubePixelCount(dimension: parsedDimension)
         else {
           throw ColorCubeFeatureLoadingError.invalidLUT3DSize(
             value,
-            line: lineNumber
+            line: line.number
           )
         }
         dimension = parsedDimension
+        rgbaValues.reserveCapacity(pixelCount * 4)
+        continue
+      }
 
-      case "LUT_1D_SIZE":
-        throw ColorCubeFeatureLoadingError.unsupportedLUT1DSize(line: lineNumber)
+      if source.token(in: keyword, equalsASCII: "LUT_1D_SIZE") {
+        throw ColorCubeFeatureLoadingError.unsupportedLUT1DSize(
+          line: line.number
+        )
+      }
 
-      case "DOMAIN_MIN":
+      if source.token(in: keyword, equalsASCII: "DOMAIN_MIN") {
         domainMin = try parseFloatValues(
-          from: tokens,
+          in: line,
+          cursor: &cursor,
           expectedCount: 3,
-          directive: keyword,
-          line: line,
-          lineNumber: lineNumber
+          directive: source.string(in: keyword),
+          source: source
         )
+        continue
+      }
 
-      case "DOMAIN_MAX":
+      if source.token(in: keyword, equalsASCII: "DOMAIN_MAX") {
         domainMax = try parseFloatValues(
-          from: tokens,
+          in: line,
+          cursor: &cursor,
           expectedCount: 3,
-          directive: keyword,
-          line: line,
-          lineNumber: lineNumber
+          directive: source.string(in: keyword),
+          source: source
         )
+        continue
+      }
 
-      case "LUT_3D_INPUT_RANGE":
+      if source.token(in: keyword, equalsASCII: "LUT_3D_INPUT_RANGE") {
         let range = try parseFloatValues(
-          from: tokens,
+          in: line,
+          cursor: &cursor,
           expectedCount: 2,
-          directive: keyword,
-          line: line,
-          lineNumber: lineNumber
+          directive: source.string(in: keyword),
+          source: source
         )
         domainMin = [range[0], range[0], range[0]]
         domainMax = [range[1], range[1], range[1]]
+        continue
+      }
 
-      default:
-        guard Float(keyword) != nil else {
-          throw ColorCubeFeatureLoadingError.invalidDirective(
-            keyword,
-            line: lineNumber
-          )
-        }
-
-        rows.append(
-          try parseFloatValues(
-            from: ["DATA"] + tokens,
-            expectedCount: 3,
-            directive: "DATA",
-            line: line,
-            lineNumber: lineNumber
-          )
+      guard let red = source.float(in: keyword) else {
+        throw ColorCubeFeatureLoadingError.invalidDirective(
+          source.string(in: keyword),
+          line: line.number
         )
       }
+      guard
+        red.isFinite,
+        let greenToken = source.nextToken(in: line, cursor: &cursor),
+        let blueToken = source.nextToken(in: line, cursor: &cursor),
+        source.nextToken(in: line, cursor: &cursor) == nil,
+        let green = source.float(in: greenToken),
+        green.isFinite,
+        let blue = source.float(in: blueToken),
+        blue.isFinite
+      else {
+        throw ColorCubeFeatureLoadingError.invalidDataLine(
+          source.string(in: line.range),
+          line: line.number
+        )
+      }
+
+      rgbaValues.append(red)
+      rgbaValues.append(green)
+      rgbaValues.append(blue)
+      rgbaValues.append(1)
     }
 
     guard let dimension else {
@@ -123,17 +336,12 @@ struct _ColorCubeTextParser {
     }
 
     let expectedRowCount = dimension * dimension * dimension
-    guard rows.count == expectedRowCount else {
+    let actualRowCount = rgbaValues.count / 4
+    guard actualRowCount == expectedRowCount else {
       throw ColorCubeFeatureLoadingError.mismatchedDataCount(
         expected: expectedRowCount,
-        actual: rows.count
+        actual: actualRowCount
       )
-    }
-
-    var rgbaValues: [Float] = []
-    rgbaValues.reserveCapacity(expectedRowCount * 4)
-    for row in rows {
-      rgbaValues.append(contentsOf: [row[0], row[1], row[2], 1])
     }
 
     return _ParsedColorCube(
@@ -143,48 +351,70 @@ struct _ColorCubeTextParser {
     )
   }
 
-  private func parseTitle(from line: String) -> String? {
-    let title = String(line.dropFirst("TITLE".count))
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-
-    guard title.isEmpty == false else {
+  private func parseTitle(
+    from line: _ColorCubeTextLine,
+    after keyword: Range<Int>,
+    source: _ColorCubeUTF8Source
+  ) -> String? {
+    var start = keyword.upperBound
+    while
+      start < line.range.upperBound,
+      _ColorCubeUTF8Source.isWhitespace(source.bytes[start])
+    {
+      start += 1
+    }
+    guard start < line.range.upperBound else {
       return nil
     }
 
-    if title.hasPrefix("\""), title.hasSuffix("\""), title.count >= 2 {
-      return String(title.dropFirst().dropLast())
+    var titleRange = start..<line.range.upperBound
+    if
+      titleRange.count >= 2,
+      source.bytes[titleRange.lowerBound] == 0x22,
+      source.bytes[titleRange.upperBound - 1] == 0x22
+    {
+      titleRange = (titleRange.lowerBound + 1)..<(titleRange.upperBound - 1)
     }
-    return title
+    return source.string(in: titleRange)
+  }
+
+  private func remainingTokens(
+    in line: _ColorCubeTextLine,
+    cursor: inout Int,
+    source: _ColorCubeUTF8Source
+  ) -> [Range<Int>] {
+    var result: [Range<Int>] = []
+    while let token = source.nextToken(in: line, cursor: &cursor) {
+      result.append(token)
+    }
+    return result
   }
 
   private func parseFloatValues(
-    from tokens: [String],
+    in line: _ColorCubeTextLine,
+    cursor: inout Int,
     expectedCount: Int,
     directive: String,
-    line: String,
-    lineNumber: Int
+    source: _ColorCubeUTF8Source
   ) throws -> [Float] {
-    let valueTokens = Array(tokens.dropFirst())
-    guard valueTokens.count == expectedCount else {
-      throw parseError(
-        directive: directive,
-        line: line,
-        lineNumber: lineNumber
-      )
-    }
-
-    let values = valueTokens.compactMap { token -> Float? in
-      guard let value = Float(token), value.isFinite else {
-        return nil
+    var values: [Float] = []
+    values.reserveCapacity(expectedCount)
+    while let token = source.nextToken(in: line, cursor: &cursor) {
+      guard let value = source.float(in: token), value.isFinite else {
+        throw parseError(
+          directive: directive,
+          line: source.string(in: line.range),
+          lineNumber: line.number
+        )
       }
-      return value
+      values.append(value)
     }
 
     guard values.count == expectedCount else {
       throw parseError(
         directive: directive,
-        line: line,
-        lineNumber: lineNumber
+        line: source.string(in: line.range),
+        lineNumber: line.number
       )
     }
     return values
@@ -195,7 +425,11 @@ struct _ColorCubeTextParser {
     line: String,
     lineNumber: Int
   ) -> ColorCubeFeatureLoadingError {
-    if directive.hasPrefix("DOMAIN") || directive == "LUT_3D_INPUT_RANGE" {
+    let uppercasedDirective = directive.uppercased()
+    if
+      uppercasedDirective.hasPrefix("DOMAIN")
+        || uppercasedDirective == "LUT_3D_INPUT_RANGE"
+    {
       return .invalidDomain(line, line: lineNumber)
     }
     return .invalidDataLine(line, line: lineNumber)
@@ -219,8 +453,12 @@ struct _ColorCubeTextParser {
       return nil
     }
 
-    let (square, squareOverflowed) = dimension.multipliedReportingOverflow(by: dimension)
-    let (cube, cubeOverflowed) = square.multipliedReportingOverflow(by: dimension)
+    let (square, squareOverflowed) = dimension.multipliedReportingOverflow(
+      by: dimension
+    )
+    let (cube, cubeOverflowed) = square.multipliedReportingOverflow(
+      by: dimension
+    )
     guard
       squareOverflowed == false,
       cubeOverflowed == false,

--- a/Tests/BrightroomParametricTests/ColorCubeFeatureLoadingTests.swift
+++ b/Tests/BrightroomParametricTests/ColorCubeFeatureLoadingTests.swift
@@ -39,6 +39,74 @@ struct ColorCubeFeatureLoadingTests {
     #expect(feature.cubeData.count == 2 * 2 * 2 * 4 * MemoryLayout<Float>.size)
   }
 
+  @Test func `Color cube parser reads CRLF comments and numeric exponents`() throws {
+    let cube = [
+      "  # DaVinci Resolve style comment",
+      "title \"Identity ü\" # inline comment",
+      "lut_3d_size\t2",
+      "lut_3d_input_range 0e0 1e0",
+      "",
+      "0 0 0",
+      "1e0 0 0",
+      "0 1 0",
+      "1 1 0",
+      "0 0 1",
+      "1 0 1",
+      "0 1 1",
+      "1 1 1 # final value",
+    ].joined(separator: "\r\n")
+
+    let parsed = try _ColorCubeTextParser().parse(cube)
+    let values = parsed.cubeData.withUnsafeBytes {
+      Array($0.bindMemory(to: Float.self))
+    }
+
+    #expect(parsed.title == "Identity ü")
+    #expect(parsed.dimension == 2)
+    #expect(
+      values == [
+        0, 0, 0, 1,
+        1, 0, 0, 1,
+        0, 1, 0, 1,
+        1, 1, 0, 1,
+        0, 0, 1, 1,
+        1, 0, 1, 1,
+        0, 1, 1, 1,
+        1, 1, 1, 1,
+      ]
+    )
+  }
+
+  @Test func `Color cube parser materializes a production-sized cube`() throws {
+    let parsed = try _ColorCubeTextParser().parse(
+      Self.identityCube(size: 64, title: "Identity 64")
+    )
+
+    #expect(parsed.title == "Identity 64")
+    #expect(parsed.dimension == 64)
+    #expect(
+      parsed.cubeData.count
+        == 64 * 64 * 64 * 4 * MemoryLayout<Float>.size
+    )
+  }
+
+  @Test func `Color cube parser preserves malformed data diagnostics`() {
+    let cube = [
+      "LUT_3D_SIZE 2",
+      "0 0 0",
+      "0 0",
+    ].joined(separator: "\n")
+
+    #expect(
+      throws: ColorCubeFeatureLoadingError.invalidDataLine(
+        "0 0",
+        line: 3
+      )
+    ) {
+      try _ColorCubeTextParser().parse(cube)
+    }
+  }
+
   @Test func `Color cube feature normalizes image LUT data`() throws {
     let image = try Self.makeCubeImage()
     let feature = try ColorCubeFeature(


### PR DESCRIPTION
## Summary

- scan `.cube` input as one UTF-8 buffer instead of allocating strings and token arrays for every line
- append parsed RGB rows directly into the final RGBA buffer instead of retaining `[[Float]]` and copying it afterward
- preserve comments, CRLF, case-insensitive directives, numeric exponents, UTF-8 titles, and existing malformed-input diagnostics
- add coverage for real-world syntax and production-sized cube data

## Why

Time Profiler data from Farg preview rendering showed `_ColorCubeTextParser` accounting for essentially all preview CPU time. Rendering was already concurrent; the bottleneck was allocation-heavy text parsing being repeated across previews.

## Performance

Measured with a real 65³ `Luna.cube` file containing 274,625 data rows and 6,663,767 UTF-8 bytes. Results are median wall time with a warm OS file cache and include `String(contentsOf:)`:

| Configuration | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Debug | 1,177.133 ms | 151.876 ms | 7.7× |
| Release | 529.922 ms | 19.671 ms | 26.9× |

## Validation

- built `BrightroomParametricTests` for the iOS Simulator with Xcode 26.6
- ran all 35 BrightroomParametric tests across 4 suites successfully
- verified a generated 64³ cube, CRLF/comments/exponents/UTF-8 title handling, and malformed-data diagnostics
- `git diff --check` passes