### PR TITLE
Fix coordinate space of the crop outside-overlay in layoutSubviews

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
+++ b/Sources/BrightroomUI/Shared/Components/Crop/CropView.swift
@@ -2012,11 +2012,14 @@ extension CropView {
     super.layoutSubviews()
 
     // TODO: Get an optimized size
+    let screenBounds = window?.screen.bounds ?? UIScreen.main.bounds
     guideOutsideContainerView.frame.size = .init(
-      width: UIScreen.main.bounds.width * 1.5,
-      height: UIScreen.main.bounds.height * 1.5
+      width: screenBounds.width * 1.5,
+      height: screenBounds.height * 1.5
     )
-    guideOutsideContainerView.center = center
+    // `center` is expressed in the superview's coordinate space; a subview's
+    // center belongs to this view's own bounds space.
+    guideOutsideContainerView.center = .init(x: bounds.midX, y: bounds.midY)
 
     if let cropOutsideOverlay {
       cropOutsideOverlay.frame = guideOutsideContainerView.bounds


### PR DESCRIPTION
## Problem

In `CropView.layoutSubviews`, the outside-overlay container was positioned with:

```swift
guideOutsideContainerView.center = center
```

`guideOutsideContainerView` is added via `addSubview(...)`, so it is a direct subview of `CropView` and its `center` is expressed in `CropView`'s own bounds space. But `self.center` is expressed in the **superview's** coordinate space. The two are being mixed.

## Impact

Behavior-neutral today. Every in-repo host lays `CropView` out at origin `.zero`, where `bounds.midX == center.x` and `bounds.midY == center.y`, so the two expressions coincide and nothing moves.

It only changes — correctly — for a host that positions `CropView` at a non-zero origin, e.g. inlined below a header. Such a host would today see the entire outside-overlay plane displaced by that origin.

## Fix

Use the view's own bounds center, which is the pattern already established a few lines below in the same file for `surfaceHost.platterView`:

```swift
surfaceHost.platterView.center = .init(x: self.bounds.midX, y: self.bounds.midY)
```

While in the same block, the hardcoded `UIScreen.main.bounds` sizing is replaced with `window?.screen.bounds ?? UIScreen.main.bounds`, so the overlay is sized from the screen the view actually lives on. This mirrors the existing `window?.screen.scale ?? UIScreen.main.scale` fallback used elsewhere in this file.

## Scope

Strictly limited to this one block in `layoutSubviews` — 6 insertions, 3 deletions in a single file. CropView's scroll behavior is untouched, and no other `UIScreen.main` site in the file was changed.

## Verification

`xcodebuild -project Dev/Brightroom.xcodeproj -scheme SwiftUIDemo -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)