### PR TITLE
Unify the brush-mask Metal pipeline construction

### DIFF
--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskMetalRasterizer.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskMetalRasterizer.swift
@@ -31,40 +31,16 @@ import simd
 /// `_EditingCanvasMTKView` builds and drives the same pipeline inline for live
 /// painting, where the encoding is interleaved with viewport math, drawable
 /// management, and stroke state. This type extracts only the rasterization
-/// kernel — pipeline construction (identical to
-/// `_EditingCanvasMTKView.makeBrushMaskShaderLibrary` /
-/// `makeBrushMaskPipeline`) and a single off-screen stamp pass — so the live
-/// rasterizer can be exercised in isolation and proven, by test, to match the
-/// parametric Core Image CIKernel rasterizer
-/// (`FeatureGraphCompiler.renderMask`) that the shared falloff establishes as
-/// the contract.
+/// kernel — a single off-screen stamp pass — so the live rasterizer can be
+/// exercised in isolation and proven, by test, to match the parametric Core
+/// Image CIKernel rasterizer (`FeatureGraphCompiler.renderMask`) that the
+/// shared falloff establishes as the contract.
 ///
-/// The pipeline is built EXACTLY as the live view builds it:
-/// - library = `BrushStampMetalLibrary.url()` (the BrightroomParametric
-///   build-compiled metallib that contains the live render shader and the
-///   parametric Core Image kernels).
-/// - render pipeline: vertex `brushStampVertex`, fragment `brushStampFragment`,
-///   `colorAttachments[0].pixelFormat = .rgba8Unorm`, blending enabled, rgb and
-///   alpha `BlendOperation = .max`, all blend factors `.one` (mirroring the
-///   parametric mask's `CIBlendKernel.componentMax` stamp accumulation).
-///
-/// The `BrushStampUniforms` layout is replicated field-for-field from the live
-/// view's `EditingCanvasBrushStampUniforms` and the MSL `BrushStampUniforms`
-/// struct in `BrushMaskRenderShader.metal`.
+/// The pipeline, the uniform layout, and the per-stamp encoding all come from
+/// `BrushMaskPipeline`, the same construction the live view uses — so this is
+/// not a replica of the live pipeline, it *is* the live pipeline, and the parity
+/// test covers the live path's construction by construction.
 struct BrushMaskMetalRasterizer {
-
-  /// Uniform values for drawing one soft circular brush stamp into a mask
-  /// texture. Field-for-field identical to `EditingCanvasBrushStampUniforms`
-  /// (and the MSL `BrushStampUniforms` struct), so the same vertex/fragment
-  /// functions interpret these bytes correctly.
-  struct BrushStampUniforms {
-    var canvasSize: SIMD2<Float>
-    var center: SIMD2<Float>
-    var radius: Float
-    var hardness: Float
-    var opacity: Float
-    var _padding: Float = 0
-  }
 
   /// One soft circular stamp to rasterize. `center` and `pixelRadius` are in
   /// canvas pixels (the identity / no-viewport domain — see `rasterize`).
@@ -93,8 +69,7 @@ struct BrushMaskMetalRasterizer {
       return nil
     }
     do {
-      let library = try Self.makeBrushMaskShaderLibrary(device: device)
-      let pipeline = try Self.makeBrushMaskPipeline(device: device, library: library)
+      let pipeline = try BrushMaskPipeline.make(device: device)
       self.device = device
       self.commandQueue = commandQueue
       self.pipeline = pipeline
@@ -161,24 +136,16 @@ struct BrushMaskMetalRasterizer {
 
     let canvasSize = SIMD2(Float(width), Float(height))
     for stamp in stamps {
-      var uniforms = BrushStampUniforms(
-        canvasSize: canvasSize,
-        center: SIMD2(Float(stamp.center.x), Float(stamp.center.y)),
-        radius: Float(stamp.pixelRadius),
-        hardness: stamp.hardness,
-        opacity: stamp.opacity
+      BrushMaskPipeline.encodeStamp(
+        .init(
+          canvasSize: canvasSize,
+          center: SIMD2(Float(stamp.center.x), Float(stamp.center.y)),
+          radius: Float(stamp.pixelRadius),
+          hardness: stamp.hardness,
+          opacity: stamp.opacity
+        ),
+        into: encoder
       )
-      encoder.setVertexBytes(
-        &uniforms,
-        length: MemoryLayout<BrushStampUniforms>.stride,
-        index: 0
-      )
-      encoder.setFragmentBytes(
-        &uniforms,
-        length: MemoryLayout<BrushStampUniforms>.stride,
-        index: 0
-      )
-      encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
     }
 
     encoder.endEncoding()
@@ -201,35 +168,5 @@ struct BrushMaskMetalRasterizer {
     // SAME coordinate the parametric `brushStamp` kernel uses (`dest.coord()`).
     // So the wrapped texture is already in `renderMask`'s frame.
     return textureImage.cropped(to: extent)
-  }
-
-  // MARK: - Pipeline construction (mirrors _EditingCanvasMTKView)
-
-  private static func makeBrushMaskShaderLibrary(device: MTLDevice) throws -> MTLLibrary {
-    // The compiled library lives in BrightroomParametric so the live shader and
-    // the parametric export kernel are built as one brush-mask rasterization family.
-    return try device.makeLibrary(URL: BrushStampMetalLibrary.url())
-  }
-
-  private static func makeBrushMaskPipeline(
-    device: MTLDevice,
-    library: MTLLibrary
-  ) throws -> MTLRenderPipelineState {
-    let descriptor = MTLRenderPipelineDescriptor()
-    descriptor.vertexFunction = library.makeFunction(name: "brushStampVertex")
-    descriptor.fragmentFunction = library.makeFunction(name: "brushStampFragment")
-    descriptor.colorAttachments[0].pixelFormat = .rgba8Unorm
-    descriptor.colorAttachments[0].isBlendingEnabled = true
-    // Overlapping stamps take the per-channel maximum, matching the parametric
-    // mask's `CIBlendKernel.componentMax` accumulation. Metal ignores the blend
-    // factors for `.max`, but they are set to `.one` for clarity — exactly as
-    // `_EditingCanvasMTKView.makeBrushMaskPipeline` does.
-    descriptor.colorAttachments[0].rgbBlendOperation = .max
-    descriptor.colorAttachments[0].alphaBlendOperation = .max
-    descriptor.colorAttachments[0].sourceRGBBlendFactor = .one
-    descriptor.colorAttachments[0].destinationRGBBlendFactor = .one
-    descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
-    descriptor.colorAttachments[0].destinationAlphaBlendFactor = .one
-    return try device.makeRenderPipelineState(descriptor: descriptor)
   }
 }

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskPipeline.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/BrushMaskPipeline.swift
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2026 Hiroshi Kimura(Muukii) <muukii.app@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import BrightroomParametric
+import Metal
+import simd
+
+/// The single construction site for the brush-mask Metal render pipeline, its
+/// uniform layout, and its per-stamp encoding.
+///
+/// Two paths rasterize brush stamps with this shader family:
+///
+/// - `_EditingCanvasMTKView` draws the committed and in-flight strokes live,
+///   every frame, into the viewport mask texture.
+/// - `BrushMaskMetalRasterizer` draws a stamp list off-screen so
+///   `BrushMaskRasterizerParityTests` can prove that live rasterization matches
+///   the parametric Core Image kernel (`FeatureGraphCompiler.renderMask`).
+///
+/// Those two paths **must** evolve together. The parity test only means anything
+/// if the pipeline it exercises is the pipeline the live view drives, and
+/// `StampUniforms` is ABI against the MSL struct in
+/// `BrushMaskRenderShader.metal`. Both previously built their own copy of this
+/// construction, kept equal only by doc comments asserting they were identical;
+/// they now share this one definition, so a change to the blend state, the pixel
+/// format, the uniform layout, or the buffer index reaches both paths — and the
+/// parity test covers the live path's construction by construction.
+enum BrushMaskPipeline {
+
+  /// Buffer index the stamp uniforms are bound at, matching `[[buffer(0)]]` on
+  /// both `brushStampVertex` and `brushStampFragment`.
+  static let stampUniformsBufferIndex = 0
+
+  /// Uniform values for drawing one soft circular brush stamp into a mask
+  /// texture.
+  ///
+  /// This layout is ABI against the MSL `BrushStampUniforms` struct in
+  /// `BrushMaskRenderShader.metal` (`float2 canvasSize; float2 center; float
+  /// radius; float hardness; float opacity; float padding;`). Changing a field
+  /// here without changing the shader silently reinterprets the bytes.
+  struct StampUniforms {
+    var canvasSize: SIMD2<Float>
+    var center: SIMD2<Float>
+    var radius: Float
+    var hardness: Float
+    var opacity: Float
+    var _padding: Float = 0
+  }
+
+  /// Loads the compiled brush-stamp shader library.
+  ///
+  /// The compiled library lives in BrightroomParametric so the live shader and
+  /// the parametric export kernel are built as one brush-mask rasterization
+  /// family.
+  static func makeLibrary(device: MTLDevice) throws -> MTLLibrary {
+    return try device.makeLibrary(URL: BrushStampMetalLibrary.url())
+  }
+
+  /// Builds the brush-stamp render pipeline state on `device`.
+  static func make(
+    device: MTLDevice,
+    library: MTLLibrary
+  ) throws -> MTLRenderPipelineState {
+    let descriptor = MTLRenderPipelineDescriptor()
+    descriptor.vertexFunction = library.makeFunction(name: "brushStampVertex")
+    descriptor.fragmentFunction = library.makeFunction(name: "brushStampFragment")
+    descriptor.colorAttachments[0].pixelFormat = .rgba8Unorm
+    descriptor.colorAttachments[0].isBlendingEnabled = true
+    // Overlapping stamps take the per-channel maximum, matching the parametric
+    // mask's `CIBlendKernel.componentMax` accumulation
+    // (`FeatureGraphCompiler.render(_:BrushMask)`). Metal ignores the blend
+    // factors for `.max`, but they are set to `.one` for clarity.
+    descriptor.colorAttachments[0].rgbBlendOperation = .max
+    descriptor.colorAttachments[0].alphaBlendOperation = .max
+    descriptor.colorAttachments[0].sourceRGBBlendFactor = .one
+    descriptor.colorAttachments[0].destinationRGBBlendFactor = .one
+    descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
+    descriptor.colorAttachments[0].destinationAlphaBlendFactor = .one
+    return try device.makeRenderPipelineState(descriptor: descriptor)
+  }
+
+  /// Loads the shader library and builds the pipeline state in one step.
+  static func make(device: MTLDevice) throws -> MTLRenderPipelineState {
+    return try make(device: device, library: makeLibrary(device: device))
+  }
+
+  /// Binds `uniforms` to both stages and draws the stamp quad.
+  ///
+  /// The quad is the four-vertex triangle strip `brushStampVertex` expands from
+  /// `vertex_id`; there is no vertex buffer. The caller is responsible for
+  /// having set `encoder`'s pipeline state to one built by `make(device:...)`.
+  static func encodeStamp(
+    _ uniforms: StampUniforms,
+    into encoder: MTLRenderCommandEncoder
+  ) {
+    var uniforms = uniforms
+    encoder.setVertexBytes(
+      &uniforms,
+      length: MemoryLayout<StampUniforms>.stride,
+      index: stampUniformsBufferIndex
+    )
+    encoder.setFragmentBytes(
+      &uniforms,
+      length: MemoryLayout<StampUniforms>.stride,
+      index: stampUniformsBufferIndex
+    )
+    encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
+  }
+}

--- a/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
+++ b/Sources/BrightroomUI/Shared/Components/EditingCanvas/EditingCanvasMTKView.swift
@@ -5,16 +5,6 @@ import MetalKit
 import simd
 import UIKit
 
-/// Uniform values for drawing one soft circular brush stamp into a mask texture.
-struct EditingCanvasBrushStampUniforms {
-  var canvasSize: SIMD2<Float>
-  var center: SIMD2<Float>
-  var radius: Float
-  var hardness: Float
-  var opacity: Float
-  var _padding: Float = 0
-}
-
 private struct EditingCanvasViewportSourceTextureKey: Equatable {
   var sourceExtent: CGRect
   var visibleContentRect: CGRect
@@ -106,7 +96,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
 
   typealias ViewportProvider = () -> Viewport?
 
-  private typealias BrushStampUniforms = EditingCanvasBrushStampUniforms
+  private typealias BrushStampUniforms = BrushMaskPipeline.StampUniforms
   // @MainActor: reads UIScreen frame-rate properties, which are main-actor only.
   @MainActor
   private enum LiveFrameRate {
@@ -361,8 +351,7 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     self.viewportState = ViewportState(canvasSize: canvasSize)
 
     do {
-      let library = try Self.makeBrushMaskShaderLibrary(device: device)
-      self.brushMaskPipeline = try Self.makeBrushMaskPipeline(device: device, library: library)
+      self.brushMaskPipeline = try BrushMaskPipeline.make(device: device)
     } catch {
       fatalError("Failed to create Editing Canvas pipeline: \(error)")
     }
@@ -1590,27 +1579,19 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
       let opacity = Float(brush.opacity)
 
       for stamp in stamps where stampIntersectsVisibleRect(stamp, radius: radius, visible: visible) {
-        var uniforms = BrushStampUniforms(
-          canvasSize: targetSize,
-          center: SIMD2(
-            Float((viewportFrame.minX + (stamp.x - visible.minX) * contentToViewScaleX) * drawableScaleX),
-            Float((viewportFrame.minY + (stamp.y - visible.minY) * contentToViewScaleY) * drawableScaleY)
+        BrushMaskPipeline.encodeStamp(
+          BrushStampUniforms(
+            canvasSize: targetSize,
+            center: SIMD2(
+              Float((viewportFrame.minX + (stamp.x - visible.minX) * contentToViewScaleX) * drawableScaleX),
+              Float((viewportFrame.minY + (stamp.y - visible.minY) * contentToViewScaleY) * drawableScaleY)
+            ),
+            radius: pixelRadius,
+            hardness: hardness,
+            opacity: opacity
           ),
-          radius: pixelRadius,
-          hardness: hardness,
-          opacity: opacity
+          into: encoder
         )
-        encoder.setVertexBytes(
-          &uniforms,
-          length: MemoryLayout<BrushStampUniforms>.stride,
-          index: 0
-        )
-        encoder.setFragmentBytes(
-          &uniforms,
-          length: MemoryLayout<BrushStampUniforms>.stride,
-          index: 0
-        )
-        encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
       }
     }
 
@@ -1686,33 +1667,5 @@ final class _EditingCanvasMTKView: MTKView, MTKViewDelegate {
     commandBuffer.commit()
     commandBuffer.waitUntilScheduled()
     drawable.present()
-  }
-
-  private static func makeBrushMaskPipeline(
-    device: MTLDevice,
-    library: MTLLibrary
-  ) throws -> MTLRenderPipelineState {
-    let descriptor = MTLRenderPipelineDescriptor()
-    descriptor.vertexFunction = library.makeFunction(name: "brushStampVertex")
-    descriptor.fragmentFunction = library.makeFunction(name: "brushStampFragment")
-    descriptor.colorAttachments[0].pixelFormat = .rgba8Unorm
-    descriptor.colorAttachments[0].isBlendingEnabled = true
-    // Overlapping stamps within the active stroke take the per-channel maximum,
-    // matching the parametric mask's `CIBlendKernel.componentMax` accumulation
-    // (FeatureGraphCompiler.render(_:BrushMask)). Metal ignores the blend factors
-    // for `.max`, but they are set to `.one` for clarity.
-    descriptor.colorAttachments[0].rgbBlendOperation = .max
-    descriptor.colorAttachments[0].alphaBlendOperation = .max
-    descriptor.colorAttachments[0].sourceRGBBlendFactor = .one
-    descriptor.colorAttachments[0].destinationRGBBlendFactor = .one
-    descriptor.colorAttachments[0].sourceAlphaBlendFactor = .one
-    descriptor.colorAttachments[0].destinationAlphaBlendFactor = .one
-    return try device.makeRenderPipelineState(descriptor: descriptor)
-  }
-
-  private static func makeBrushMaskShaderLibrary(device: MTLDevice) throws -> MTLLibrary {
-    // The compiled library lives in BrightroomParametric so the live shader and
-    // the parametric export kernel are built as one brush-mask rasterization family.
-    return try device.makeLibrary(URL: BrushStampMetalLibrary.url())
   }
 }


### PR DESCRIPTION
## Problem

The brush-mask Metal render pipeline was constructed **twice**:

| | Live path | Test path |
|---|---|---|
| Owner | `_EditingCanvasMTKView` (inline, drives live painting) | `BrushMaskMetalRasterizer` (off-screen, single stamp pass) |
| Library load | `makeBrushMaskShaderLibrary` | `makeBrushMaskShaderLibrary` |
| Pipeline descriptor | `makeBrushMaskPipeline` | `makeBrushMaskPipeline` |
| Uniform layout | `EditingCanvasBrushStampUniforms` | `BrushMaskMetalRasterizer.BrushStampUniforms` |
| Per-stamp encoding | inline `setVertexBytes`/`setFragmentBytes`/`drawPrimitives` | inline `setVertexBytes`/`setFragmentBytes`/`drawPrimitives` |

The two copies were kept equal only by doc comments asserting it — *"exactly as `_EditingCanvasMTKView.makeBrushMaskPipeline` does"*, *"replicated field-for-field"*.

That made `BrushMaskRasterizerParityTests` weaker than it looks. The rasterizer exists to prove the **live** pipeline matches the parametric Core Image kernel (`FeatureGraphCompiler.renderMask`), but because it rebuilt its own copy, the test exercised the copy. If the live view's blend op, pixel format, or uniform layout drifted, the test would have stayed green.

## Change

Extract one internal `BrushMaskPipeline` factory (new file, same directory) holding the single definition of:

- `makeLibrary(device:)` — the BrightroomParametric metallib
- `make(device:library:)` / `make(device:)` — the pipeline descriptor and blend state
- `StampUniforms` — the uniform layout
- `encodeStamp(_:into:)` — the per-stamp bind + draw
- `stampUniformsBufferIndex` — named, matching `[[buffer(0)]]` in the shader

Both paths now call it. `_EditingCanvasMTKView` keeps its `private typealias BrushStampUniforms`, retargeted at the shared type, so its call sites are otherwise untouched.

## Why share (rather than tolerate the duplication)

These two constructions **must** evolve together — it is the entire reason the second copy exists, and a test already enshrines that requirement:

- Both target the same shader functions (`brushStampVertex` / `brushStampFragment`) in the same metallib.
- The uniform layout is **ABI** against the MSL `BrushStampUniforms` struct in `BrushMaskRenderShader.metal`. A field change on one side silently reinterprets bytes on the other.
- The `.max` blend state is what makes the live rasterization agree with the parametric mask's `CIBlendKernel.componentMax` accumulation — the property the parity test pins.

Comment-enforced equality across files is exactly the convention that breaks quietly. After this change the parity test covers the live path's construction *by construction*.

## Divergence found between the two copies

**None.** The copies were already effect-identical, and every axis was checked before unifying:

- Pixel format: `.rgba8Unorm` on both (and both render targets are `.rgba8Unorm`).
- Blend state: `isBlendingEnabled = true`; `rgbBlendOperation`/`alphaBlendOperation` `.max`; all four blend factors `.one` on both.
- Uniform layout: field-for-field identical (`canvasSize`, `center`, `radius`, `hardness`, `opacity`, `_padding`), and both match the MSL struct.
- Encoding: `setVertexBytes` + `setFragmentBytes` at index `0` with `MemoryLayout<...>.stride`, then `drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)` on both.

Only the prose of the surrounding comments differed. The shared implementation is the committed path's code verbatim — the path the parity test pins — so behavior is bit-identical.

## Verification

- `xcodebuild -scheme SwiftUIDemo -destination 'generic/platform=iOS Simulator'` — **BUILD SUCCEEDED**
- `BrightroomEngineTests` on a clean private simulator (iPhone 17 Pro / iOS 27.0), `-parallel-testing-enabled NO` — **153 tests in 36 suites passed**, including the three suites that guard this area:
  - `BrushMaskRasterizerParityTests` passed
  - `BrushStampFalloffTests` passed
  - `CommittedMaskParametricParityTests` passed

Diff is confined to the two files that held the duplication plus the new shared file; no other render-path code was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
