### PR TITLE
Stop the live-stroke display link when the editing canvas leaves the window

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
@@ -420,6 +420,22 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
   override func didMoveToWindow() {
     super.didMoveToWindow()
+
+    guard window != nil else {
+      // Invariant: leaving the window severs the display-link retain chain.
+      // `deinit` alone cannot, because the run loop retains the link and the
+      // link retains its target — so a live stroke keeps this view, and its
+      // rgba16Float texture caches, alive and ticking forever. Teardown can
+      // land mid-stroke (canvas-size change, focus switch during a touch)
+      // because the drawing gesture recognizer lives on the container, not
+      // here, so the owner does not necessarily cancel the stroke first.
+      cancelActiveStroke()
+      // Restated rather than left implicit: stopping the link is the standing
+      // guarantee of this path, not a side effect of stroke bookkeeping.
+      stopLiveDisplayLink()
+      return
+    }
+
     // Re-assert: MTKView can rebuild its drawable/layer when entering a window,
     // which would drop the colorspace and silently reinterpret the drawable.
     applyColorSpaceContract()


### PR DESCRIPTION
## Problem

`_EditingCanvasMTKView.startLiveDisplayLinkIfNeeded` creates a `CADisplayLink` targeting `self` and adds it to the main run loop:

```swift
let displayLink = CADisplayLink(target: self, selector: #selector(liveDisplayLinkDidTick(_:)))
displayLink.add(to: .main, forMode: .common)
```

The run loop retains the link and the link retains its target, so while a stroke is live the canvas view is held alive by that chain. The existing `isolated deinit { stopLiveDisplayLink() }` cannot save it — deinit is exactly what the cycle prevents from running.

`CropView.removeCanvasView()` tears the canvas down without cancelling the stroke, and the drawing gesture recognizer lives on the container rather than on the MTKView, so teardown can land mid-stroke (a canvas-size change, or a focus switch while a touch is down). The result is an orphaned MTKView plus its `rgba16Float` texture caches, with the display link still firing every frame for the life of the run loop. The per-frame work is mostly a no-op, but both the callback and the leaked textures persist.

## Fix

Handle it inside the MTKView: on `didMoveToWindow` with `window == nil`, cancel the active stroke and stop the live display link, so `removeFromSuperview` always severs the retain chain and `deinit` becomes reachable.

- Reuses the existing `cancelActiveStroke()` path that the gesture flow's `cancelStroke()` already calls — no parallel cancel path.
- `stopLiveDisplayLink()` is restated after it so the lifecycle guarantee of this branch does not rest on stroke bookkeeping being refactored carefully later. The call is a no-op once the link is already nil.
- The `window != nil` branch (colorspace re-assert, preferred frame-rate update) is unchanged, so being *added* to a window behaves exactly as before.
- Direct calls, no actor hops: the class inherits `MTKView`'s main-actor isolation and `didMoveToWindow` is already on the main thread.

## Stroke survival across a detach

Checked, as the fix would otherwise be a behavior change: nothing depends on a stroke outliving a brief window detach.

- `CropView.removeCanvasView()` does `canvasView?.removeFromSuperview(); canvasView = nil`, and `ensureCanvasView` constructs a brand-new `_EditingCanvasMTKView` — a detach is always terminal for a given canvas instance, never a detach/re-attach round trip.
- The only other `window` references in the file are `window?.screen` frame-rate reads.

So no gating was needed beyond the `window == nil` check.

`setNeedsDisplay()` inside `cancelActiveStroke()` is inert during teardown: the view is configured `enableSetNeedsDisplay = true` / `isPaused = true`, an off-window layer never displays, and `renderViewportImage()` guards on `currentDrawable` anyway.

## Scope

Confined to `EditingCanvasMTKView.swift` (+16 lines, lifecycle path only). `CropView` is untouched — its surfaces are behaviorally frozen. No hot render path is modified, given this file's history of one-frame-flash regressions.

## Verification

- `SwiftUIDemo` builds for `generic/platform=iOS Simulator`: **BUILD SUCCEEDED**
- `BrightroomEngineTests` on a clean private simulator (iPhone 17 Pro, iOS 27.0, `-parallel-testing-enabled NO`): **153 tests in 36 suites passed**, including the canvas-related suites `EditingCanvasColorContractTests`, `EditingCanvasContentBakeTests`, and `BrushMaskRasterizerParityTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)