### PR TITLE
Fix image-load data race and misclassified remote metadata failure

### DIFF
--- a/Sources/BrightroomEngine/Core/EditingStack.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.swift
@@ -393,7 +393,19 @@ open class EditingStack: Hashable {
         }
       })
     }
-    imageProviderSubscription = imageProviderSub
+    /**
+     `backgroundQueue` owns the lifecycle of `imageProviderSubscription`.
+
+     `start()` may be called from any thread, while the load completion nils this
+     out on `backgroundQueue`. For an already-loaded provider the `onChange` above
+     fires synchronously inside `withGraphTracking`, so the load is already
+     enqueued by the time we get here — assigning directly would race with that
+     nil-out. Hopping through the serial queue orders the install before the
+     nil-out, so the subscription is always released rather than re-installed.
+     */
+    backgroundQueue.async { [weak self] in
+      self?.imageProviderSubscription = imageProviderSub
+    }
   }
 
   private func markStartedIfNeeded() -> Bool {
@@ -467,6 +479,10 @@ open class EditingStack: Hashable {
            */
           self.backgroundQueue.async { [weak self] in
             guard let self else { return }
+
+            // A second provider emission must never rebuild the loaded state over
+            // edits already in flight; the first load wins.
+            guard self.loadedState == nil else { return }
 
             // Fall back to the CPU-backed source if no Metal device is available
             // (e.g. unsupported environment); display still works, just without

--- a/Sources/BrightroomEngine/DataSource/ImageProvider.swift
+++ b/Sources/BrightroomEngine/DataSource/ImageProvider.swift
@@ -280,7 +280,7 @@ public final class ImageProvider: Equatable {
           }
 
           guard let metadata = ImageTool.makeImageMetadata(from: imageSource) else {
-            self.loadingNonFatalErrors.append(ImageProviderError.failedToGetImageMetadata)
+            self.loadingFatalErrors.append(ImageProviderError.failedToGetImageMetadata)
             return
           }
 


### PR DESCRIPTION
Two independent correctness fixes in the image-loading path.

## 1. `imageProviderSubscription` data race (`EditingStack.swift`)

**What.** `start()` wrote `imageProviderSubscription` on the caller's thread; the load completion nils the same unsynchronized `private var` from `backgroundQueue`. The subscription is now handed off through the serial background queue, and the publish block is guarded with `loadedState == nil`.

**Mechanism.** `start()` is documented as callable from a background thread. When the `ImageProvider` is already loaded, the graph-tracking `onChange` fires *synchronously* inside `withGraphTracking` — before the assignment line is reached — and enqueues `handleImageLoaded` on `backgroundQueue`. So two threads write the same variable with no happens-before edge between them. If the nil-out won that race, the assignment would re-install the observation instead of releasing it, and a later provider emission could rebuild `loadedState` on top of edits already in flight.

**Why this shape.** Hopping through the serial queue gives FIFO ordering: the install is enqueued before the completion's nil-out can run, so the nil-out always lands last and the subscription is released rather than re-installed. The queue becomes the single owner of the variable's lifecycle, which is what the added comment states. The `loadedState == nil` guard closes the same hole from the other side: a duplicate emission can never rebuild loaded state over in-flight edits, independently of subscription timing.

The practical window here is narrow — this is a memory-model correctness fix rather than a response to a reproduced user-facing failure. The GCD flow is deliberately left as-is; restructuring it into Tasks is planned separately.

## 2. Remote metadata failure was misclassified (`ImageProvider.swift`)

This one **is** user-visible. In `init(editableRemoteURLRequest:)`, a `makeImageMetadata` failure appended to `loadingNonFatalErrors` and returned early, skipping the `editableImage` assignment. `loadedImage` then stayed nil forever: the editor spun in its loading state indefinitely while hosts observing `loadingFatalErrors` were never notified — a silent hang with no way to surface an error.

The two sibling guards immediately above it (`failedToCreateCGDataProvider`, `failedToCreateCGImageSource`) already use `loadingFatalErrors`, and the local-file initializer throws `failedToGetImageSize` for the same condition. Changing this one append to `loadingFatalErrors` makes remote-load failures surface to the host instead of spinning forever.

## Verification

- `xcodebuild -scheme SwiftUIDemo -destination 'generic/platform=iOS Simulator' build` — **BUILD SUCCEEDED**
- `BrightroomEngineTests` full suite on a clean iPhone 17 Pro simulator, `-parallel-testing-enabled NO` — **153 tests in 36 suites passed**, no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
