### PR TITLE
Correct contract documentation and label two sliders

### DIFF
--- a/Sources/BrightroomEngine/Core/EditingStack.swift
+++ b/Sources/BrightroomEngine/Core/EditingStack.swift
@@ -334,10 +334,18 @@ open class EditingStack: Hashable {
 
   public var cropModifier: CropModifier
 
-  // The editing source is downsampled to this longest-side resolution; it is the
-  // upper bound on detail anywhere downstream. Keep in sync with the canvas
-  // preview bake cap `EditingCanvasImageProcessing.contentBakeMaxPixelSize`
-  // (BrightroomUI): that bake is "visually lossless" only while the two match.
+  // The editing source is downsampled so that its SHORT side is at most this
+  // value; the long side scales with the aspect ratio and is larger for anything
+  // but a square (a 4032×3024 photo loads at 3413×2560). A source whose short
+  // side is already below it — a wide panorama, say — is not downsampled at all.
+  // See `ImageTool.makeResizedCGImage(from:maxPixelSizeHint:fixesOrientation:)`.
+  //
+  // The canvas preview bake cap `EditingCanvasImageProcessing.contentBakeMaxPixelSize`
+  // (BrightroomUI) carries the same number but caps the LONGEST side, so the two
+  // resolutions coincide only for square content; otherwise the bake resamples
+  // somewhat below the editing source. Keep the numbers together anyway: they
+  // express one intent, and neither module can enforce the relation at compile
+  // time.
   private let editingImageMaxPixelSize: CGFloat = 2560
 
   // MARK: - Initializers

--- a/Sources/BrightroomEngine/DataSource/ImageSource.swift
+++ b/Sources/BrightroomEngine/DataSource/ImageSource.swift
@@ -120,7 +120,13 @@ public final class ImageSource: Equatable, @unchecked Sendable {
   }
 
   /**
-   Creates an instance of CGImage resized to maximum pixel size.
+   Creates an instance of CGImage downsampled so that its shortest side is at
+   most `maxPixelSize` pixels.
+
+   `maxPixelSize` is a short-side target, not a longest-side cap: the longest
+   side scales with the aspect ratio and can exceed it, and an image whose
+   shortest side is already below it is returned at full resolution. See
+   `ImageTool.makeResizedCGImage(from:maxPixelSizeHint:fixesOrientation:)`.
 
    - Attention: The image is not orientated.
    */

--- a/Sources/BrightroomEngine/Engine/ImageTool.swift
+++ b/Sources/BrightroomEngine/Engine/ImageTool.swift
@@ -150,6 +150,20 @@ public enum ImageTool: Sendable {
     return destination
   }
 
+  /// Downsamples the image so that its **shortest** side is at most
+  /// `maxPixelSizeHint` pixels.
+  ///
+  /// Despite the "max pixel size" wording, the hint is a short-side target, not
+  /// a longest-side cap. The longest side lands at `hint × aspectRatio` and may
+  /// far exceed the hint — a 4032×3024 source with a hint of 2560 loads at
+  /// 3413×2560 — and an image whose shortest side is already below the hint is
+  /// not downsampled at all, so a 6000×2000 panorama loads at full resolution.
+  ///
+  /// - Note: Whether this should instead be a true longest-side cap (bounding
+  ///   the memory of extreme aspect ratios at the cost of preview detail on
+  ///   ordinary photos) is an open product decision. The behavior is documented
+  ///   here as it stands; changing it moves preview detail everywhere
+  ///   downstream.
   public static func makeResizedCGImage(
     from imageSource: CGImageSource,
     maxPixelSizeHint: CGFloat,
@@ -207,6 +221,12 @@ public enum ImageTool: Sendable {
     return scaledImage
   }
 
+  /// Downsamples the image so that its **shortest** side is at most
+  /// `maxPixelSizeHint` pixels.
+  ///
+  /// Short-side target, not a longest-side cap; see
+  /// ``makeResizedCGImage(from:maxPixelSizeHint:fixesOrientation:)`` for the
+  /// full contract and its consequences for wide aspect ratios.
   public static func makeResizedCGImage(
     from sourceImage: CGImage,
     maxPixelSizeHint: CGFloat

--- a/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
+++ b/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
@@ -301,7 +301,7 @@ extension SharpenFeature: ImageEffectFeatureType {
     let radius = ParametricRadiusCalculator.radius(
       value: radius,
       max: ParametricFilterConstants.gaussianBlurSliderMax,
-      imageExtent: context.radiusReferenceExtent ?? image.extent
+      imageExtent: context.radiusBasis(for: image)
     )
     return image.applyingFilter(
       "CISharpenLuminance",
@@ -325,7 +325,7 @@ extension GaussianBlurFeature: ImageEffectFeatureType {
       radius = ParametricRadiusCalculator.radius(
         value: value,
         max: ParametricFilterConstants.gaussianBlurSliderMax,
-        imageExtent: context.radiusReferenceExtent ?? image.extent
+        imageExtent: context.radiusBasis(for: image)
       )
     }
 
@@ -348,7 +348,7 @@ extension UnsharpMaskFeature: ImageEffectFeatureType {
     let radius = ParametricRadiusCalculator.radius(
       value: radius,
       max: ParametricFilterConstants.unsharpMaskRadiusSliderMax,
-      imageExtent: context.radiusReferenceExtent ?? image.extent
+      imageExtent: context.radiusBasis(for: image)
     )
     return image.applyingFilter(
       "CIUnsharpMask",

--- a/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureEvaluation.swift
@@ -71,6 +71,19 @@ public struct FeatureEvaluationContext: Sendable {
     self.presentationTime = presentationTime
   }
 
+  /// Returns the extent that a diagonal-based radius must resolve against when
+  /// the recipe is evaluating `image`.
+  ///
+  /// Every recipe with a proportional radius goes through this accessor rather
+  /// than reading `radiusReferenceExtent` and writing its own fallback: the
+  /// fallback to `image.extent` is correct ONLY when `image` is the chain entry.
+  /// Applied to any mid-chain input — a cropped result, a zoomed viewport slice,
+  /// an intermediate — it re-bases the radius and silently changes the strength
+  /// of a committed effect, which is exactly what the pinned semantics forbid.
+  public func radiusBasis(for image: CIImage) -> CGRect {
+    radiusReferenceExtent ?? image.extent
+  }
+
   /// Returns a copy that resolves diagonal-based radii against `extent`
   /// (the full source extent in the current render pixel space).
   public func withRadiusReferenceExtent(_ extent: CGRect?) -> Self {

--- a/Sources/BrightroomParametric/ParametricFeatureModel.swift
+++ b/Sources/BrightroomParametric/ParametricFeatureModel.swift
@@ -482,6 +482,13 @@ public struct ParametricRGBAColor: Codable, Equatable, Sendable {
 }
 
 /// A highlight/shadow tint effect.
+///
+/// - Important: The names describe the intended *use*, not a masked evaluation.
+///   The recipe source-over composites both colors across the whole image with
+///   no luminance or region weighting; the only thing that limits either tint is
+///   the alpha the caller chooses. This reproduces the legacy
+///   `FilterHighlightShadowTint` exactly and must keep doing so — every stored
+///   document renders against it.
 public struct HighlightShadowTintFeature: Feature, Codable {
 
   /// The stable identity of this effect.
@@ -490,10 +497,14 @@ public struct HighlightShadowTintFeature: Feature, Codable {
   /// A Boolean value indicating whether this effect participates in rendering.
   public var isEnabled: Bool
 
-  /// The color composited over highlight regions.
+  /// The tint color composited over the whole image, on top of `shadowColor`.
+  ///
+  /// Not restricted to highlight regions; see the type's discussion.
   public var highlightColor: ParametricRGBAColor
 
-  /// The color composited over shadow regions.
+  /// The tint color composited over the whole image, beneath `highlightColor`.
+  ///
+  /// Not restricted to shadow regions; see the type's discussion.
   public var shadowColor: ParametricRGBAColor
 
   /// Creates a highlight/shadow tint adjustment.
@@ -556,7 +567,9 @@ public struct SharpenFeature: Feature, Codable {
   /// The sharpness value passed to `CISharpenLuminance`.
   public var sharpness: Double
 
-  /// The Brightroom filter radius value, resolved against the current extent.
+  /// The Brightroom filter radius value, resolved against the render pass's
+  /// chain-entry extent (see `FeatureEvaluationContext.radiusReferenceExtent`),
+  /// so a mid-chain crop never re-bases it.
   public var radius: Double
 
   /// Creates a sharpen adjustment.
@@ -579,7 +592,10 @@ public enum GaussianBlurRadius: Codable, Equatable, Sendable {
   /// A Core Image blur radius in image-domain points.
   case absolute(Double)
 
-  /// A `FilterGaussianBlur.value` slider value, resolved against image extent.
+  /// A `FilterGaussianBlur.value` slider value, resolved against the render
+  /// pass's chain-entry extent (see
+  /// `FeatureEvaluationContext.radiusReferenceExtent`), so a mid-chain crop
+  /// never re-bases it.
   case editingStackFilterValue(Double)
 }
 
@@ -630,7 +646,9 @@ public struct UnsharpMaskFeature: Feature, Codable {
   /// The intensity passed to `CIUnsharpMask`.
   public var intensity: Double
 
-  /// The Brightroom filter radius value, resolved against the current extent.
+  /// The Brightroom filter radius value, resolved against the render pass's
+  /// chain-entry extent (see `FeatureEvaluationContext.radiusReferenceExtent`),
+  /// so a mid-chain crop never re-bases it.
   public var radius: Double
 
   /// Creates an unsharp mask adjustment.

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasGeometry.swift
@@ -83,12 +83,18 @@ enum EditingCanvasImageProcessing {
   static let colorTextureFormat: MTLPixelFormat = .rgba16Float
 
   /// Longest-side cap (in pixels) for the per-generation base/adjusted content
-  /// bake. MUST stay equal to the engine's editing-source resolution
-  /// (`EditingStack.editingImageMaxPixelSize`, currently also 2560): the effects
-  /// + blur graph carries no detail beyond it, so baking at this cap is visually
-  /// lossless for the fit-to-frame preview while bounding the texture memory the
-  /// bake holds for a gesture's duration. If one value moves, move both — the
-  /// modules can't enforce the equality at compile time.
+  /// bake, bounding the texture memory the bake holds for a gesture's duration.
+  ///
+  /// Numerically this matches the engine's editing-source value
+  /// (`EditingStack.editingImageMaxPixelSize`, currently also 2560), but the two
+  /// are not the same measurement: the engine caps the SHORT side, so its source
+  /// is at least this large on the long side (a 4032×3024 photo loads at
+  /// 3413×2560). Baking at this cap is therefore visually lossless only for
+  /// square content; for other aspect ratios it resamples the fit-to-frame
+  /// preview modestly below the editing source — acceptable because the preview
+  /// is displayed fit-to-frame, but a real difference rather than an identity.
+  /// If one value moves, move both — the modules can't enforce the relation at
+  /// compile time.
   static let contentBakeMaxPixelSize: CGFloat = 2560
 
   /// Pixel format for the final drawable written by the editing canvas.

--- a/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
+++ b/Sources/BrightroomUI/builtin/PhotosCrop/PhotosCropContentView.swift
@@ -758,6 +758,7 @@ private struct PhotosCropBlurMaskingControl: View {
       )
       .tint(.white)
       .frame(height: 50)
+      .accessibilityLabel("Brush Size")
 
       PhotosCropToolbarIconButton(
         systemName: "trash",
@@ -1238,6 +1239,7 @@ private struct PhotosCropAdjustmentsControl: View {
       .id(selection)
       .tint(.white)
       .frame(height: 44)
+      .accessibilityLabel(selection.title)
       .padding(.horizontal, 24)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
Four documentation contracts in this repo state the opposite of what the code
does, and two sliders are unlabeled for VoiceOver. This corrects the comments
and adds the labels. **No rendering, resize, or evaluation behavior changes.**

## 1. Editing-source resolution is a short-side target, not a longest-side cap

`ImageTool.makeResizedCGImage(from:maxPixelSizeHint:)` computes
`largestSide * hint / smallestSide`, and returns early without downsampling when
`smallestSide < hint`. So with the engine's 2560:

| source | loaded as |
| --- | --- |
| 4032x3024 | 3413x2560 |
| 6000x2000 | 6000x2000 (untouched) |

Three docs claimed a longest-side cap, and a fourth
(`EditingCanvasImageProcessing.contentBakeMaxPixelSize`) declared itself
"visually lossless" on the strength of a `MUST stay equal` parity with it. That
bake cap *is* a real longest-side cap, so the two resolutions coincide only for
square content; for anything else the bake resamples somewhat below the editing
source. The comments now describe the actual relation at all four sites
(`ImageTool`, `EditingStack`, `ImageSource`, `EditingCanvasGeometry`).

Whether this *should* be a true longest-side cap - which would bound the memory
of extreme aspect ratios but reduce preview detail on ordinary photos - is an
owner decision, so it is flagged as an open question in the corrected comment
rather than changed silently.

## 2. Radius basis docs and a named accessor

`SharpenFeature.radius`, `UnsharpMaskFeature.radius`, and
`GaussianBlurRadius.editingStackFilterValue` still said "resolved against the
current extent", the pre-decision behavior. fea9619 pinned the opposite: a
proportional radius resolves against the render pass's chain-entry extent, so a
mid-chain crop can never re-base a committed effect. The docs now say that.

The `context.radiusReferenceExtent ?? image.extent` motif repeated by the three
recipes becomes `FeatureEvaluationContext.radiusBasis(for:)`, whose doc carries
the subtle part - the fallback is correct *only* when the input is the chain
entry - so a fourth diagonal-based effect cannot copy the `??` without meeting
the rule. The accessor's body is that same expression, so the change is
behavior-neutral by construction.

## 3. HighlightShadowTintFeature docs overstated the recipe

The properties were documented as "composited over highlight/shadow regions",
but the recipe source-over composites both colors across the entire extent with
no luminance or region weighting. This is faithful parity with the legacy
`FilterHighlightShadowTint` (verified against its pre-parametric source), so the
recipe is deliberately left alone and the comment now states the behavior and
why it must not be "fixed" - stored documents render against it.

## 4. Accessibility labels for two sliders

`BrightroomSteppedSliderControl` is an adjustable accessibility element with an
`accessibilityValue` but no label of its own. The rotation slider gets one from
its host; the Adjust-mode value slider and the blur brush-size slider did not,
so VoiceOver announced a bare number - and in Adjust mode without saying which
of the nine parameters it moves. Both now follow the local rotation-slider
pattern, with the Adjust slider labeled by `selection.title`.

## Verification

`xcodebuild -scheme SwiftUIDemo -destination 'generic/platform=iOS Simulator'`
- **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
