### PR TITLE
Pass presentation time through parametric rendering

### DIFF
--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 import CoreImage
+import CoreMedia
 import Foundation
 
 /// Compiles a parametric editing document into a Core Image graph.
@@ -67,17 +68,22 @@ public struct FeatureGraphCompiler: Sendable {
   /// - Parameters:
   ///   - input: The source image used as the first graph node.
   ///   - document: The parametric document to evaluate.
+  ///   - radiusReferenceExtent: The full source extent in the current render
+  ///     pixel space, used to resolve proportional radii.
+  ///   - presentationTime: The presentation time represented by `input`.
   /// - Returns: The final image recipe and debug mask outputs.
   public func makeOutput(
     from input: CIImage,
     document: EditingDocument,
-    radiusReferenceExtent: CGRect? = nil
+    radiusReferenceExtent: CGRect? = nil,
+    presentationTime: CMTime = .zero
   ) throws -> FeatureGraphOutput {
     try validate(document)
 
     let context = FeatureEvaluationContext(
       kernelRegistry: kernelRegistry,
-      radiusReferenceExtent: radiusReferenceExtent
+      radiusReferenceExtent: radiusReferenceExtent,
+      presentationTime: presentationTime
     )
     var image = options.normalizesInputExtent ? ParametricImageGeometry.removingExtentOffset(input) : input
     var localAdjustmentMasks: [FeatureID: CIImage] = [:]

--- a/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
@@ -20,17 +20,26 @@
 // THE SOFTWARE.
 
 import CoreImage
+import CoreMedia
 import Foundation
 
 /// Values available to features while they evaluate.
 ///
-/// The context deliberately carries no document state — a feature sees only
-/// its input image and shared facilities. This keeps evaluation a pure
-/// function of (parameters, input).
+/// The context deliberately carries no document state. A feature sees its input
+/// image, explicit render-time values, and shared facilities. This keeps
+/// evaluation a pure function of (parameters, input, context).
 public struct FeatureEvaluationContext: Sendable {
 
   /// Custom Core Image kernels shared by mask rendering.
   public let kernelRegistry: ParametricKernelRegistry
+
+  /// The presentation time of the image being evaluated.
+  ///
+  /// Video renderers supply the exact AVFoundation composition time for each
+  /// frame. Still-image renderers use `.zero` by default, which gives
+  /// time-sensitive effects a deterministic sample without adding time to the
+  /// persisted feature parameters.
+  public let presentationTime: CMTime
 
   /// The image extent that diagonal-based radii (Gaussian blur, sharpen,
   /// unsharp mask) resolve against, expressed in the **current render pixel
@@ -53,16 +62,22 @@ public struct FeatureEvaluationContext: Sendable {
   /// Creates an evaluation context.
   public init(
     kernelRegistry: ParametricKernelRegistry = .init(),
-    radiusReferenceExtent: CGRect? = nil
+    radiusReferenceExtent: CGRect? = nil,
+    presentationTime: CMTime = .zero
   ) {
     self.kernelRegistry = kernelRegistry
     self.radiusReferenceExtent = radiusReferenceExtent
+    self.presentationTime = presentationTime
   }
 
   /// Returns a copy that resolves diagonal-based radii against `extent`
   /// (the full source extent in the current render pixel space).
   public func withRadiusReferenceExtent(_ extent: CGRect?) -> Self {
-    .init(kernelRegistry: kernelRegistry, radiusReferenceExtent: extent)
+    .init(
+      kernelRegistry: kernelRegistry,
+      radiusReferenceExtent: extent,
+      presentationTime: presentationTime
+    )
   }
 }
 

--- a/Sources/BrightroomParametric/ParametricImageRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricImageRenderer.swift
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 import CoreImage
+import CoreMedia
 import Foundation
 
 /// Renders parametric feature documents for still images.
@@ -45,28 +46,38 @@ public struct ParametricImageRenderer: Sendable {
   /// intermediate so diagonal-based radii stay a fixed fraction of the source.
   /// `nil` (the default) is correct when `sourceImage` is the full source at
   /// render scale (export, preview composition).
+  ///
+  /// `presentationTime` defaults to `.zero` for deterministic still-image
+  /// evaluation. Video paths pass the frame's exact presentation time.
   public func makeOutput(
     from sourceImage: CIImage,
     document: EditingDocument,
-    radiusReferenceExtent: CGRect? = nil
+    radiusReferenceExtent: CGRect? = nil,
+    presentationTime: CMTime = .zero
   ) throws -> FeatureGraphOutput {
     try compiler.makeOutput(
       from: sourceImage,
       document: document,
-      radiusReferenceExtent: radiusReferenceExtent
+      radiusReferenceExtent: radiusReferenceExtent,
+      presentationTime: presentationTime
     )
   }
 
   /// Returns only the final image recipe.
+  ///
+  /// `presentationTime` has the same render-time semantics as
+  /// `makeOutput(from:document:radiusReferenceExtent:presentationTime:)`.
   public func makeImage(
     from sourceImage: CIImage,
     document: EditingDocument,
-    radiusReferenceExtent: CGRect? = nil
+    radiusReferenceExtent: CGRect? = nil,
+    presentationTime: CMTime = .zero
   ) throws -> CIImage {
     try makeOutput(
       from: sourceImage,
       document: document,
-      radiusReferenceExtent: radiusReferenceExtent
+      radiusReferenceExtent: radiusReferenceExtent,
+      presentationTime: presentationTime
     )
     .image
   }

--- a/Sources/BrightroomParametric/ParametricVideoRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricVideoRenderer.swift
@@ -66,15 +66,19 @@ public struct ParametricVideoRenderer: Sendable {
   ///   - renderExtent: The optional output canvas. When specified, the feature
   ///     output is placed at the canvas origin and cropped/expanded to that
   ///     extent using a transparent Core Image background.
+  ///   - presentationTime: The presentation time represented by `sourceImage`.
+  ///     The default keeps direct single-frame evaluation deterministic.
   /// - Returns: A Core Image recipe for the filtered frame.
   public func makeFrameImage(
     from sourceImage: CIImage,
     document: EditingDocument,
-    renderExtent: CGRect? = nil
+    renderExtent: CGRect? = nil,
+    presentationTime: CMTime = .zero
   ) throws -> CIImage {
     let output = try imageRenderer.makeImage(
       from: sourceImage,
-      document: document
+      document: document,
+      presentationTime: presentationTime
     )
 
     guard let renderExtent else {
@@ -156,7 +160,8 @@ public struct ParametricVideoRenderer: Sendable {
         let output = try ParametricVideoRenderer(imageRenderer: imageRenderer).makeFrameImage(
           from: request.sourceImage,
           document: document,
-          renderExtent: renderExtent
+          renderExtent: renderExtent,
+          presentationTime: request.compositionTime
         )
         request.finish(with: output, context: ciContext)
       } catch {

--- a/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
+++ b/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
@@ -449,6 +449,48 @@ struct ParametricFeatureTreeTests {
     )
   }
 
+  @Test func videoFrameRendererPassesPresentationTimeToFeatureEvaluation() throws {
+    let presentationTime = CMTime(value: 17, timescale: 30)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestPresentationTimeFeature(
+              id: FeatureID(rawValue: "video-presentation-time"),
+              expectedPresentationTime: presentationTime
+            )
+          )
+        ]
+      )
+    )
+
+    _ = try ParametricVideoRenderer().makeFrameImage(
+      from: Self.smallInput,
+      document: document,
+      presentationTime: presentationTime
+    )
+  }
+
+  @Test func imageRendererDefaultsPresentationTimeToZero() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestPresentationTimeFeature(
+              id: FeatureID(rawValue: "still-presentation-time"),
+              expectedPresentationTime: .zero
+            )
+          )
+        ]
+      )
+    )
+
+    _ = try ParametricImageRenderer().makeImage(
+      from: Self.smallInput,
+      document: document
+    )
+  }
+
   @Test func videoRendererResolvesCropOutputRenderSize() throws {
     let document = EditingDocument(
       mainTree: MainTree(
@@ -1064,6 +1106,29 @@ struct ParametricFeatureTreeTests {
       )
       .cropped(to: image.extent)
     }
+  }
+
+  /// Verifies that render-time values reach a host-defined effect without being
+  /// stored as authored feature parameters.
+  private struct TestPresentationTimeFeature: ImageEffectFeatureType {
+
+    var id: FeatureID
+    var isEnabled: Bool = true
+    var expectedPresentationTime: CMTime
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      guard context.presentationTime == expectedPresentationTime else {
+        throw TestPresentationTimeError.unexpectedTime(
+          expected: expectedPresentationTime,
+          actual: context.presentationTime
+        )
+      }
+      return image
+    }
+  }
+
+  private enum TestPresentationTimeError: Error {
+    case unexpectedTime(expected: CMTime, actual: CMTime)
   }
 
   /// The v1 shape of the migrating test feature: field named `amount`.


### PR DESCRIPTION
## Summary

- add an explicit `presentationTime` to `FeatureEvaluationContext`
- thread presentation time through `FeatureGraphCompiler`, `ParametricImageRenderer`, and `ParametricVideoRenderer`
- pass AVFoundation's `request.compositionTime` into video feature evaluation while keeping `.zero` as the deterministic still-image default
- cover explicit video-frame time and still-image default behavior with host-defined feature tests

## Why

Time-varying single-frame features need the current frame time as an evaluation input. Keeping it in the evaluation context avoids storing transient render state in authored feature parameters and lets host-defined effects participate in the normal parametric feature graph.

## Impact

Existing callers remain source-compatible because the new parameter defaults to `.zero`. Video compositions now expose their exact composition time to each feature evaluation.

## Validation

- `xcodebuild -quiet -project Brightroom.xcodeproj -target BrightroomParametricTests -configuration Debug -sdk iphonesimulator ... build`
- downstream Farg physical-device integration test: 1 passed, 0 failed (`previewEffectChangesPreservePlayerItemAndPlayhead`)