### PR TITLE
Add tint axis to white balance

### DIFF
--- a/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
+++ b/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
@@ -287,7 +287,7 @@ extension TemperatureFeature: ImageEffectFeatureType {
     image.applyingFilter(
       "CITemperatureAndTint",
       parameters: [
-        "inputNeutral": CIVector(x: CGFloat(value) + 6500, y: 0),
+        "inputNeutral": CIVector(x: CGFloat(value) + 6500, y: CGFloat(tint)),
         "inputTargetNeutral": CIVector(x: 6500, y: 0),
       ]
     )

--- a/Sources/BrightroomParametric/ParametricDocumentCodec.swift
+++ b/Sources/BrightroomParametric/ParametricDocumentCodec.swift
@@ -584,6 +584,39 @@ extension HighlightShadowTintFeature: PersistableFeature {
 
 extension TemperatureFeature: PersistableFeature {
   public static let featureTypeKey: FeatureTypeKey = "brightroom.effect.temperature"
+
+  /// v2 added the tint axis. v1 documents stored only color temperature and
+  /// decode with a neutral tint so their rendering remains unchanged.
+  public static var schemaVersion: Int { 2 }
+
+  private struct V1Parameters: Decodable {
+    var id: FeatureID
+    var isEnabled: Bool
+    var value: Double
+  }
+
+  public static func decodeParameters(
+    from decoder: Decoder,
+    version: Int
+  ) throws -> TemperatureFeature {
+    switch version {
+    case 2:
+      return try TemperatureFeature(from: decoder)
+    case 1:
+      let v1 = try V1Parameters(from: decoder)
+      return TemperatureFeature(
+        id: v1.id,
+        isEnabled: v1.isEnabled,
+        value: v1.value,
+        tint: 0
+      )
+    default:
+      throw ParametricDocumentCodecError.unsupportedSchemaVersion(
+        featureTypeKey,
+        version: version
+      )
+    }
+  }
 }
 
 extension SharpenFeature: PersistableFeature {

--- a/Sources/BrightroomParametric/ParametricFeatureModel.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureModel.swift
@@ -510,7 +510,12 @@ public struct HighlightShadowTintFeature: Feature, Codable {
   }
 }
 
-/// A color temperature adjustment.
+/// A two-axis white-balance adjustment evaluated by Core Image.
+///
+/// `value` shifts color temperature relative to Brightroom's neutral white
+/// point, while `tint` moves the same white point along the green–magenta axis.
+/// Keeping both values in one feature preserves the coupled semantics of
+/// `CITemperatureAndTint` instead of approximating them as sequential filters.
 public struct TemperatureFeature: Feature, Codable {
 
   /// The stable identity of this effect.
@@ -519,18 +524,23 @@ public struct TemperatureFeature: Feature, Codable {
   /// A Boolean value indicating whether this effect participates in rendering.
   public var isEnabled: Bool
 
-  /// The temperature offset from Brightroom's neutral value.
+  /// The color-temperature offset from Brightroom's neutral value, in Kelvin.
   public var value: Double
 
-  /// Creates a temperature adjustment.
+  /// The green–magenta tint offset from Brightroom's neutral value.
+  public var tint: Double
+
+  /// Creates a white-balance adjustment.
   public init(
     id: FeatureID = .init(),
     isEnabled: Bool = true,
-    value: Double
+    value: Double,
+    tint: Double = 0
   ) {
     self.id = id
     self.isEnabled = isEnabled
     self.value = value
+    self.tint = tint
   }
 }
 

--- a/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
+++ b/Tests/BrightroomParametricTests/ParametricFeatureTreeTests.swift
@@ -61,7 +61,13 @@ struct ParametricFeatureTreeTests {
               shadowColor: ParametricRGBAColor(red: 0.1, green: 0.2, blue: 1, alpha: 0.04)
             )
           ),
-          .effect(TemperatureFeature(id: FeatureID(rawValue: "temperature-a"), value: 450)),
+          .effect(
+            TemperatureFeature(
+              id: FeatureID(rawValue: "temperature-a"),
+              value: 450,
+              tint: -18
+            )
+          ),
           .effect(SharpenFeature(id: FeatureID(rawValue: "sharpen-a"), sharpness: 0.2, radius: 4)),
           .effect(UnsharpMaskFeature(id: FeatureID(rawValue: "unsharp-a"), intensity: 0.1, radius: 0.25)),
           .effect(VignetteFeature(id: FeatureID(rawValue: "vignette-a"), value: 0.35)),
@@ -311,13 +317,69 @@ struct ParametricFeatureTreeTests {
     let decoded = try readingCodec.decode(data)
 
     let firstFeature = try #require(decoded.mainTree.features.first)
-    guard case let .effect(effect) = firstFeature else {
+    guard case .effect(let effect) = firstFeature else {
       Issue.record("expected the migrated v2 feature")
       return
     }
     let migrated = try #require(effect as? TestMigratingFeatureV2, "expected the migrated v2 feature")
     #expect(migrated.id == FeatureID(rawValue: "migrating-feature"))
     #expect(migrated.strength == 0.5)
+  }
+
+  @Test func temperatureV1PayloadDecodesWithNeutralTint() throws {
+    var writingCodec = ParametricDocumentCodec()
+    writingCodec.register(TestTemperatureFeatureV1.self)
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TestTemperatureFeatureV1(
+              id: FeatureID(rawValue: "legacy-temperature"),
+              value: 375
+            )
+          )
+        ]
+      )
+    )
+    let data = try writingCodec.encode(document)
+
+    let decoded = try ParametricDocumentCodec().decode(data)
+
+    let firstFeature = try #require(decoded.mainTree.features.first)
+    guard case .effect(let effect) = firstFeature else {
+      Issue.record("Expected the migrated Temperature feature.")
+      return
+    }
+    let temperature = try #require(effect as? TemperatureFeature)
+    #expect(temperature.id == FeatureID(rawValue: "legacy-temperature"))
+    #expect(temperature.value == 375)
+    #expect(temperature.tint == 0)
+  }
+
+  @Test func temperatureFeatureEvaluatesTintAxis() throws {
+    let document = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .effect(
+            TemperatureFeature(
+              id: FeatureID(rawValue: "tint-axis"),
+              value: 0,
+              tint: 100
+            )
+          )
+        ]
+      )
+    )
+
+    let output = try Self.compiler.makeOutput(
+      from: Self.smallInput,
+      document: document
+    )
+    let rendered = try Self.render(output.image)
+    let pixel = Self.rgba(in: rendered, x: 4, y: 4)
+
+    #expect(pixel.red > pixel.green)
+    #expect(pixel.blue > pixel.green)
   }
 
   @Test func unsupportedDocumentFormatVersionThrows() throws {
@@ -1139,6 +1201,21 @@ struct ParametricFeatureTreeTests {
     var id: FeatureID = .init()
     var isEnabled: Bool = true
     var amount: Double
+
+    func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
+      image
+    }
+  }
+
+  /// The persisted shape used by TemperatureFeature before its tint axis was
+  /// added in schema version 2.
+  private struct TestTemperatureFeatureV1: ImageEffectFeatureType, PersistableFeature {
+
+    static let featureTypeKey = TemperatureFeature.featureTypeKey
+
+    var id: FeatureID = .init()
+    var isEnabled: Bool = true
+    var value: Double
 
     func apply(to image: CIImage, context: FeatureEvaluationContext) throws -> CIImage {
       image


### PR DESCRIPTION
## Summary

- extend `TemperatureFeature` with a source-compatible `tint` axis that defaults to zero
- evaluate temperature and tint together through the existing `CITemperatureAndTint` recipe
- advance the persisted feature schema to v2 and migrate v1 temperature-only payloads with neutral tint
- cover v2 round trips, v1 migration, and tint rendering

## Why

White balance is a coupled temperature and green–magenta correction. Keeping both axes in one Brightroom feature lets consumers use the same white-point transform for previews and final rendering instead of approximating tint as a separate sequential effect.

Existing temperature-only callers keep their current behavior because `tint` defaults to zero, the feature type key is unchanged, and v1 documents migrate to neutral tint.

## Validation

- `xcodebuild build -scheme BrightroomParametric -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO -quiet`
- Farg integration tests covering codec round-trip, v1 migration, temperature/tint rendering, feature ordering, and preview identity
- Farg suite: 81 tests pass with the unrelated missing Resolve golden TIFF suite excluded
- `git diff --check`

The standalone Brightroom Xcode scheme currently has no Test action, so the same codec and rendering paths are also exercised by the consuming Farg test target.