### PR TITLE
Fix three correctness defects in the parametric render path

### DIFF
--- a/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
+++ b/Dev/Tests/BrightroomEngineTests/ParametricFeatureTreeTests.swift
@@ -794,6 +794,44 @@ struct ParametricFeatureTreeTests {
     }
   }
 
+  @Test func disabledLocalAdjustmentWithEmptyPipelinePassesValidation() throws {
+    // Evaluation skips disabled features, so validation has to accept them too.
+    // Otherwise toggling a layer off makes the whole document unexportable
+    // while the preview still renders it fine.
+    let brightness = BrightnessFeature(
+      id: FeatureID(rawValue: "kept-brightness"),
+      value: 0.1
+    )
+    let withDisabled = EditingDocument(
+      mainTree: MainTree(
+        features: [
+          .localAdjustment(
+            LocalAdjustmentFeature(
+              id: FeatureID(rawValue: "disabled-local"),
+              isEnabled: false,
+              maskTree: MaskTree(
+                root: .brush(BrushMask(id: FeatureID(rawValue: "disabled-mask")))
+              ),
+              effectPipeline: EffectPipeline()
+            )
+          ),
+          .effect(brightness),
+        ]
+      )
+    )
+    let withoutDisabled = EditingDocument(
+      mainTree: MainTree(features: [.effect(brightness)])
+    )
+    let input = CIImage.parametricColorPatchImage(
+      extent: CGRect(x: 0, y: 0, width: 36, height: 24)
+    )
+
+    let output = try Self.compiler.makeOutput(from: input, document: withDisabled).image
+    let expected = try Self.compiler.makeOutput(from: input, document: withoutDisabled).image
+
+    try Self.assertImagesMatch(output, expected, tolerance: 2)
+  }
+
   @Test func metalKernelRegistryCanCreateBrushStampRecipe() throws {
     let registry = ParametricKernelRegistry()
 

--- a/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
+++ b/Sources/BrightroomParametric/BuiltInFeatureRecipes.swift
@@ -148,7 +148,7 @@ extension ColorCubeFeature: ImageEffectFeatureType {
     let filter = ParametricColorCubeHelper.makeColorCubeFilter(
       cubeData: cubeData,
       dimension: dimension,
-      cacheKey: identifier
+      identifier: identifier
     )
     filter.setValue(image, forKeyPath: kCIInputImageKey)
 

--- a/Sources/BrightroomParametric/FeatureGraphCompiler.swift
+++ b/Sources/BrightroomParametric/FeatureGraphCompiler.swift
@@ -397,9 +397,15 @@ private extension FeatureGraphCompiler {
         try validateChildren(of: effect, insert: insert)
 
       case let .localAdjustment(localAdjustment):
-        let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
-        guard enabledEffects.isEmpty == false else {
-          throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+        // An enabled local adjustment that applies nothing stays an error: it
+        // is a construction mistake worth surfacing. A disabled one is skipped
+        // by evaluation, so failing it here would reject documents the preview
+        // renders — toggling a layer off must not break export.
+        if localAdjustment.isEnabled {
+          let enabledEffects = localAdjustment.effectPipeline.effects.filter(\.isEnabled)
+          guard enabledEffects.isEmpty == false else {
+            throw FeatureGraphCompilerError.emptyLocalAdjustmentEffectPipeline(localAdjustment.id)
+          }
         }
 
         for effect in localAdjustment.effectPipeline.effects {

--- a/Sources/BrightroomParametric/ParametricExportRenderer.swift
+++ b/Sources/BrightroomParametric/ParametricExportRenderer.swift
@@ -97,6 +97,11 @@ public struct ParametricExportRenderer {
   public enum RenderingError: Swift.Error {
     /// A file-backed render could not be decoded back into a `CGImage`.
     case failedToDecodeRenderedFile(URL)
+
+    /// A memory-backed render could not allocate a `CGImage` for the extent.
+    ///
+    /// Most likely at the sizes `Output.file` exists to avoid.
+    case failedToCreateCGImage(extent: CGRect)
   }
 
   /**
@@ -312,13 +317,15 @@ public struct ParametricExportRenderer {
     switch options.output {
     case .memory:
       /// To keep wide-color(DisplayP3), use createCGImage instead drawing with CIContext
-      let cgImage = ciContext.createCGImage(
+      guard let cgImage = ciContext.createCGImage(
         image,
         from: image.extent,
         format: options.workingFormat,
         colorSpace: colorSpace,
         deferred: false
-      )!
+      ) else {
+        throw RenderingError.failedToCreateCGImage(extent: image.extent)
+      }
       return .init(cgImage: cgImage, options: options)
 
     case let .file(url, fileType):

--- a/Sources/BrightroomParametric/ParametricFilterSupport.swift
+++ b/Sources/BrightroomParametric/ParametricFilterSupport.swift
@@ -106,11 +106,24 @@ enum ParametricImageGeometry {
 enum ParametricColorCubeHelper {
 
   /// Creates a `CIColorCubeWithColorSpace` filter for a stored RGBA float cube.
+  ///
+  /// `identifier` only names the cube; the cache key also carries the cube's
+  /// shape so a reused name (file-loaded features default their identifier to
+  /// `url.lastPathComponent`) cannot hand back a filter built from different
+  /// cube data. A caller that reuses one identifier for two cubes of the same
+  /// shape must pass distinct identifiers itself — the cube bytes are far too
+  /// large to hash on this path, which runs per frame.
+  ///
+  /// The returned filter is always a fresh copy: the caller sets an input image
+  /// on it, and a shared instance would pin that image's full-resolution recipe
+  /// inside the cache.
   static func makeColorCubeFilter(
     cubeData: Data,
     dimension: Int,
-    cacheKey: String?
+    identifier: String?
   ) -> CIFilter {
+    let cacheKey = identifier.map { "\($0)|\(dimension)|\(cubeData.count)" }
+
     if let cacheKey,
        let cached = parametricColorCubeFilterCache.object(forKey: cacheKey as NSString)
     {
@@ -136,7 +149,7 @@ enum ParametricColorCubeHelper {
       parametricColorCubeFilterCache.setObject(filter, forKey: cacheKey as NSString)
     }
 
-    return filter
+    return filter.copy() as! CIFilter
   }
 }
 


### PR DESCRIPTION
Three independent bugs in `BrightroomParametric`, found while reviewing the render/export path. Each is small, but each changes what the engine actually produces. They are unrelated to each other and grouped only because they were found together.

## 1. Color-cube filter cache pinned its render input, and aliased by file name

`ParametricColorCubeHelper.makeColorCubeFilter` had two defects, fixed together.

**It pinned a full-resolution image chain.** The miss path stored the filter in the `NSCache` *and* returned that same instance. The caller (`ColorCubeFeature.apply`) then sets `kCIInputImageKey` on it, so the cache entry held a strong reference to that render's lazy full-resolution `CIImage` recipe until the entry was evicted. The hit path already returned `cached.copy()`, so only the first render of each cube leaked. The miss path now caches the pristine filter and returns a copy too.

**It could hand back the wrong cube.** The cache key was the identifier string alone, and both file-based `ColorCubeFeature` initializers default that identifier to `url.lastPathComponent`. Two different LUT files sharing a file name would silently render with whichever cube was cached first — and because the lookup happens before the byte-count precondition, nothing caught the mismatch. The key now carries the cube's shape (`identifier|dimension|byteCount`), so a reused name cannot return a filter built from a differently shaped cube, and a hit now implies the cached data matched the requested dimension.

The cube bytes themselves are deliberately **not** hashed: a 64³ float cube is ~4MB and this path runs per frame. A caller that reuses one identifier for two cubes of the *same* shape still has to pass distinct identifiers; the parameter is renamed `cacheKey` -> `identifier` and documented so that contract is visible at the call site.

## 2. `validate()` rejected documents the preview renders

`FeatureGraphCompiler.validate(_:)` iterated **all** features and threw `emptyLocalAdjustmentEffectPipeline` for any local adjustment with no enabled effect — including one whose own `isEnabled` is `false`. Evaluation, meanwhile, skips disabled features entirely (`for feature in document.mainTree.features where feature.isEnabled`).

The user-visible consequence: toggle a layer off, and export throws for the whole document while the preview keeps rendering it fine.

Validation now skips the empty-pipeline check for disabled local adjustments. Duplicate-ID bookkeeping still walks them, so ID collisions are still caught. An **enabled** but empty pipeline still throws — that is a construction mistake worth surfacing, and the existing test covering it is unchanged.

## 3. Force-unwrap in a throwing export

`ParametricExportRenderer.render(...)` is `throws`, but the `.memory` path force-unwrapped `ciContext.createCGImage(...)`. That call returns nil on allocation or GPU failure — most likely at exactly the huge sizes this type's own documentation points at `Output.file` to avoid — so the in-memory path crashed where callers expect a thrown error. The sibling file path already throws properly.

Adds `RenderingError.failedToCreateCGImage(extent:)` (the enum previously had only `failedToDecodeRenderedFile(URL)`) and replaces the unwrap with a `guard let`.

## Verification

- `SwiftUIDemo` builds clean for `generic/platform=iOS Simulator`.
- Full `BrightroomEngineTests` suite on a clean iPhone 17 Pro simulator (iOS 27.0, `-parallel-testing-enabled NO`): **154 tests in 36 suites passed**, no failures — so there were no pre-existing failures to triage.
- New regression test for finding 2, `disabledLocalAdjustmentWithEmptyPipelinePassesValidation`: a disabled local adjustment with an empty pipeline must compile and render identically to the same document without it. Confirmed it bites — with only the `FeatureGraphCompiler` change reverted, it is the **single** failure in the run (`Caught error: .emptyLocalAdjustmentEffectPipeline(...)`), and the other 153 tests still pass.
- Findings 1 and 3 are not covered by new tests: the leak is a lifetime property with no cheap assertion, the aliasing needs two same-named LUT fixtures, and the nil return needs an allocation failure to reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)